### PR TITLE
Customize progress bars pw

### DIFF
--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -72,7 +72,7 @@ loader:
 trainer:
   gpus: 1                     # Number of gpus to use for training.
   max_epochs: 100             # Number of epochs to train for.
-  precision: 32               # If set to 16, will use half-precision.
+  precision: 32               # If set to 16, will use half-precision.
 
 # seed
 seed: 1

--- a/lightly/embedding/__init__.py
+++ b/lightly/embedding/__init__.py
@@ -1,6 +1,6 @@
 """The lightly.embedding module provides trainable embedding strategies.
 
-The embedding models use a pre-trained ResNet but should be finetuned on each 
+The embedding models use a pre-trained ResNet but should be finetuned on each
 dataset instance.
 
 """

--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -12,6 +12,17 @@ import torch.nn as nn
 from lightly.embedding._callback import CustomModelCheckpoint
 
 
+def _efficiency(start_time: float,
+                prepare_time: float,
+                process_time: float) -> float:
+    """
+
+    """
+    if start_time > 0:
+        return (process_time - prepare_time) / (prepare_time - start_time)
+    return 0.
+
+
 class BaseEmbedding(lightning.LightningModule):
     """All trainable embeddings must inherit from BaseEmbedding.
 
@@ -40,7 +51,7 @@ class BaseEmbedding(lightning.LightningModule):
         self.dataloader = dataloader
         self.scheduler = scheduler
         self.checkpoint = None
-        # create custom model checkpoint and set attributes
+        # create custom model checkpoint and set attributes
         self.checkpoint_callback = CustomModelCheckpoint()
         self.checkpoint_callback.save_last = True
         self.checkpoint_callback.save_top_k = 1
@@ -51,10 +62,12 @@ class BaseEmbedding(lightning.LightningModule):
         return self.model(x)
 
     def training_step(self, batch, batch_idx):
+
         x, y, _ = batch
         y_hat = self(x)
         loss = self.criterion(y_hat, y)
         self.log('loss', loss)
+
         return loss
 
     def configure_optimizers(self):

--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -12,17 +12,6 @@ import torch.nn as nn
 from lightly.embedding._callback import CustomModelCheckpoint
 
 
-def _efficiency(start_time: float,
-                prepare_time: float,
-                process_time: float) -> float:
-    """
-
-    """
-    if start_time > 0:
-        return (process_time - prepare_time) / (prepare_time - start_time)
-    return 0.
-
-
 class BaseEmbedding(lightning.LightningModule):
     """All trainable embeddings must inherit from BaseEmbedding.
 

--- a/lightly/embedding/_callback.py
+++ b/lightly/embedding/_callback.py
@@ -1,8 +1,7 @@
 from typing import Dict, Optional, Any
-import os
 
-import pytorch_lightning as pl
 import pytorch_lightning.callbacks as cb
+
 
 class CustomModelCheckpoint(cb.ModelCheckpoint):
     """Custom implementation of the Pytorch Lightning ModelCheckpoint.
@@ -10,27 +9,26 @@ class CustomModelCheckpoint(cb.ModelCheckpoint):
     Attributes:
         checkpoint_fmt:
             String which determines the format of the checkpoint name.
-            Default leads to, e.g. 
+            Default leads to, e.g.
 
             >>> epoch_10.ckpt
     """
 
     def __init__(self, checkpoint_fmt: str = 'lightly_epoch_{epoch}.ckpt'):
         # use default initialization to prevent compatability
-        # issues in case pytorch_lightning changes attributes
+        # issues in case pytorch_lightning changes attributes
         super(CustomModelCheckpoint, self).__init__()
         self.checkpoint_fmt = checkpoint_fmt
-    
+
     def format_checkpoint_name(
         self, epoch: int, metrics: Dict[str, Any], ver: Optional[int] = None
     ) -> str:
         """Formats the format string to an actual checkpoint name.
-        
+
         Args:
             epoch:
                 Training epoch of the checkpoint.
+
         """
-        # use custom template to prevent the = in the checkpoint name
+        # use custom template to prevent the = in the checkpoint name
         return self.checkpoint_fmt.format(epoch=epoch)
-
-


### PR DESCRIPTION
There was an error with the way the compute efficiency was calculated. Fixed it, now the efficiency is:
```
efficiency = time_to_process_data / (time_to_process_data + time_to_load_data)
``` 
Also, all of `lightly.embeddings` now passes `make lint`. 