### PR TITLE
Add SimSiam and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,29 @@ Lightly is a computer vision framework for self-supervised learning.
 - [Github](https://github.com/lightly-ai/lightly)
 - [Discord](https://discord.gg/xvNJW94)
 
+
+### Tutorials
+
 Want to jump to the tutorials and see lightly in action?
 
 - [Train MoCo on CIFAR-10](https://docs.lightly.ai/tutorials/package/tutorial_moco_memory_bank.html)
 - [Train SimCLR on clothing data](https://docs.lightly.ai/tutorials/package/tutorial_simclr_clothing.html)
+- [Train SimSiam on satellite images](https://docs.lightly.ai/tutorials/package/tutorial_simsiam_esa.html)
+
+
+### Benchmarks
+
+Currently implemented models and their accuracy on cifar10. All models have been trained for 200 epochs and evaluated using kNN. We report the max test accuracy over the epochs as well as the maximum GPU memory consumption. All models in this benchmark use the same augmentations as well as the same ResNet-18 backbone.
+
+| Model   | Batch Size | Test Accuracy | Peak GPU usage |
+|---------|------------|---------------|----------------|
+| MoCo    | 128        | 0.83          | 2.1 GBytes     |
+| SimCLR  | 128        | 0.78          | 2.0 GBytes     |
+| SimSiam | 128        | 0.73          | 3.0 GBytes     |
+| MoCo    | 512        | 0.85          | 7.4 GBytes     |
+| SimCLR  | 512        | 0.83          | 7.8 GBytes     |
+| SimSiam | 512        | 0.81          | 7.0 GBytes     |
+
 
 ## Terminology
 - **Dataset:** A collection of raw images.


### PR DESCRIPTION
### Changes

- Add the new SimSiam tutorial to the readme
- Add results from benchmarking the MoCo, SimCLR, and SimSiam models on cifar10