### PR TITLE
[CI] check with setup py me

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -1,0 +1,43 @@
+name: check setup.py
+on: [push]
+
+jobs:
+  test:
+    name: Test setup.py
+    runs-on: ubuntu-latest
+
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: Hack to get setup-python to work on nektos/act
+      run: |
+        if [ ! -f "/etc/lsb-release" ] ; then
+          echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release
+        fi
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install Dependencies
+      run: pip install -e '.[all]'
+    - name: Install lightly directly from a branch
+      run: |
+        sudo apt update
+        sudo apt install git
+        pip uninstall lightly --yes
+        BRANCH_NAME=${GITHUB_REF##*/}
+        pip install "git+https://github.com/lightly-ai/lightly.git@$BRANCH_NAME"
+    - name: basic tests of CLI
+      run: |
+        lightly-train --help
+        lightly-embed --help
+        lightly-upload --help
+        lightly-magic --help
+        lightly-download --help
+    - name: test of CLI on a real dataset
+      run: |
+        git clone https://github.com/alexeygrigorev/clothing-dataset-small clothing_dataset_small
+        INPUT_DIR_1="clothing_dataset_small/test/dress"
+        lightly-train input_dir=$INPUT_DIR_1 trainer.max_epochs=1 loader.num_workers=6
+        lightly-embed input_dir=$INPUT_DIR_1

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -23,7 +23,6 @@ jobs:
       run: pip install -e '.[all]'
     - name: Install lightly directly from a branch
       run: |
-        sudo apt update
         sudo apt install git
         pip uninstall lightly --yes
         BRANCH_NAME=${GITHUB_REF##*/}


### PR DESCRIPTION
This CI checks following things that were previously untested:
- The setup.py must include all necessary directories (i.e. all in lightly). If not, they are not installed in the lightly package.
- The help section of all CLI commands is tested from the command line.
- lightly-train and lightly-embed CLI commands are tested from the command line