### PR TITLE
Deactivate default checkpoints

### DIFF
--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -141,8 +141,8 @@ class BaseEmbedding(lightning.LightningModule):
         raise NotImplementedError()
 
     def init_checkpoint_callback(self,
-                                 save_last=True,
-                                 save_top_k=1,
+                                 save_last=False,
+                                 save_top_k=0,
                                  monitor='loss',
                                  dirpath=None):
         """Initializes the checkpoint callback.


### PR DESCRIPTION
Addresses #73. Checkpointing is now deactivated by default for `SelfSupervisedEmbeddings` and can be customized as follows:

```python
encoder = SelfSupervisedEmbedding(...)
encoder.init_checkpoint_callback(
    save_last=True, # save checkpoint from the last epoch
    save_top_k=1,  # save top 1 checkpoint
)
```