### PR TITLE
Low memory causes tests fail fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **__pycache__**
 **build
 **settings.json
+lightning_logs/

--- a/tests/models/test_ModelsSimCLR.py
+++ b/tests/models/test_ModelsSimCLR.py
@@ -15,7 +15,7 @@ class TestModelsSimCLR(unittest.TestCase):
             'resnet-101',
             'resnet-152'
         ]
-        self.batch_size = 4
+        self.batch_size = 2
         self.input_tensor = torch.rand((self.batch_size, 3, 32, 32))
 
     def test_create_variations_cpu(self):
@@ -59,8 +59,8 @@ class TestModelsSimCLR(unittest.TestCase):
     def test_variations_input_dimension(self):
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
         for model_name in self.resnet_variants:
-            for input_width in [16, 32, 64, 256]:
-                for input_height in [16, 32, 64, 256]:
+            for input_width in [16, 32, 64, 128]:
+                for input_height in [16, 32, 64, 128]:
                     model = ResNetSimCLR(name=model_name).to(device)
 
                     input_tensor = torch.rand((self.batch_size,


### PR DESCRIPTION
Tests didn't pass on my 10GB memory machine due to out of memory errors. The new configuration works fine and should
significantly reduce memory footprint.

### Changes

- reduce batch size from 4 to 2 for ML model tests
- reduce maximum image dimension from 256 to 128 for model tests
- add lightning_logs to .gitignore
