### PR TITLE
Fix API calls in 3.6

### DIFF
--- a/lightly/__init__.py
+++ b/lightly/__init__.py
@@ -15,7 +15,7 @@ For information about the command-line interace, see lightly.cli.
 # All Rights Reserved
 
 __name__ = 'lightly'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 
 try:

--- a/lightly/api/__init__.py
+++ b/lightly/api/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+from lightly.api import routes
 from lightly.api.routes.pip import get_version              # noqa: F401
 from lightly.api.upload import upload_images_from_folder    # noqa: F401
 from lightly.api.upload import upload_embeddings_from_csv   # noqa: F401

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -5,7 +5,7 @@
 
 from typing import List
 
-import lightly.api.routes as routes
+from lightly.api import routes
 
 
 def get_samples_by_tag(tag_name: str,

--- a/lightly/api/routes/__init__.py
+++ b/lightly/api/routes/__init__.py
@@ -3,21 +3,7 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from lightly.api.utils import getenv
-
-
-def _prefix(*args, **kwargs):
-    """Returns the lightly server location.
-
-    The server location is the prefix for all api requests.
-
-    """
-    return getenv(
-        'LIGHTLY_SERVER_LOCATION',
-        'https://api.lightly.ai'
-    )
-
 
 # submodules
-import lightly.api.routes.pip       # noqa: F401, E402
-import lightly.api.routes.users     # noqa: F401, E402
+from lightly.api.routes import pip
+from lightly.api.routes import users

--- a/lightly/api/routes/pip/__init__.py
+++ b/lightly/api/routes/pip/__init__.py
@@ -3,19 +3,7 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import lightly.api.routes as routes
-
-__module = 'pip'
-
-
-def _prefix(*args, **kwargs):
-    """Returns the prefix for the pip route.
-
-    The pip route does not require authentication.
-
-    """
-    return routes._prefix(*args, **kwargs) + '/' + __module
-
 
 # provided functions
+from . import service
 from lightly.api.routes.pip.service import get_version  # noqa: F401, E402

--- a/lightly/api/routes/pip/service.py
+++ b/lightly/api/routes/pip/service.py
@@ -3,8 +3,21 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from . import _prefix
 import requests
+from lightly.api.utils import getenv
+
+
+def _prefix(*args, **kwargs):
+    """Returns the prefix for the pip route.
+
+    The pip route does not require authentication.
+
+    """
+    server_location = getenv(
+        'LIGHTLY_SERVER_LOCATION',
+        'https://api.lightly.ai'
+    )
+    return server_location + '/pip'
 
 
 def get_version(version, timeout: int = 1):

--- a/lightly/api/routes/users/__init__.py
+++ b/lightly/api/routes/users/__init__.py
@@ -3,23 +3,10 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import lightly.api.routes as routes
-
-__module = 'users'
-
-
-def _prefix(*args, **kwargs):
-    """Returns the prefix for the users routes.
-
-    All routes through users require authentication via jwt.
-
-    """
-    return routes._prefix() + '/' + __module
-
 
 # provided functions
 from lightly.api.routes.users.service import get_quota  # noqa: F401, E402
 
 # submodules
-import lightly.api.routes.users.datasets    # noqa: F401, E402
-import lightly.api.routes.users.docker      # noqa: F401, E402
+from . import datasets   # noqa: F401, E402
+from . import docker      # noqa: F401, E402

--- a/lightly/api/routes/users/datasets/__init__.py
+++ b/lightly/api/routes/users/datasets/__init__.py
@@ -3,26 +3,6 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from typing import Union
-import lightly.api.routes.users as users
-
-__module = 'datasets'
-
-
-def _prefix(dataset_id: Union[str, None] = None, *args, **kwargs):
-    """Returns the prefix for the datasets routes.
-
-    Args:
-        dataset_id:
-            The identifier of the dataset.
-
-    """
-    prefix = users._prefix(*args, **kwargs) + '/' + __module
-    if dataset_id is None:
-        return prefix
-    else:
-        return prefix + '/' + dataset_id
-
 
 # provided functions
 from lightly.api.routes.users.datasets.service import put_image_type  # noqa: F401, E402, E501

--- a/lightly/api/routes/users/datasets/embeddings/__init__.py
+++ b/lightly/api/routes/users/datasets/embeddings/__init__.py
@@ -3,23 +3,6 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from typing import Union
-import lightly.api.routes.users.datasets as datasets
-
-__module = 'embeddings'
-
-
-def _prefix(dataset_id: Union[str, None] = None,
-            *args, **kwargs):
-    """Returns the prefix for the embeddings routes.
-
-    Args:
-        dataset_id:
-            Identifier of the dataset.
-
-    """
-    return datasets._prefix(dataset_id=dataset_id) + '/' + __module
-
 
 # provided functions
 from lightly.api.routes.users.datasets.embeddings.service import post           # noqa: F401, E402, E501

--- a/lightly/api/routes/users/datasets/embeddings/service.py
+++ b/lightly/api/routes/users/datasets/embeddings/service.py
@@ -3,8 +3,29 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from . import _prefix
-import lightly.api.utils as utils
+from typing import Union
+from lightly.api.utils import getenv, get_request, post_request
+
+
+def _prefix(dataset_id: Union[str, None] = None,
+            *args, **kwargs):
+    """Returns the prefix for the embeddings routes.
+
+    Args:
+        dataset_id:
+            Identifier of the dataset.
+
+    """
+    server_location = getenv(
+        'LIGHTLY_SERVER_LOCATION',
+        'https://api.lightly.ai'
+    )
+    prefix = server_location + '/users/datasets'
+    if dataset_id is None:
+        return prefix + '/embeddings'
+    else:
+        return prefix + '/' + dataset_id + '/embeddings'
+
 
 
 def get_summaries(dataset_id: str,
@@ -33,7 +54,7 @@ def get_summaries(dataset_id: str,
     # fix url, TODO: fix api instead
     dst_url += '/'
 
-    response = utils.get_request(dst_url, params=payload)
+    response = get_request(dst_url, params=payload)
     return response.json()
 
 
@@ -64,5 +85,5 @@ def post(dataset_id: str,
         'token': token,
     }
 
-    response = utils.post_request(dst_url, json=payload)
+    response = post_request(dst_url, json=payload)
     return response

--- a/lightly/api/routes/users/datasets/samples/__init__.py
+++ b/lightly/api/routes/users/datasets/samples/__init__.py
@@ -3,31 +3,6 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from typing import Union
-import lightly.api.routes.users.datasets as datasets
-
-__module = 'samples'
-
-
-def _prefix(dataset_id: Union[str, None] = None,
-            sample_id: Union[str, None] = None,
-            *args, **kwargs):
-    """Returns the prefix for the samples routes.
-
-    Args:
-        dataset_id:
-            Identifier of the dataset.
-        sample_id:
-            Identifier of the sample.
-
-    """
-    prefix = datasets._prefix(dataset_id=dataset_id)
-    if sample_id is None:
-        return prefix + '/' + __module
-    else:
-        return prefix + '/' + __module + '/' + sample_id
-
-
 # provided functions
 from lightly.api.routes.users.datasets.samples.service import get_presigned_upload_url  # noqa: F401, E402, E501
 from lightly.api.routes.users.datasets.samples.service import post                      # noqa: F401, E402, E501

--- a/lightly/api/routes/users/datasets/samples/service.py
+++ b/lightly/api/routes/users/datasets/samples/service.py
@@ -3,8 +3,35 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from . import _prefix
-import lightly.api.utils as utils
+from lightly.api.utils import getenv, get_request, post_request
+from typing import Union
+
+
+def _prefix(dataset_id: Union[str, None] = None,
+            sample_id: Union[str, None] = None,
+            *args, **kwargs):
+    """Returns the prefix for the samples routes.
+
+    Args:
+        dataset_id:
+            Identifier of the dataset.
+        sample_id:
+            Identifier of the sample.
+
+    """
+    server_location = getenv(
+        'LIGHTLY_SERVER_LOCATION',
+        'https://api.lightly.ai'
+    )
+    prefix = server_location + '/users/datasets'
+    if dataset_id is None:
+        prefix = prefix + '/samples'
+    else:
+        prefix = prefix + '/' + dataset_id + '/samples'
+    if sample_id is None:
+        return prefix
+    else:
+        return prefix + '/' + sample_id
 
 
 def get_presigned_upload_url(filename: str,
@@ -35,7 +62,7 @@ def get_presigned_upload_url(filename: str,
         'token': token
     }
 
-    response = utils.get_request(dst_url, params=payload)
+    response = get_request(dst_url, params=payload)
     signed_url = response.json()['signedWriteUrl']
     return signed_url
 
@@ -81,6 +108,6 @@ def post(filename: str,
     if thumbname is not None:
         payload['sample']['thumbName'] = thumbname
 
-    response = utils.post_request(dst_url, json=payload)
+    response = post_request(dst_url, json=payload)
     sample_id = response.json()['sampleId']
     return sample_id

--- a/lightly/api/routes/users/datasets/service.py
+++ b/lightly/api/routes/users/datasets/service.py
@@ -3,8 +3,27 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from . import _prefix
-import lightly.api.utils as utils
+from typing import Union
+from lightly.api.utils import getenv, put_request
+
+
+def _prefix(dataset_id: Union[str, None] = None, *args, **kwargs):
+    """Returns the prefix for the datasets routes.
+
+    Args:
+        dataset_id:
+            The identifier of the dataset.
+
+    """
+    server_location = getenv(
+        'LIGHTLY_SERVER_LOCATION',
+        'https://api.lightly.ai'
+    )
+    prefix = server_location + '/users/datasets'
+    if dataset_id is None:
+        return prefix
+    else:
+        return prefix + '/' + dataset_id
 
 
 def put_image_type(dataset_id: str,
@@ -39,5 +58,5 @@ def put_image_type(dataset_id: str,
         }
     }
 
-    response = utils.put_request(dst_url, json=data, params=payload)
+    response = put_request(dst_url, json=data, params=payload)
     return response

--- a/lightly/api/routes/users/datasets/tags/__init__.py
+++ b/lightly/api/routes/users/datasets/tags/__init__.py
@@ -3,31 +3,6 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from typing import Union
-import lightly.api.routes.users.datasets as datasets
-
-__module = 'tags'
-
-
-def _prefix(dataset_id: Union[str, None] = None,
-            tag_id: Union[str, None] = None,
-            *args, **kwargs):
-    """Returns the prefix for the tags routes.
-
-    Args:
-        dataset_id:
-            Identifier of the dataset.
-        tag_id:
-            Identifier of the tag.
-
-    """
-    prefix = datasets._prefix(dataset_id=dataset_id)
-    if tag_id is None:
-        return prefix + '/' + __module
-    else:
-        return prefix + '/' + __module + '/' + tag_id
-
-
 # provided functions
 from lightly.api.routes.users.datasets.tags.service import post         # noqa: F401, E402, E501
 from lightly.api.routes.users.datasets.tags.service import get          # noqa: F401, E402, E501

--- a/lightly/api/routes/users/datasets/tags/service.py
+++ b/lightly/api/routes/users/datasets/tags/service.py
@@ -3,8 +3,35 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from . import _prefix
-import lightly.api.utils as utils
+from typing import Union
+from lightly.api.utils import getenv, get_request, post_request
+
+
+def _prefix(dataset_id: Union[str, None] = None,
+            tag_id: Union[str, None] = None,
+            *args, **kwargs):
+    """Returns the prefix for the tags routes.
+
+    Args:
+        dataset_id:
+            Identifier of the dataset.
+        tag_id:
+            Identifier of the tag.
+
+    """
+    server_location = getenv(
+        'LIGHTLY_SERVER_LOCATION',
+        'https://api.lightly.ai'
+    )
+    prefix = server_location + '/users/datasets'
+    if dataset_id is None:
+        prefix = prefix + '/tags'
+    else:
+        prefix = prefix + '/' + dataset_id + '/tags'
+    if tag_id is None:
+        return prefix
+    else:
+        return prefix + '/' + tag_id
 
 
 def get(dataset_id: str,
@@ -32,7 +59,7 @@ def get(dataset_id: str,
     # fix url, TODO: fix api instead
     dst_url += '/'
 
-    response = utils.get_request(dst_url, params=payload)
+    response = get_request(dst_url, params=payload)
     return response.json()
 
 
@@ -81,7 +108,7 @@ def get_samples(dataset_id: str,
         'token': token
     }
 
-    response = utils.get_request(dst_url, params=payload)
+    response = get_request(dst_url, params=payload)
     return response.text.splitlines()
 
 
@@ -115,5 +142,5 @@ def post(dataset_id: str,
     if tag is not None:
         payload['tag'] = tag
 
-    response = utils.post_request(dst_url, json=payload)
+    response = post_request(dst_url, json=payload)
     return response

--- a/lightly/api/routes/users/docker/__init__.py
+++ b/lightly/api/routes/users/docker/__init__.py
@@ -6,14 +6,3 @@ This site is under construction.
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
-
-import lightly.api.routes.users as users
-
-__module = 'docker'
-
-
-def _prefix(*args, **kwargs):
-    """Returns the prefix for the docker routes.
-
-    """
-    return users._prefix() + '/' + __module

--- a/lightly/api/routes/users/service.py
+++ b/lightly/api/routes/users/service.py
@@ -3,10 +3,23 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from . import _prefix
 import requests
 
 from lightly.api.constants import LIGHTLY_MAXIMUM_DATASET_SIZE
+from lightly.api.utils import getenv
+
+
+def _prefix(*args, **kwargs):
+    """Returns the prefix for the users routes.
+
+    All routes through users require authentication via jwt.
+
+    """
+    server_location = getenv(
+        'LIGHTLY_SERVER_LOCATION',
+        'https://api.lightly.ai'
+    )
+    return server_location + '/users'
 
 
 def get_quota(token: str):

--- a/lightly/api/upload.py
+++ b/lightly/api/upload.py
@@ -12,7 +12,8 @@ import numpy as np
 
 from itertools import islice
 
-import lightly.api.routes as routes
+#import lightly.api.routes as routes
+from lightly.api import routes
 from lightly.api.constants import LIGHTLY_MAXIMUM_DATASET_SIZE
 
 from lightly.api.utils import get_thumbnail_from_img

--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -54,8 +54,8 @@ class BaseEmbedding(lightning.LightningModule):
         x, y, _ = batch
         y_hat = self(x)
         loss = self.criterion(y_hat, y)
-        tensorboard_logs = {'train_loss': loss}
-        return {'loss': loss, 'log': tensorboard_logs}
+        self.log('loss', loss)
+        return loss
 
     def configure_optimizers(self):
         if self.scheduler is None:

--- a/tests/api/test_CreateInitialTag.py
+++ b/tests/api/test_CreateInitialTag.py
@@ -5,7 +5,7 @@ import os
 import random
 import responses
 
-import lightly.api.routes as routes
+from lightly.api import routes
 
 N = 10
 

--- a/tests/api/test_GetPresignedURL.py
+++ b/tests/api/test_GetPresignedURL.py
@@ -6,7 +6,7 @@ import random
 import responses
 
 import torchvision
-import lightly.api.routes as routes
+from lightly.api import routes
 
 
 class TestGetPresignedURL(unittest.TestCase):

--- a/tests/api/test_GetSamples.py
+++ b/tests/api/test_GetSamples.py
@@ -5,7 +5,8 @@ import os
 import random
 import responses
 
-import lightly.api.routes as routes
+from lightly.api import routes
+
 
 N = 10
 

--- a/tests/api/test_GetTags.py
+++ b/tests/api/test_GetTags.py
@@ -5,7 +5,7 @@ import os
 import random
 import responses
 
-import lightly.api.routes as routes
+from lightly.api import routes
 
 N = 10
 

--- a/tests/api/test_Routes.py
+++ b/tests/api/test_Routes.py
@@ -2,7 +2,7 @@ import unittest
 import json
 import os
 
-import lightly.api.routes as routes
+from lightly.api import routes
 
 class TestRoutes(unittest.TestCase):
 
@@ -17,55 +17,55 @@ class TestRoutes(unittest.TestCase):
 
         # pip
         self.assertEqual(
-            routes.pip._prefix(),
+            routes.pip.service._prefix(),
             f'{dst_url}/pip'
         )
         # users
         self.assertEqual(
-            routes.users._prefix(),
+            routes.users.service._prefix(),
             f'{dst_url}/users'
         )
         # datasets
         self.assertEqual(
-            routes.users.datasets._prefix(),
+            routes.users.datasets.service._prefix(),
             f'{dst_url}/users/datasets'
         )
         self.assertEqual(
-            routes.users.datasets._prefix(dataset_id=dataset_id),
+            routes.users.datasets.service._prefix(dataset_id=dataset_id),
             f'{dst_url}/users/datasets/{dataset_id}'
         )
         # embeddings
         self.assertEqual(
-            routes.users.datasets.embeddings._prefix(),
+            routes.users.datasets.embeddings.service._prefix(),
             f'{dst_url}/users/datasets/embeddings'
         )
         self.assertEqual(
-            routes.users.datasets.embeddings._prefix(dataset_id=dataset_id),
+            routes.users.datasets.embeddings.service._prefix(dataset_id=dataset_id),
             f'{dst_url}/users/datasets/{dataset_id}/embeddings'
         )
         # samples
         self.assertEqual(
-            routes.users.datasets.samples._prefix(),
+            routes.users.datasets.samples.service._prefix(),
             f'{dst_url}/users/datasets/samples'
         )
         self.assertEqual(
-            routes.users.datasets.samples._prefix(dataset_id=dataset_id),
+            routes.users.datasets.samples.service._prefix(dataset_id=dataset_id),
             f'{dst_url}/users/datasets/{dataset_id}/samples'
         )
         self.assertEqual(
-            routes.users.datasets.samples._prefix(dataset_id=dataset_id, sample_id=sample_id),
+            routes.users.datasets.samples.service._prefix(dataset_id=dataset_id, sample_id=sample_id),
             f'{dst_url}/users/datasets/{dataset_id}/samples/{sample_id}'
         )
         # tags
         self.assertEqual(
-            routes.users.datasets.tags._prefix(),
+            routes.users.datasets.tags.service._prefix(),
             f'{dst_url}/users/datasets/tags'
         )
         self.assertEqual(
-            routes.users.datasets.tags._prefix(dataset_id=dataset_id),
+            routes.users.datasets.tags.service._prefix(dataset_id=dataset_id),
             f'{dst_url}/users/datasets/{dataset_id}/tags'
         )
         self.assertEqual(
-            routes.users.datasets.tags._prefix(dataset_id=dataset_id, tag_id=tag_id),
+            routes.users.datasets.tags.service._prefix(dataset_id=dataset_id, tag_id=tag_id),
             f'{dst_url}/users/datasets/{dataset_id}/tags/{tag_id}'
         )

--- a/tests/api/test_UploadEmbedding.py
+++ b/tests/api/test_UploadEmbedding.py
@@ -5,7 +5,7 @@ import os
 import random
 import responses
 
-import lightly.api.routes as routes
+from lightly.api import routes
 
 N = 10
 

--- a/tests/api/test_UploadSample.py
+++ b/tests/api/test_UploadSample.py
@@ -6,7 +6,7 @@ import os
 import random
 import responses
 
-import lightly.api.routes as routes
+from lightly.api import routes
 
 N = 10
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ skipsdist=True
 
 [testenv:cuda]
 # test the full package on the gpu
+basepython = python3.7
 
 # suppress warnings              
 whitelist_externals = make
@@ -35,7 +36,6 @@ passenv = *
 setenv = LIGHTLY_SERVER_LOCATION = https://api-dev.lightly.ai
 
 commands = 
-           make clean
            pip install torch==1.6.0+cu101 torchvision==0.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
            pip install .[dev]
            echo "Running cuda test"
@@ -43,6 +43,7 @@ commands =
 
 [testenv:cpu]
 # test the full package on the cpu
+basepython = python3.7
 
 # suppress warnings              
 whitelist_externals = make
@@ -54,7 +55,6 @@ setenv = LIGHTLY_SERVER_LOCATION = https://api-dev.lightly.ai
          CUDA_VISIBLE_DEVICES = -1
 
 commands = 
-           make clean
            pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
            pip install .[dev]
            echo "Running cpu test"
@@ -74,7 +74,6 @@ setenv = LIGHTLY_SERVER_LOCATION = https://api-dev.lightly.ai
          CUDA_VISIBLE_DEVICES = -1
 
 commands = 
-           make clean
            pip install pillow==7.0.0
            pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
            pip install pytorch-lightning==0.10.0


### PR DESCRIPTION
# Fix API calls in 3.6 
There was a bug which didn't allow the import of the package in Python 3.6. The problem was with how the `lightly.api.routes`  module was imported. The changes in this PR pass the `tox` tests in Python 3.6 and Python 3.7. I also tested upload, download, embedding, and training from the command line. 

## Changes
- Fixed the tox test environment to Python 3.6 and 3.7 
- Removed the circular imports from the `lightly.api.routes` sub-package. They did not cause the problem but were unnecessarily complicated and could have lead to problems in the future.
- Change the import of `routes` from
   ```python
   import lightly.api.routes as routes
   ```
   to
   ```python
   from lightly.api import routes
   ```
- Removed the warning which appeared during training.