### PR TITLE
245 cli lightly version pw

### DIFF
--- a/docs/source/getting_started/command_line_tool.rst
+++ b/docs/source/getting_started/command_line_tool.rst
@@ -24,6 +24,22 @@ the CLI.
     </div>
 
 
+Check the installation of lightly
+-----------------------------------
+To see if the lightly command-line tool was installed correctly, you can run the
+following command which will print the installed lightly version:
+
+.. code-block:: bash
+
+    lightly-version
+
+If lightly was installed correctly, you should see something like this:
+
+.. code-block:: bash
+
+    lightly version 1.1.4
+
+
 Train a model using the CLI
 ---------------------------------------
 Training a model using default parameters can be done with just one command. Let's

--- a/docs/source/lightly.cli.rst
+++ b/docs/source/lightly.cli.rst
@@ -28,6 +28,10 @@ lightly.cli
 .. automodule:: lightly.cli.download_cli
    :members:
 
+.version_cli
+-------------
+.. automodule:: lightly.cli.version_cli
+
 .config.config.yaml
 -------------------
 

--- a/lightly/cli/version_cli.py
+++ b/lightly/cli/version_cli.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""**Lightly Version:** Show version of installed package.
+
+"""
+
+# Copyright (c) 2020. Lightly AG and its affiliates.
+# All Rights Reserved
+
+import hydra
+import lightly
+
+def _version_cli():
+    version = lightly.__version__
+    print(f'lightly version {version}', flush=True)
+
+
+@hydra.main(config_path='config', config_name='config')
+def version_cli(cfg):
+    """Prints the version of the used lightly package to the terminal.
+
+    """
+    _version_cli()
+
+
+def entry():
+    version_cli()

--- a/lightly/cli/version_cli.py
+++ b/lightly/cli/version_cli.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-"""**Lightly Version:** Show version of installed package.
+"""**Lightly Version:** Show the version of the installed package.
 
+Example:
+    >>> # show the version of the installed package
+    >>> lightly-version
 """
 
 # Copyright (c) 2021. Lightly AG and its affiliates.

--- a/lightly/cli/version_cli.py
+++ b/lightly/cli/version_cli.py
@@ -3,11 +3,12 @@
 
 """
 
-# Copyright (c) 2020. Lightly AG and its affiliates.
+# Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
 import hydra
 import lightly
+
 
 def _version_cli():
     version = lightly.__version__

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
             "lightly-magic = lightly.cli.lightly_cli:entry",
             "lightly-upload = lightly.cli.upload_cli:entry",
             "lightly-download = lightly.cli.download_cli:entry",
+            "lightly-version = lightly.cli.version_cli:entry",
         ]
     }
 


### PR DESCRIPTION
# Add cli command to show installed version

Closes #245.

I added a new CLI command which shows which version of lightly is installed and used for the cli.
This can be very helpful when working with different environments.

Example:
```
philipp_lightly_ai@philipp-gpu:~/$ lightly-version
lightly version 1.1.3
```