### PR TITLE
Add coverage config to ignore generated files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit = 
+    lightly/openapi_generated/*


### PR DESCRIPTION
### Changes

- Added a coverage config file to prevent the report from including the OpenAPI generated files