### PR TITLE
Fix #49 and add option to resize before upload

### DIFF
--- a/lightly/api/upload.py
+++ b/lightly/api/upload.py
@@ -9,6 +9,7 @@ import time
 import random
 
 import numpy as np
+import torchvision
 
 from itertools import islice
 
@@ -338,6 +339,7 @@ def upload_images_from_folder(path_to_folder: str,
                               token: str,
                               max_workers: int = 8,
                               mode: str = 'thumbnails',
+                              size: int = -1,
                               verbose: bool = True):
     """Uploads images from a directory to the Lightly cloud solution.
 
@@ -356,6 +358,12 @@ def upload_images_from_folder(path_to_folder: str,
         mode:
             One of [full, thumbnails, metadata]. Whether to upload thumbnails,
             full images, or metadata only.
+        size:
+            Desired output size. If negative, default output size is used.
+            If size is a sequence like (h, w), output size will be matched to 
+            this. If size is an int, smaller edge of the image will be matched 
+            to this number. i.e, if height > width, then image will be rescaled
+            to (size * height / width, size).
 
     Raises:
         ValueError if dataset is too large.
@@ -364,7 +372,11 @@ def upload_images_from_folder(path_to_folder: str,
 
     """
 
-    dataset = LightlyDataset(from_folder=path_to_folder)
+    transform = None
+    if isinstance(size, tuple) or size > 0:
+        transform = torchvision.transforms.Resize(size)
+
+    dataset = LightlyDataset(from_folder=path_to_folder, transform=transform)
     upload_dataset(
         dataset,
         dataset_id,

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -14,6 +14,7 @@ token: ''                     # User access token to the platform.
 dataset_id: ''                # Identifier of the dataset on the platform
 upload: 'full'                # Whether to upload full images, thumbnails only, or metadata only.
                               # Must be one of ['full', 'thumbnails', 'none']
+resize: -1                    # Allow resizing of the images before uploading, usage =-1, =x, =[x,y]
 embedding_name: 'default'     # Name of the embedding to be used on the platform.
 emb_upload_bsz: 32            # Number of embeddings which are uploaded in a single batch.
 tag_name: 'initial-tag'       # Name of the requested tag on the Lightly platform.

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -19,7 +19,10 @@ def _lightly_cli(cfg, is_cli_call=True):
 
     cfg['loader']['shuffle'] = True
     cfg['loader']['drop_last'] = True
-    checkpoint = _train_cli(cfg, is_cli_call)
+    if cfg['trainer']['max_epochs'] > 0:
+        checkpoint = _train_cli(cfg, is_cli_call)
+    else:
+        checkpoint = ''
 
     cfg['loader']['shuffle'] = False
     cfg['loader']['drop_last'] = False

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -28,6 +28,10 @@ def _upload_cli(cfg, is_cli_call=True):
     dataset_id = cfg['dataset_id']
     token = cfg['token']
 
+    size = cfg['resize']
+    if not isinstance(size, int):
+        size = tuple(size)
+
     if not token or not dataset_id:
         print('Please specify your access token and dataset id.')
         print('For help, try: lightly-upload --help')
@@ -36,7 +40,8 @@ def _upload_cli(cfg, is_cli_call=True):
     if input_dir:
         mode = cfg['upload']
         try:
-            upload_images_from_folder(input_dir, dataset_id, token, mode=mode)
+            upload_images_from_folder(
+                input_dir, dataset_id, token, mode=mode, size=size)
         except (ValueError, ConnectionRefusedError) as error:
             msg = f'Error: {error}'
             print(msg)


### PR DESCRIPTION
# Fix #49 and add option to resize before upload

- Fixed #49, `lightly-magic` with `trainer.max_epochs=0` now simply skips training.
- Added option to resize images before uploading them:
   ```bash
   # upload images with original size (default)
   lightly-upload input_dir=data/ dataset_id=XYZ token=123 resize=-1

   # resize images such that shortest edge matches 128
   lightly-upload input_dir=data/ dataset_id=XYZ token=123 resize=128

   # resize images to (128, 256)
   lightly-upload input_dir=data/ dataset_id=XYZ token=123 resize=[128,256]
   ```