### PR TITLE
Fix PL warning

### DIFF
--- a/lightly/__init__.py
+++ b/lightly/__init__.py
@@ -1,4 +1,4 @@
-""" Lightly is a computer vision framework for self-supervised learning.
+"""Lightly is a computer vision framework for self-supervised learning.
 
 With Lightly you can train deep learning models using
 self-supervision. This means, that you don't require
@@ -7,7 +7,60 @@ to help you understand and work with large unlabeled datasets.
 It is built on top of PyTorch and therefore fully compatible 
 with other frameworks such as Fast.ai.
 
-For information about the command-line interace, see lightly.cli.
+The framework is structured into the following modules:
+
+- **api**: 
+
+  The lightly.api module handles communication with the Lightly web-app.
+
+- **cli**:
+
+  The lightly.cli module provides a command-line interface for training 
+  self-supervised models and embedding images. Furthermore, the command-line
+  tool can be used to upload and download images from/to the Lightly web-app.
+
+- **core**:
+
+  The lightly.core module offers one-liners for simple self-supervised learning.
+
+- **data**:
+
+  The lightly.data module provides a dataset wrapper and collate functions. The
+  collate functions are in charge of the data augmentations which are crucial for
+  self-supervised learning.
+
+- **embedding**:
+
+  The lightly.embedding module combines the self-supervised models with a dataloader,
+  optimizer, and loss function to provide a simple pytorch-lightning trainable.
+
+- **loss**:
+
+  The lightly.loss module contains implementations of popular self-supervised training
+  loss functions.
+
+- **models**:
+
+  The lightly.models module holds the implementation of the ResNet as well as self-
+  supervised methods. Currently implements:
+
+  - SimCLR
+
+  - MoCo
+
+- **transforms**:
+
+  The lightly.transforms module implements custom data transforms. Currently implements:
+
+  - Gaussian Blur
+
+  - Random Rotation
+
+- **utils**:
+
+  The lightly.utils package provides global utility methods.
+  The io module contains utility to save and load embeddings in a format which is
+  understood by the Lightly library.
 
 """
 

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -74,6 +74,12 @@ trainer:
   max_epochs: 100             # Number of epochs to train for.
   precision: 32               # If set to 16, will use half-precision.
 
+# checkpoint_callback namespace: Modify the checkpoint callback
+checkpoint_callback:
+  save_last: True             # Whether to save the checkpoint from the last epoch
+  save_top_k: 1               # Save the top k checkpoints
+  dirpath:                    # Where to store the checkpoints
+
 # seed
 seed: 1
 

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -76,9 +76,10 @@ trainer:
 
 # checkpoint_callback namespace: Modify the checkpoint callback
 checkpoint_callback:
-  save_last: True             # Whether to save the checkpoint from the last epoch
-  save_top_k: 1               # Save the top k checkpoints
-  dirpath:                    # Where to store the checkpoints
+  save_last: True             # Whether to save the checkpoint from the last epoch.
+  save_top_k: 1               # Save the top k checkpoints.
+  dirpath:                    # Where to store the checkpoints (empty field resolves to None).
+                              # If not set, checkpoints are stored in the hydra output dir.
 
 # seed
 seed: 1

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -107,6 +107,7 @@ def _train_cli(cfg, is_cli_call=True):
                                              collate_fn=collate_fn)
 
     encoder = SelfSupervisedEmbedding(model, criterion, optimizer, dataloader)
+    encoder.init_checkpoint_callback(**cfg['checkpoint_callback'])
     encoder = encoder.train_embedding(**cfg['trainer'])
 
     print('Best model is stored at: %s' % (encoder.checkpoint))


### PR DESCRIPTION
# Fix PL warning and add overview

- Fixed the following pytorch-lightning warning:
   ```bash
   Passing a ModelCheckpoint instance to Trainer(checkpoint_callbacks=...) is deprecated since v1.1 
   and will no longer be supported in v1.3
   ```
   The fix checks the local pytorch-lightning version and acts accordingly. Let's remove the fix once we increment the version requirements.
- Checkpoint callback is now customizable:
   ```
   lightly-train input_dir=my_dataset/ save_last=True save_top_k=3
   ```
- Added an overview of the submodules to `lightly/__init__.py`