### PR TITLE
Remove annotations and fix tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint-tests:
 
 ## run tests
 test:
-	pytest tests -n 4
+	pytest tests -n 4 --runslow
 
 ## build source and wheel package
 dist: clean 

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -1,9 +1,3 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from lightly.api.api_workflow_client import ApiWorkflowClient
-
 from typing import List
 
 from lightly.openapi_generated.swagger_client.models.create_entity_response import CreateEntityResponse
@@ -13,7 +7,7 @@ from lightly.openapi_generated.swagger_client.models.dataset_data import Dataset
 
 class _DatasetsMixin:
 
-    def set_dataset_id_by_name(self: ApiWorkflowClient, dataset_name: str):
+    def set_dataset_id_by_name(self, dataset_name: str):
         """Sets the dataset id given the name of the dataset
 
         Args:
@@ -34,7 +28,7 @@ class _DatasetsMixin:
             raise ValueError(f"A dataset with the name {dataset_name} does not exist on the web platform. "
                              f"Please create it first.")
 
-    def create_dataset(self: ApiWorkflowClient, dataset_name: str):
+    def create_dataset(self, dataset_name: str):
         """Creates a dataset on the webplatform
 
         If a dataset with that name already exists, instead the dataset_id is set.
@@ -48,7 +42,7 @@ class _DatasetsMixin:
         except ValueError:
             self._create_dataset_without_check_existing(dataset_name=dataset_name)
 
-    def _create_dataset_without_check_existing(self: ApiWorkflowClient, dataset_name: str):
+    def _create_dataset_without_check_existing(self, dataset_name: str):
         """Creates a dataset on the webplatform
 
         No checking if a dataset with such a name already exists is performed.
@@ -61,7 +55,7 @@ class _DatasetsMixin:
         response: CreateEntityResponse = self.datasets_api.create_dataset(body=body)
         self._dataset_id = response.id
 
-    def create_new_dataset_with_unique_name(self: ApiWorkflowClient, dataset_basename: str):
+    def create_new_dataset_with_unique_name(self, dataset_basename: str):
         """Creates a new dataset on the web platform
 
         If a dataset with the specified name already exists,
@@ -86,7 +80,7 @@ class _DatasetsMixin:
             dataset_name = f"{dataset_basename}_{counter}"
         self._create_dataset_without_check_existing(dataset_name=dataset_name)
 
-    def delete_dataset_by_id(self: ApiWorkflowClient, dataset_id: str):
+    def delete_dataset_by_id(self, dataset_id: str):
         """Deletes a dataset on the web platform
 
         Args:

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -1,8 +1,3 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from lightly.api.api_workflow_client import ApiWorkflowClient
-
 import time
 from typing import Dict, List
 
@@ -21,7 +16,7 @@ from lightly.openapi_generated.swagger_client.models.sampling_config_stopping_co
 
 class _SamplingMixin:
 
-    def sampling(self: ApiWorkflowClient, sampler_config: SamplerConfig, al_scores: Dict[str, List[np.ndarray]] = None,
+    def sampling(self, sampler_config: SamplerConfig, al_scores: Dict[str, List[np.ndarray]] = None,
                  preselected_tag_id: str = None, query_tag_id: str = None) -> TagData:
         """Performs a sampling given the arguments.
 

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 import warnings
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 from lightly.openapi_generated.swagger_client.models.sample_create_request import SampleCreateRequest
 
@@ -11,9 +9,6 @@ from lightly.api.utils import check_filename, check_image, get_thumbnail_from_im
 from lightly.openapi_generated.swagger_client.models.initial_tag_create_request import InitialTagCreateRequest
 import tqdm
 
-if TYPE_CHECKING:
-    from lightly.api.api_workflow_client import ApiWorkflowClient
-
 from lightly.api.constants import LIGHTLY_MAXIMUM_DATASET_SIZE
 from lightly.data.dataset import LightlyDataset
 from lightly.api.routes.users.service import get_quota
@@ -21,7 +16,7 @@ from lightly.api.routes.users.service import get_quota
 
 class _UploadDatasetMixin:
 
-    def upload_dataset(self: ApiWorkflowClient, input: Union[str, LightlyDataset], max_workers: int = 8,
+    def upload_dataset(self, input: Union[str, LightlyDataset], max_workers: int = 8,
                        mode: str = 'thumbnails', verbose: bool = True):
         """Uploads a dataset to to the Lightly cloud solution.
 
@@ -126,7 +121,7 @@ class _UploadDatasetMixin:
         initial_tag_create_request = InitialTagCreateRequest(img_type=img_type)
         self.tags_api.create_initial_tag_by_dataset_id(body=initial_tag_create_request, dataset_id=self.dataset_id)
 
-    def _upload_single_image(self: ApiWorkflowClient, image, label, filename: str, mode):
+    def _upload_single_image(self, image, label, filename: str, mode):
         """Uploads a single image to the Lightly platform.
 
         """

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -1,9 +1,3 @@
-from __future__ import annotations
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from lightly.api.api_workflow_client import ApiWorkflowClient
-
 import csv
 from typing import List
 
@@ -13,7 +7,7 @@ from lightly.openapi_generated.swagger_client.models.write_csv_url_data import W
 
 class _UploadEmbeddingsMixin:
 
-    def set_embedding_id_by_name(self: ApiWorkflowClient, embedding_name: str = None):
+    def set_embedding_id_by_name(self, embedding_name: str = None):
         embeddings: List[DatasetEmbeddingData] = \
             self.embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
 
@@ -26,7 +20,7 @@ class _UploadEmbeddingsMixin:
         except StopIteration:
             raise ValueError(f"No embedding with name {embedding_name} found on the server.")
 
-    def upload_embeddings(self: ApiWorkflowClient, path_to_embeddings_csv: str, name: str):
+    def upload_embeddings(self, path_to_embeddings_csv: str, name: str):
         """Uploads embeddings to the server.
 
         First checks that the specified embedding name is not on ther server. If it is, the upload is aborted.
@@ -64,7 +58,7 @@ class _UploadEmbeddingsMixin:
         with open(path_to_ordered_embeddings_csv, 'rb') as file_ordered_embeddings_csv:
             self.upload_file_with_signed_url(file=file_ordered_embeddings_csv, signed_write_url=signed_write_url)
 
-    def _order_csv_by_filenames(self: ApiWorkflowClient, path_to_embeddings_csv: str) -> str:
+    def _order_csv_by_filenames(self, path_to_embeddings_csv: str) -> str:
         """Orders the rows in a csv according to the order specified on the server and saves it as a new file.
 
         Args:

--- a/tox.ini
+++ b/tox.ini
@@ -76,9 +76,16 @@ setenv = LIGHTLY_SERVER_LOCATION = https://api-dev.lightly.ai
 commands = 
            pip install pillow==7.0.0
            pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-           pip install pytorch-lightning==0.10.0
+           pip install pytorch-lightning==1.0.4
            pip install hydra-core==1.0.0
-           pip install tqdm==4.41.1
+           pip install numpy==1.18.1
+           pip install urllib3==1.15.1
+           pip install requests==2.23.0
+           pip install tqdm==4.44
+           pip install certifi==14.05.14
+           pip install six==1.10
+           pip install python_dateutil==2.5.3
+           pip install setuptools==21.0.0
            pip install .[dev]
            echo "Running cpu-minimal test"
            make test


### PR DESCRIPTION
Closes #193 

I fixed the problem which let lightly crash in Python 3.6 by removing typehints for `self` in the api workflow clients.