### PR TITLE
trigger CI on workflow_dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: [push, pull_request_target]
+on: [push, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -1,5 +1,5 @@
 name: check setup.py
-on: [push, pull_request_target]
+on: [push, workflow_dispatch]
 
 jobs:
   test:


### PR DESCRIPTION
close #238 
- removes the triggering of CI with pull requests
- allows to trigger workflows manually: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow