### PR TITLE
Fix slow download and make minor changes

### DIFF
--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -4,7 +4,6 @@
 # All Rights Reserved
 
 import os
-import av
 from PIL import Image
 from torchvision import datasets
 
@@ -235,12 +234,21 @@ class VideoDataset(datasets.VisionDataset):
         i = len(self.offsets) - 1
         while (self.offsets[i] > index):
             i = i - 1
-        
+
+        # get filename of the video file
         filename = self.videos[i]
         filename = os.path.relpath(filename, self.root)
 
+        # get video format and video name
         splits = filename.split('.')
         video_format = splits[-1]
         video_name = '.'.join(splits[:-1])
-        timestamp = float(self.video_timestamps[i][index - self.offsets[i]])
-        return '%s-%.8fs-%s.png' % (video_name, timestamp, video_format)
+
+        # get frame number
+        frame_number = index - self.offsets[i]
+        if i < len(self.offsets) - 1:
+            n_frames = self.offsets[i+1] - self.offsets[i]
+        else:
+            n_frames = self.__len__() - self.offsets[i]
+        
+        return f'{video_name}-{frame_number:0{len(str(n_frames))}}-{video_format}.png'

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -9,6 +9,7 @@ from lightly.data import LightlyDataset
 
 try:
     from lightly.data._video import VideoDataset
+    import av
     import cv2
     VIDEO_DATASET_AVAILABLE = True
 except Exception:
@@ -169,7 +170,7 @@ class TestLightlyDataset(unittest.TestCase):
             image, _ = dataset[0]
             image.save(path)
             os.rename(path, os.path.join(tmp_dir, 'my_file.avi'))
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ImportError):
                 dataset = LightlyDataset(from_folder=tmp_dir)
 
             warnings.warn(

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -8,6 +8,7 @@ import PIL
 
 try:
     from lightly.data._video import VideoDataset
+    import av
     import cv2
     VIDEO_DATASET_AVAILABLE = True
 except Exception:
@@ -62,9 +63,10 @@ class TestVideoDataset(unittest.TestCase):
         for i in range(len(dataset)):
             frame, label = dataset[i]
             filename = dataset.get_filename(i)
+            print(filename)
             self.assertTrue(
                 filename.endswith(
-                    f"-{float(i % self.n_frames_per_video):.8f}s-avi.png"
+                    f"-{(i % self.n_frames_per_video):02d}-avi.png"
                 )
             )
         


### PR DESCRIPTION
# Fix Slow Download and Make Minor Changes

- Download of images was very slow because of `dataset.get_filenames().index(filename)` with quadratic runtime in `dump`. By moving it outside of the for-loop, we get a considerable speed-up.
- We're now using `torchvision`'s error message when `av` is not available.
- Changed the filename for video frames from format `my_video_file-0.12345678s-format.png` to `my_video_file-0023-format.png` where the integer represents the frame index.
- Fixed the tests so that they pass again.