### PR TITLE
132 Docs on embeddings upload

### DIFF
--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -159,6 +159,17 @@ drag-and-drop or using the Python Package according to:
     You can upload up to 1'000 images using the frontend.
 
 
+Images can also be uploaded from a Python script:
+
+.. code-block:: python
+
+    from lightly.api.api_workflow_client import ApiWorkflowClient
+    client = ApiWorkflowClient(token='123'm dataset_id='xyz')
+
+    # change mode to thumbnails or meta if you're working with sensitive data
+    client.upload_dataset('path/to/your/images/', mode='full')
+
+
 Upload Embeddings
 -------------------------
 

--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -166,7 +166,7 @@ Images can also be uploaded from a Python script:
     from lightly.api.api_workflow_client import ApiWorkflowClient
     client = ApiWorkflowClient(token='123'm dataset_id='xyz')
 
-    # change mode to thumbnails or meta if you're working with sensitive data
+    # change mode to 'thumbnails' or 'meta' if you're working with sensitive data
     client.upload_dataset('path/to/your/images/', mode='full')
 
 
@@ -185,10 +185,11 @@ them from your Python code or using the CLI. The following snippet shows how to 
     from lightly.utils import save_embeddings
     from lightly.api.api_workflow_client import ApiWorkflowClient
 
-    # save embeddings
+    # store the embeddings in a lightly compatible CSV format before uploading
+    # them to the platform
     save_embeddings('embeddings.csv', embeddings, labels, filenames)
 
-    # upload them to the platform
+    # upload the embeddings.csv file to the platform
     client = ApiWorkflowClient(token='123', dataset_id='xyz')
     client.upload_embeddings('embeddings.csv', name='my-embeddings')
 

--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -162,9 +162,24 @@ drag-and-drop or using the Python Package according to:
 Upload Embeddings
 -------------------------
 
-Embeddings can be uploaded using the Python Package.
-You can not upload embedding through the web interface. Instead
-:ref:`ref-upload-embedding-lightly`
+Embeddings can be uploaded using the Python Package or the front-end. The simplest
+way to upload the embeddings is from the command line: :ref:`ref-upload-embedding-lightly`.
+
+If you have a numpy array of image embeddings, the filenames of the images, and categorical pseudo-labels,
+you can use the `save_embeddings` function to store them in a lightly-compatible CSV format and upload
+them from your Python code or using the CLI. The following snippet shows how to upload the embeddings from Python.
+
+.. code-block:: python
+
+    from lightly.utils import save_embeddings
+    from lightly.api.api_workflow_client import ApiWorkflowClient
+
+    # save embeddings
+    save_embeddings('embeddings.csv', embeddings, labels, filenames)
+
+    # upload them to the platform
+    client = ApiWorkflowClient(token='123', dataset_id='xyz')
+    client.upload_embeddings('embeddings.csv', name='my-embeddings')
 
 
 Sampling

--- a/docs/source/lightly.api.rst
+++ b/docs/source/lightly.api.rst
@@ -8,6 +8,20 @@ lightly.api
 .. automodule:: lightly.api.api_workflow_client
    :members:
 
+.. automodule:: lightly.api.api_workflow_datasets
+   :members:
+
+.. automodule:: lightly.api.api_workflow_download_dataset
+   :members:
+
+.. automodule:: lightly.api.api_workflow_sampling
+   :members:
+
+.. automodule:: lightly.api.api_workflow_upload_dataset
+   :members:
+
+.. automodule:: lightly.api.api_workflow_upload_embeddings
+   :members:
 
 .utils
 ---------------

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -85,12 +85,11 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin, _SamplingMixin, _UploadDatasetMi
 
     @property
     def dataset_id(self) -> str:
-        ''' Returns the dataset_id
+        '''The current dataset_id.
 
         If the dataset_id is set, it is returned.
-        If it is unset, then the dataset_id of the last modified dataset is taken.
-
-        '''
+        If it is not set, then the dataset_id of the last modified dataset is selected.
+        ''' 
         try:
             return self._dataset_id
         except AttributeError:
@@ -127,6 +126,9 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin, _SamplingMixin, _UploadDatasetMi
 
     @property
     def filenames_on_server(self):
+        '''The list of the filenames in the dataset.
+
+        '''
         if not hasattr(self, "_filenames_on_server"):
             self._filenames_on_server = self.mappings_api. \
                 get_sample_mappings_by_dataset_id(dataset_id=self.dataset_id, field="fileName")

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -20,6 +20,15 @@ def _is_valid_filename(filename: str):
 class _UploadEmbeddingsMixin:
 
     def set_embedding_id_by_name(self, embedding_name: str = None):
+        """Sets the embedding id of the client by embedding name.
+
+        Args:
+            embedding_name:
+                Name under which the embedding was uploaded.
+    
+        Raises:
+            ValueError if the embedding does not exist.
+        """
         embeddings: List[DatasetEmbeddingData] = \
             self.embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
 
@@ -38,13 +47,13 @@ class _UploadEmbeddingsMixin:
         First checks that the specified embedding name is not on ther server. If it is, the upload is aborted.
         Then creates a new csv with the embeddings in the order specified on the server. Next it uploads it to the server.
         The received embedding_id is saved as a property of self.
-        Args:
-            path_to_embeddings_csv: the filepath to the .csv containing the embeddings, e.g. "path/to/embeddings.csv"
-            name: The name of the embedding. If an embedding with such a name already exists on the server,
-                the upload is aborted.
 
-        Returns:
-            None
+        Args:
+            path_to_embeddings_csv:
+                The path to the .csv containing the embeddings, e.g. "path/to/embeddings.csv"
+            name:
+                The name of the embedding. If an embedding with such a name already exists on the server,
+                the upload is aborted.
 
         """
         # get the names of the current embeddings on the server:


### PR DESCRIPTION
# Docs on embeddings upload

Closes #132. 

- Fixed the api workflow client docstrings and added them to the autodocs.
- Showcased how to save embeddings and upload them from Python code
- Showcased how to upload images from a Python