### PR TITLE
Bugfix: active learning scores numpy float32 me

### DIFF
--- a/lightly/active_learning/config/sampler_config.py
+++ b/lightly/active_learning/config/sampler_config.py
@@ -24,13 +24,13 @@ class SamplerConfig:
     Examples:
         >>> # sample 100 images with CORESET sampling
         >>> config = SamplerConfig(method=SamplingMethod.CORESET, n_samples=100)
-        >>> config = SamplerConfig(method='CORESET', n_samples=100)
+        >>> config = SamplerConfig(method=SamplingMethod.CORESET, n_samples=100)
         >>>
         >>> # give your sampling a name
-        >>> config = SamplerConfig(method='CORESET', n_samples=100, name='my-sampling')
+        >>> config = SamplerConfig(method=SamplingMethod.CORESET, n_samples=100, name='my-sampling')
         >>>
         >>> # use minimum distance between samples as stopping criterion
-        >>> config = SamplerConfig(method='CORESET', n_samples=-1, min_distance=0.1)
+        >>> config = SamplerConfig(method=SamplingMethod.CORESET, n_samples=-1, min_distance=0.1)
 
     """
     def __init__(self, method: SamplingMethod = SamplingMethod.CORESET, n_samples: int = 32, min_distance: float = -1,

--- a/lightly/active_learning/config/sampler_config.py
+++ b/lightly/active_learning/config/sampler_config.py
@@ -24,7 +24,6 @@ class SamplerConfig:
     Examples:
         >>> # sample 100 images with CORESET sampling
         >>> config = SamplerConfig(method=SamplingMethod.CORESET, n_samples=100)
-        >>> config = SamplerConfig(method=SamplingMethod.CORESET, n_samples=100)
         >>>
         >>> # give your sampling a name
         >>> config = SamplerConfig(method=SamplingMethod.CORESET, n_samples=100, name='my-sampling')

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -55,6 +55,8 @@ class _SamplingMixin:
             if preselected_tag_id is None:
                 raise ValueError
             for score_type, score_values in al_scores.items():
+                if isinstance(score_values, np.ndarray):
+                    score_values = score_values.astype(np.float64)
                 body = ActiveLearningScoreCreateRequest(score_type=score_type, scores=list(score_values))
                 self.scores_api.create_or_update_active_learning_score_by_tag_id(
                     body, dataset_id=self.dataset_id, tag_id=preselected_tag_id)

--- a/tests/active_learning/test_active_learning_agent.py
+++ b/tests/active_learning/test_active_learning_agent.py
@@ -27,7 +27,7 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
                         sampler_config = SamplerConfig(n_samples=n_samples, method=method)
 
                     if sampler_config.method == SamplingMethod.CORESET:
-                        predictions = np.random.rand(len(agent.unlabeled_set), 10)
+                        predictions = np.random.rand(len(agent.unlabeled_set), 10).astype(np.float32)
                         predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]
                         al_scorer = ScorerClassification(predictions_normalized)
                         chosen_filenames = agent.query(sampler_config=sampler_config, al_scorer=al_scorer)

--- a/tests/api/test_rest_parser.py
+++ b/tests/api/test_rest_parser.py
@@ -1,0 +1,26 @@
+import unittest
+
+import numpy as np
+
+from lightly.openapi_generated.swagger_client import ApiClient, ScoresApi, ActiveLearningScoreCreateRequest, \
+    SamplingMethod
+from lightly.openapi_generated.swagger_client.rest import ApiException
+
+
+class TestRestParser(unittest.TestCase):
+
+    def test_parse_active_learning_scores_generator(self):
+        score_value_tuple = (
+            np.random.normal(0, 1, size=(999,)).astype(np.float32),
+            np.random.normal(0, 1, size=(999,)).astype(np.float64),
+            [12.0] * 999
+        )
+        api_client = ApiClient()
+        self.scores_api = ScoresApi(api_client)
+        for i, score_values in enumerate(score_value_tuple):
+            with self.subTest(i=i, msg=str(type(score_values))):
+                body = ActiveLearningScoreCreateRequest(score_type=SamplingMethod.CORESET, scores=list(score_values))
+                with self.assertRaises(ApiException):
+                    self.scores_api.create_or_update_active_learning_score_by_tag_id(
+                        body, dataset_id="dataset_id_xyz", tag_id="tag_id_xyz")
+

--- a/tests/api/test_rest_parser.py
+++ b/tests/api/test_rest_parser.py
@@ -9,7 +9,8 @@ from lightly.openapi_generated.swagger_client.rest import ApiException
 
 class TestRestParser(unittest.TestCase):
 
-    def test_parse_active_learning_scores_generator(self):
+    @unittest.skip("This test only shows the error, it does not ensure it is solved.")
+    def test_parse_active_learning_scores(self):
         score_value_tuple = (
             np.random.normal(0, 1, size=(999,)).astype(np.float32),
             np.random.normal(0, 1, size=(999,)).astype(np.float64),
@@ -20,7 +21,12 @@ class TestRestParser(unittest.TestCase):
         for i, score_values in enumerate(score_value_tuple):
             with self.subTest(i=i, msg=str(type(score_values))):
                 body = ActiveLearningScoreCreateRequest(score_type=SamplingMethod.CORESET, scores=list(score_values))
-                with self.assertRaises(ApiException):
-                    self.scores_api.create_or_update_active_learning_score_by_tag_id(
-                        body, dataset_id="dataset_id_xyz", tag_id="tag_id_xyz")
+                if isinstance(score_values[0], float):
+                    with self.assertRaises(ApiException):
+                        self.scores_api.create_or_update_active_learning_score_by_tag_id(
+                            body, dataset_id="dataset_id_xyz", tag_id="tag_id_xyz")
+                else:
+                    with self.assertRaises(AttributeError):
+                        self.scores_api.create_or_update_active_learning_score_by_tag_id(
+                            body, dataset_id="dataset_id_xyz", tag_id="tag_id_xyz")
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -110,6 +110,8 @@ class MockedTagsApi(TagsApi):
 class MockedScoresApi(ScoresApi):
     def create_or_update_active_learning_score_by_tag_id(self, body, dataset_id, tag_id, **kwargs) -> \
             CreateEntityResponse:
+        if len(body.scores) > 0 and not isinstance(body.scores[0], float):
+            raise AttributeError
         response_ = CreateEntityResponse(id="sampled_tag_id_xyz")
         return response_
 


### PR DESCRIPTION
close #259 

Problem: as `isinstance(np.ones((1, ) dtype=float32), float) == False`, serialising a np.float32 array to json fails, whereas np.float64 is a float. The error occurs as https://github.com/lightly-ai/lightly/blob/4b9401e91c555be6811dfe320ce46b22cb4cb976/lightly/openapi_generated/swagger_client/api_client.py#L196 is not entered for np.float32 arrays, causing Exceptions later on. The test in https://github.com/lightly-ai/lightly/blob/259-active-learning-scores-numpy-float32-me/tests/api/test_rest_parser.py shows the error directly as the unmocked functions are used. The changes in the other two test files reproduce the error, as the mocked function mimics the error throwing for np.float32.

I solved the problem by 
https://github.com/lightly-ai/lightly/blob/acb59f3416a33a2bc0b3eb00a55cd59639c127c4/lightly/api/api_workflow_sampling.py#L58-L59


The change in the documentation to SamplingMethod.CORESET is unrelated, but I changed it, as PyCharm showed me an error for it and it is easier for users to use the attributes, as they guide directly which methods are allowed.