### PR TITLE
327 Add check for comma in filenames of CSV file

### DIFF
--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -96,9 +96,8 @@ class _UploadEmbeddingsMixin:
                                  f'{len(self.filenames_on_server)} filenames/samples on the server.')
             if set(filenames) != set(self.filenames_on_server):
                 raise ValueError(f'The filenames in the embedding file and the filenames on the server do not align')
-            are_valid_filenames = [_is_valid_filename(f) for f in filenames]
-            if not all(are_valid_filenames):
-                invalid_filenames = [f for f, v in zip(filenames, are_valid_filenames) if v]
+            invalid_filenames = [f for f in filenames if not _is_valid_filename(f)]
+            if len(invalid_filenames) > 0:
                 raise ValueError(f'Invalid filename(s) in embedding file: {invalid_filenames}')
 
             rows_without_header_ordered = self._order_list_by_filenames(filenames, rows_without_header)

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -5,6 +5,18 @@ from lightly.openapi_generated.swagger_client.models.dataset_embedding_data impo
 from lightly.openapi_generated.swagger_client.models.write_csv_url_data import WriteCSVUrlData
 
 
+
+def _is_valid_filename(filename: str):
+    """Returns False if the filename is misformatted.
+
+    """
+    invalid_characters = [',']
+    for character in invalid_characters:
+        if character in filename:
+            return False
+    return True
+
+
 class _UploadEmbeddingsMixin:
 
     def set_embedding_id_by_name(self, embedding_name: str = None):
@@ -39,6 +51,7 @@ class _UploadEmbeddingsMixin:
         embeddings_on_server: List[DatasetEmbeddingData] = \
             self.embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
         names_embeddings_on_server = [embedding.name for embedding in embeddings_on_server]
+
         if name in names_embeddings_on_server:
             print(f"Aborting upload, embedding with name='{name}' already exists.")
             self.embedding_id = next(embedding for embedding in embeddings_on_server if embedding.name == name).id
@@ -79,10 +92,14 @@ class _UploadEmbeddingsMixin:
             filenames = [row[index_filenames] for row in rows_without_header]
 
             if len(filenames) != len(self.filenames_on_server):
-                raise ValueError(f"There are {len(filenames)} rows in the embedding file, but "
-                                 f"{len(self.filenames_on_server)} filenames/samples on the server.")
+                raise ValueError(f'There are {len(filenames)} rows in the embedding file, but '
+                                 f'{len(self.filenames_on_server)} filenames/samples on the server.')
             if set(filenames) != set(self.filenames_on_server):
-                raise ValueError(f"The filenames in the embedding file and the filenames on the server do not align")
+                raise ValueError(f'The filenames in the embedding file and the filenames on the server do not align')
+            are_valid_filenames = [_is_valid_filename(f) for f in filenames]
+            if not all(are_valid_filenames):
+                invalid_filenames = [f for f, v in zip(filenames, are_valid_filenames) if v]
+                raise ValueError(f'Invalid filename(s) in embedding file: {invalid_filenames}')
 
             rows_without_header_ordered = self._order_list_by_filenames(filenames, rows_without_header)
 

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -22,6 +22,8 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
         sample_names = [f'img_{i}.jpg' for i in range(n_data)]
         if special_name_first_sample:
             sample_names[0] = "bliblablub"
+        if comma_in_first_sample:
+            sample_names[0] = "bli,blablu"
         labels = [0] * len(sample_names)
         save_embeddings(
             path_to_embeddings,

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -65,3 +65,11 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
 
     def test_set_embedding_id_default(self):
         self.api_workflow_client.set_embedding_id_by_name()
+
+    def test_is_valid_filename(self):
+        filenames = [',a', ',', 'a,', 'a']
+        is_valid = [False, False, False, True]
+        result = [
+            lightly.api.api_workflow_upload_embeddings._is_valid_filename(f) for f in filenames
+        ]
+        self.assertListEqual(is_valid, result)

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -9,7 +9,10 @@ from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 
 class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
-    def t_ester_upload_embedding(self, n_data, special_name_first_sample: bool = False):
+    def t_ester_upload_embedding(self,
+                                 n_data,
+                                 special_name_first_sample: bool = False,
+                                 comma_in_first_sample: bool = False):
         # create fake embeddings
         folder_path = tempfile.mkdtemp()
         path_to_embeddings = os.path.join(
@@ -43,6 +46,11 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
         n_data = len(self.api_workflow_client.mappings_api.sample_names)
         with self.assertRaises(ValueError):
             self.t_ester_upload_embedding(n_data=n_data, special_name_first_sample=True)
+
+    def test_upload_comma_filenames(self):
+        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        with self.assertRaises(ValueError):
+            self.t_ester_upload_embedding(n_data=n_data, comma_in_first_sample=True)
 
     def test_set_embedding_id_success(self):
         embedding_name = self.api_workflow_client.embeddings_api.embeddings[0].name


### PR DESCRIPTION
# Add check for comma in filenames of CSV file

Forbids the upload of embeddings which contain filenames with a comma in them through the pip package. 