### PR TITLE
Move State Dict Loading

### DIFF
--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -19,18 +19,6 @@ def fix_input_path(path):
     return path
 
 
-def filter_state_dict(state_dict):
-    """Prevent unexpected key error when loading PyTorch-Lightning checkpoints
-       by removing the unnecessary prefix model. from each key.
-
-    """
-    new_state_dict = {}
-    for key, item in state_dict.items():
-        new_key = '.'.join(key.split('.')[1:])
-        new_state_dict[new_key] = item
-    return new_state_dict
-
-
 def is_url(checkpoint):
     """Check whether the checkpoint is a url or not.
 

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -16,12 +16,11 @@ from lightly.data import ImageCollateFunction
 from lightly.data import LightlyDataset
 from lightly.embedding import SelfSupervisedEmbedding
 from lightly.loss import NTXentLoss
-from lightly.models import ResNetSimCLR
+from lightly.models import ResNetSimCLR, ResNetMoCo
 
 from lightly.cli._helpers import is_url
 from lightly.cli._helpers import get_ptmodel_from_config
 from lightly.cli._helpers import fix_input_path
-from lightly.cli._helpers import filter_state_dict
 from lightly.cli._helpers import load_state_dict_from_url
 
 
@@ -59,7 +58,7 @@ def _train_cli(cfg, is_cli_call=True):
         msg += 'loader.batch_size=BSZ'
         warnings.warn(msg)
 
-    model = ResNetSimCLR(**cfg['model'])
+    state_dict = None
     checkpoint = cfg['checkpoint']
     if cfg['pre_trained'] and not checkpoint:
         # if checkpoint wasn't specified explicitly and pre_trained is True
@@ -75,9 +74,6 @@ def _train_cli(cfg, is_cli_call=True):
     
     if checkpoint:
         # load the PyTorch state dictionary and map it to the current device
-        # then, remove the model. prefix which is caused by the pytorch-lightning
-        # checkpoint saver and load the model from the "filtered" state dict
-        # this approach is compatible with pytorch_lightning 0.7.1 - 0.8.4 (latest)
         if is_url(checkpoint):
             state_dict = load_state_dict_from_url(
                 checkpoint, map_location=device
@@ -86,9 +82,12 @@ def _train_cli(cfg, is_cli_call=True):
             state_dict = torch.load(
                 checkpoint, map_location=device
             )['state_dict']
-        if state_dict is not None:
-            state_dict = filter_state_dict(state_dict)
-            model.load_state_dict(state_dict)
+
+    # load model
+    if state_dict is not None:
+        model = ResNetSimCLR.from_state_dict(state_dict, **cfg['model'])
+    else:
+        model = ResNetSimCLR(**cfg['model'])
 
     criterion = NTXentLoss(**cfg['criterion'])
     optimizer = torch.optim.SGD(model.parameters(), **cfg['optimizer'])

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -16,7 +16,7 @@ from lightly.data import ImageCollateFunction
 from lightly.data import LightlyDataset
 from lightly.embedding import SelfSupervisedEmbedding
 from lightly.loss import NTXentLoss
-from lightly.models import ResNetSimCLR, ResNetMoCo
+from lightly.models import ResNetSimCLR
 
 from lightly.cli._helpers import is_url
 from lightly.cli._helpers import get_ptmodel_from_config

--- a/lightly/models/_helpers.py
+++ b/lightly/models/_helpers.py
@@ -1,0 +1,13 @@
+from difflib import ndiff
+
+
+def filter_state_dict(state_dict):
+    """Prevent unexpected key error when loading PyTorch-Lightning checkpoints
+       by removing the unnecessary prefix model. from each key.
+
+    """
+    new_state_dict = {}
+    for key, item in state_dict.items():
+        new_key = '.'.join(key.split('.')[1:])
+        new_state_dict[new_key] = item
+    return new_state_dict

--- a/lightly/models/_helpers.py
+++ b/lightly/models/_helpers.py
@@ -1,4 +1,3 @@
-from difflib import ndiff
 
 
 def filter_state_dict(state_dict):

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -6,6 +6,7 @@
 import torch
 import torch.nn as nn
 from lightly.models.resnet import ResNetGenerator
+from lightly.models._helpers import filter_state_dict
 
 
 def _get_features_and_projections(resnet, num_ftrs, out_dim):
@@ -83,6 +84,56 @@ class ResNetMoCo(nn.Module):
             param_k.requires_grad = False
         self._momentum_update_key_encoder(0.)
 
+    @classmethod
+    def from_state_dict(cls,
+                        state_dict: dict,
+                        name: str = 'resnet-18',
+                        width: float = 1.,
+                        num_ftrs: int = 32,
+                        out_dim: int = 128,
+                        m: float = 0.999,
+                        strict: bool = True,
+                        apply_filter: bool = True):
+        """Initializes a ResNetMoCo and loads weights from a checkpoint.
+
+        Args:
+            state_dict:
+                State dictionary with layer weights.
+            name:
+                ResNet version, choose from resnet-{9, 18, 34, 50, 101, 152}.
+            width:
+                Width of the ResNet.
+            num_ftrs:
+                Dimension of the embedding (before the projection head).
+            out_dim:
+                Dimension of the output (after the projection head).
+            m:
+                Momentum for momentum update of the key-encoder.
+            strict:
+                Set to False when loading from a partial state_dict.
+            apply_filter:
+                If True, removes the `model.` prefix from keys in the state_dict.
+
+        """
+        model = cls(
+            name=name,
+            width=width,
+            num_ftrs=num_ftrs,
+            out_dim=out_dim,
+            m=m,
+        )
+
+        # remove the model. prefix which is caused by the pytorch-lightning
+        # checkpoint saver and load the model from the "filtered" state dict
+        # this approach is compatible with pytorch_lightning 0.7.1 - 0.8.4 (latest)
+        if apply_filter:
+            state_dict_ = filter_state_dict(state_dict)
+        else:
+            state_dict_ = state_dict
+
+        model.load_state_dict(state_dict_, strict=strict)
+
+        return model
 
     @torch.no_grad()
     def _momentum_update_key_encoder(self, m=0.):

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -7,6 +7,7 @@ import torch
 import torch.nn as nn
 
 from lightly.models.resnet import ResNetGenerator
+from lightly.models._helpers import filter_state_dict
 
 
 def _get_features_and_projections(resnet, num_ftrs, out_dim):
@@ -69,6 +70,52 @@ class ResNetSimCLR(nn.Module):
         self.features, self.projection_head = _get_features_and_projections(
             resnet, self.num_ftrs, self.out_dim)
 
+    @classmethod
+    def from_state_dict(cls,
+                        state_dict: dict,
+                        name: str = 'resnet-18',
+                        width: float = 1.,
+                        num_ftrs: int = 32,
+                        out_dim: int = 128,
+                        strict: bool = True,
+                        apply_filter: bool = True):
+        """Initializes a ResNetMoCo and loads weights from a checkpoint.
+
+        Args:
+            state_dict:
+                State dictionary with layer weights.
+            name:
+                ResNet version, choose from resnet-{9, 18, 34, 50, 101, 152}.
+            width:
+                Width of the ResNet.
+            num_ftrs:
+                Dimension of the embedding (before the projection head).
+            out_dim:
+                Dimension of the output (after the projection head).
+            strict:
+                Set to False when loading from a partial state_dict.
+            apply_filter:
+                If True, removes the `model.` prefix from keys in the state_dict.
+
+        """
+        model = cls(
+            name=name,
+            width=width,
+            num_ftrs=num_ftrs,
+            out_dim=out_dim,
+        )
+
+        # remove the model. prefix which is caused by the pytorch-lightning
+        # checkpoint saver and load the model from the "filtered" state dict
+        # this approach is compatible with pytorch_lightning 0.7.1 - 0.8.4 (latest)
+        if apply_filter:
+            state_dict_ = filter_state_dict(state_dict)
+        else:
+            state_dict_ = state_dict
+
+        model.load_state_dict(state_dict_, strict=strict)
+
+        return model
 
     def forward(self, x: torch.Tensor):
         """Forward pass through ResNetSimCLR.


### PR DESCRIPTION
# Move State Dict Loading
Added a function `CLASS.from_state_dict` which allows to load models (`ResNetSimCLR` and `ResNetMoCo`) from a state dictionary. This refactoring will be useful when we want to allow SimCLR and MoCo to be  used from the command line.

# Changes
- Moved `filter_state_dict` from `lightly.cli._helpers` to `lightly.models._helpers`.
- Added `from_state_dict` functions to `ResNetSimCLR` and `ResNetMoCo`.
