### PR TITLE
Remove print statement

### DIFF
--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -75,7 +75,6 @@ class _DownloadDatasetMixin:
         # check if tag exists
         available_tags = self._get_all_tags()
         try:
-            print(available_tags)
             tag = next(tag for tag in available_tags if tag.name == tag_name)
         except StopIteration:
             raise ValueError(


### PR DESCRIPTION
# Remove print statement

Forgot a print statement in the download api. Need to remove it before the release. This means we also have to merge develop into master again. Please review @IgorSusmelj.