### PR TITLE
126 consistency regularization pw

### DIFF
--- a/docs/source/lightly.loss.rst
+++ b/docs/source/lightly.loss.rst
@@ -17,3 +17,9 @@ lightly.loss
 -------------
 .. autoclass:: lightly.loss.memory_bank.MemoryBankModule
    :members:
+
+
+.regularizer.co2
+-----------------
+.. autoclass:: lightly.loss.regularizer.co2.CO2Regularizer
+   :members:

--- a/lightly/loss/regularizer/__init__.py
+++ b/lightly/loss/regularizer/__init__.py
@@ -1,0 +1,7 @@
+"""The lightly.loss.regularizer package provides regularizers for self-supervised learning. """
+
+
+# Copyright (c) 2020. Lightly AG and its affiliates.
+# All Rights Reserved
+
+from lightly.loss.regularizer.co2 import CO2Regularizer

--- a/lightly/loss/regularizer/co2.py
+++ b/lightly/loss/regularizer/co2.py
@@ -1,0 +1,131 @@
+""" CO2 Regularizer """
+
+# Copyright (c) 2020. Lightly AG and its affiliates.
+# All Rights Reserved
+
+import torch
+from lightly.loss.memory_bank import MemoryBankModule
+
+
+class CO2Regularizer(MemoryBankModule):
+    """Implementation of the CO2 regularizer [0] for self-supervised learning.
+
+    [0] CO2, 2021, https://arxiv.org/abs/2010.02217
+
+    Attributes:
+        alpha:
+            Weight of the regularization term.
+        t_consistency:
+            Temperature used during softmax calculations.
+        memory_bank_size:
+            Number of negative samples to store in the memory bank.
+            Use 0 to use the second batch for negative samples.
+
+    Examples:
+        >>> # initialize loss function for MoCo
+        >>> loss_fn = NTXentLoss(memory_bank_size=4096)
+        >>>
+        >>> # initialize CO2 regularizer
+        >>> co2 = CO2Regularizer(alpha=1.0, memory_bank_size=4096)
+        >>>
+        >>> # generate two random trasnforms of images
+        >>> t0 = transforms(images)
+        >>> t1 = transforms(images)
+        >>>
+        >>> # feed through the MoCo model
+        >>> out0, out1 = model(t0, t1)
+        >>> 
+        >>> # calculate loss and apply regularizer
+        >>> loss = loss_fn(out0, out1) + co2(out0, out1)
+
+    """
+
+    def __init__(self,
+                alpha: float = 1,
+                t_consistency: float = 0.05,
+                memory_bank_size: int = 0):
+
+        super(CO2Regularizer, self).__init__(size=memory_bank_size)
+        self.kl_div = torch.nn.KLDivLoss(reduction='batchmean', log_target=True)
+        self.t_consistency = t_consistency
+        self.alpha = alpha
+
+    def _get_pseudo_labels(self,
+                           out0: torch.Tensor,
+                           out1: torch.Tensor,
+                           negatives: torch.Tensor = None):
+        """Computes the soft pseudo labels across negative samples.
+
+        Args:
+            out0:
+                Output projections of the first set of transformed images.
+            out1:
+                Output projections of the second set of transformed images.
+            negatives:
+                Negative samples to compare against. If this is None, the second
+                batch of images will be used as negative samples.
+
+        Returns:
+            Log probability that a positive samples will classify each negative 
+            sample as the positive sample.
+
+        """
+        batch_size, _ = out0.shape
+        if negatives is None:
+            # use second batch as negative samples
+            l_pos = torch.einsum('nc,nc->n', [out0, out1]).unsqueeze(-1)
+            l_neg = torch.einsum('nc,ck->nk', [out0, out1.t()])
+            # remove elements on the diagonal
+            l_neg = l_neg.masked_select(
+                ~torch.eye(batch_size, dtype=bool, device=l_neg.device)
+            ).view(batch_size, batch_size - 1)
+        else:
+            # use memory bank as negative samples
+            negatives = negatives.to(out0.device)
+            l_pos = torch.einsum('nc,nc->n', [out0, out1]).unsqueeze(-1)
+            l_neg = torch.einsum('nc,ck->nk', [out0, negatives.clone().detach()])
+            
+        # concatenate such that positive samples are at index 0
+        logits = torch.cat([l_pos, l_neg], dim=1)
+        # divide by temperature
+        logits = logits / self.t_consistency
+
+        # the input to kl_div is expected to be log(p) and we set the
+        # flag log_target to True, so both probabilities should be passed as log
+        log_probs = torch.nn.functional.log_softmax(logits, dim=-1)
+        return log_probs
+
+
+    def forward(self,
+                out0: torch.Tensor,
+                out1: torch.Tensor):
+        """Computes the CO2 regularization term for two model outputs.
+
+        Args:
+            out0:
+                Output projections of the first set of transformed images.
+            out1:
+                Output projections of the second set of transformed images.
+
+        Returns:
+            The regularization term multiplied by the weight factor alpha.
+
+        """
+
+        # normalize the output to length 1
+        out0 = torch.nn.functional.normalize(out0, dim=1)
+        out1 = torch.nn.functional.normalize(out1, dim=1)
+
+        # ask memory bank for negative samples and extend it with out1 if 
+        # out1 requires a gradient, otherwise keep the same vectors in the 
+        # memory bank (this allows for keeping the memory bank constant e.g.
+        # for evaluating the loss on the test set)
+        out1, negatives = \
+            super(CO2Regularizer, self).forward(out1, update=True)
+        
+        # get log probabilities
+        p = self._get_pseudo_labels(out0, out1, negatives)
+        q = self._get_pseudo_labels(out1, out0, negatives)
+        
+        # calculate kullback leibler divergence from log probabilities
+        return self.alpha * 0.5 * (self.kl_div(p, q) + self.kl_div(q, p))

--- a/tests/imports/test_from_imports.py
+++ b/tests/imports/test_from_imports.py
@@ -45,6 +45,8 @@ class TestFromImports(unittest.TestCase):
         from lightly.loss import SymNegCosineSimilarityLoss
         from lightly.loss.sym_neg_cos_sim_loss import SymNegCosineSimilarityLoss
         from lightly.loss.memory_bank import MemoryBankModule
+        from lightly.loss.regularizer import CO2Regularizer
+        from lightly.loss.regularizer.co2 import CO2Regularizer
 
         # models imports
         from lightly.models import ResNetGenerator

--- a/tests/imports/test_nested_imports.py
+++ b/tests/imports/test_nested_imports.py
@@ -46,6 +46,8 @@ class TestNestedImports(unittest.TestCase):
         lightly.loss.SymNegCosineSimilarityLoss
         lightly.loss.sym_neg_cos_sim_loss.SymNegCosineSimilarityLoss
         lightly.loss.memory_bank.MemoryBankModule
+        lightly.loss.regularizer.CO2Regularizer
+        lightly.loss.regularizer.co2.CO2Regularizer
 
         # models imports
         lightly.models.ResNetGenerator

--- a/tests/imports/test_seminested_imports.py
+++ b/tests/imports/test_seminested_imports.py
@@ -52,6 +52,10 @@ class TestSemiNestedImports(unittest.TestCase):
         loss.sym_neg_cos_sim_loss.SymNegCosineSimilarityLoss
         loss.memory_bank.MemoryBankModule
 
+        from lightly.loss import regularizer
+        regularizer.CO2Regularizer
+        regularizer.co2.CO2Regularizer
+
         # models imports
         from lightly import models
         models.ResNetGenerator

--- a/tests/loss/test_CO2Regularizer.py
+++ b/tests/loss/test_CO2Regularizer.py
@@ -1,0 +1,59 @@
+import unittest
+import torch
+
+from lightly.loss.regularizer import CO2Regularizer
+
+class TestCO2Regularizer(unittest.TestCase):
+
+    def test_forward_pass_no_memory_bank(self):
+        reg = CO2Regularizer(memory_bank_size=0)
+        for bsz in range(1, 20):
+
+            batch_1 = torch.randn((bsz, 32))
+            batch_2 = torch.randn((bsz, 32))
+
+            # symmetry
+            l1 = reg(batch_1, batch_2)
+            l2 = reg(batch_2, batch_1)
+            self.assertAlmostEqual((l1 - l2).pow(2).item(), 0.)
+
+    def test_forward_pass_memory_bank(self):
+        reg = CO2Regularizer(memory_bank_size=4096)
+        for bsz in range(1, 20):
+
+            batch_1 = torch.randn((bsz, 32))
+            batch_2 = torch.randn((bsz, 32))
+
+            l1 = reg(batch_1, batch_2)
+            self.assertGreater(l1.item(), 0)
+
+    def test_forward_pass_cuda_no_memory_bank(self):
+        if not torch.cuda.is_available():
+            return
+
+        reg = CO2Regularizer(memory_bank_size=0)
+        for bsz in range(1, 20):
+
+            batch_1 = torch.randn((bsz, 32)).cuda()
+            batch_2 = torch.randn((bsz, 32)).cuda()
+
+            # symmetry
+            l1 = reg(batch_1, batch_2)
+            l2 = reg(batch_2, batch_1)
+            self.assertAlmostEqual((l1 - l2).pow(2).item(), 0.)
+
+
+    def test_forward_pass_cuda_memory_bank(self):
+        if not torch.cuda.is_available():
+            return
+
+        reg = CO2Regularizer(memory_bank_size=4096)
+        for bsz in range(1, 20):
+
+            batch_1 = torch.randn((bsz, 32)).cuda()
+            batch_2 = torch.randn((bsz, 32)).cuda()
+
+            # symmetry
+            l1 = reg(batch_1, batch_2)
+            self.assertGreater(l1.cpu().item(), 0)
+


### PR DESCRIPTION
# Consistency Regularization

Implementation of the [CO2 paper](https://arxiv.org/abs/2010.02217) for consistency regularization based on [this repo](https://github.com/philippmwirth/co2).

- Implemented the CO2 regularizer as a standalone feature (can be added to any existing loss)
- Added documentation
- Added tests

For benchmarks, check out my [other repo](https://github.com/philippmwirth/co2). Regularized models consistently outperform the default ones but only by a tiny margin.