### PR TITLE
273 retry wrapper pw

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -152,27 +152,11 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin, _SamplingMixin, _UploadDatasetMi
 
         """
 
-        counter = 0
-        backoff = 1. + random.random() * 0.1
-        success = False
-        while not success:
+        response = requests.put(signed_write_url, data=file)
 
-            response = requests.put(signed_write_url, data=file)
-            success = (response.status_code == 200)
-
-            # exponential backoff
-            if response.status_code in [500, 502]:
-                time.sleep(backoff)
-                backoff = 2 * backoff if backoff < max_backoff else backoff
-            # something went wrong
-            elif not success:
-                msg = f'Failed PUT request to {signed_write_url} with status_code '
-                msg += f'{response.status_code}.'
-                raise RuntimeError(msg)
-
-            counter += 1
-            if counter >= max_retries:
-                msg = f'The connection to the server at {signed_write_url} timed out. '
-                raise RuntimeError(msg)
+        if response.status_code != 200:
+            msg = f'Failed PUT request to {signed_write_url} with status_code'
+            msg += f'{response.status__code}!'
+            raise RuntimeError(msg)
 
         return response

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -5,6 +5,8 @@
 
 import io
 import os
+import time
+import random
 
 import numpy as np
 from PIL import Image, ImageFilter
@@ -17,6 +19,44 @@ JpegImagePlugin._getmp = lambda: None
 LEGAL_IMAGE_FORMATS = ['jpg', 'jpeg', 'png', 'tiff', 'bmp']
 MAXIMUM_FILENAME_LENGTH = 80
 MAX_WIDTH, MAX_HEIGHT = 2048, 2048
+
+
+def retry(func, *args, **kwargs):
+    """Repeats a function until it completes successfully or fails too often.
+
+    Args:
+        func:
+            The function call to repeat.
+        args:
+            The arguments which are passed to the function.
+        kwargs:
+            Key-word arguments which are passed to the function.
+
+    Returns:
+        What func returns.
+
+    Exceptions:
+        RuntimeError when number of retries has been exceeded.
+
+    """
+
+    # config
+    backoff = 1. + random.random() * 0.1
+    max_backoff = 32
+    max_retries = 5
+
+    # try to make the request
+    for i in range(max_retries):
+        try:
+            # return on success
+            return func(*args, **kwargs)
+        except Exception:
+            # sleep on failure
+            time.sleep(backoff)
+            backoff = 2 * backoff if backoff < max_backoff else backoff
+        
+    # max retries exceeded
+    raise RuntimeError('The connection to the server timed out.')
 
 
 def getenv(key: str, default: str):

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,0 +1,23 @@
+import unittest
+
+import lightly
+from lightly.api.utils import retry
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_retry_success(self):
+
+        def my_func(arg, kwarg=5):
+            return arg + kwarg
+        
+        self.assertEqual(retry(my_func, 5, kwarg=5), 10)
+
+
+    def test_retry_fail(self):
+
+        def my_func():
+            raise RuntimeError()
+        
+        with self.assertRaises(RuntimeError):
+            retry(my_func)


### PR DESCRIPTION
# retry wrapper

Closes #273.

I wrapped all function calls to the api which are used in `_upload_single_image` in retry wrappers so that a single failed request will not interrupt the upload process.