### PR TITLE
Bugfix: lightly-upload now uses loader.num_workers

### DIFF
--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -61,6 +61,7 @@ class _UploadDatasetMixin:
 
         # handle the case where len(dataset) < max_workers
         max_workers = min(len(dataset), max_workers)
+        max_workers = max(max_workers, 1)
 
         # upload the samples
         if verbose:

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -52,7 +52,7 @@ def _upload_cli(cfg, is_cli_call=True):
         mode = cfg['upload']
         dataset = LightlyDataset(input_dir=input_dir, transform=transform)
         api_workflow_client.upload_dataset(
-            input=dataset, mode=mode
+            input=dataset, mode=mode, max_workers=cfg['loader']['num_workers']
         )
 
     if path_to_embeddings:

--- a/tests/UNMOCKED_end2end_tests/test_api.py
+++ b/tests/UNMOCKED_end2end_tests/test_api.py
@@ -4,6 +4,9 @@ import sys
 from typing import List, Tuple
 
 import numpy as np
+from hydra.experimental import initialize, compose
+
+from lightly.cli import upload_cli
 from lightly.data.dataset import LightlyDataset
 
 from lightly.active_learning.scorers.classification import ScorerClassification
@@ -69,7 +72,14 @@ def create_new_dataset_with_embeddings(path_to_dataset: str,
     api_workflow_client.create_new_dataset_with_unique_name(dataset_basename=dataset_name)
 
     # upload to the dataset
-    api_workflow_client.upload_dataset(input=path_to_dataset)
+    initialize(config_path="../../lightly/cli/config", job_name="test_app")
+    cfg = compose(config_name="config", overrides=[
+        f"input_dir='{path_to_dataset}'",
+        f"token='{token}'",
+        f"dataset_id={api_workflow_client.dataset_id}",
+        f"loader.num_workers=9"
+        ])
+    upload_cli(cfg)
 
     # calculate and save the embeddings
     path_to_embeddings_csv = f"{path_to_dataset}/embeddings.csv"


### PR DESCRIPTION
close #295 

## Changes:
- bugfix itself: look at code, very straightforward
- testing it: adapted the unmocked `test_api` function, it works

## How to test:
- run the new `test_api`function and see how 9 workers are used
- directly with CLI:
```bash
export BRANCH_NAME="295-lightly-upload-always-uses-8-workers-me" 
pip install "git+https://github.com/lightly-ai/lightly.git@$BRANCH_NAME" 
export LIGHTLY_SERVER_LOCATION="http://localhost:5000"
# create a new dataset on production and copy the CLI command, e.g.
lightly-upload token='your_token' dataset_id='your_dataset_id' input_dir='path_to_your_dataset' loader.num_workers=5
```