### PR TITLE
304 fix import api workflow client pw

### DIFF
--- a/docs/source/lightly.active_learning.rst
+++ b/docs/source/lightly.active_learning.rst
@@ -22,3 +22,9 @@ lightly.active_learning
 .. automodule:: lightly.active_learning.scorers.detection
    :members:
 
+.utils
+--------
+.. automodule:: lightly.active_learning.utils.bounding_box
+   :members:
+.. automodule:: lightly.active_learning.utils.object_detection_output
+   :members:

--- a/lightly/active_learning/utils/__init__.py
+++ b/lightly/active_learning/utils/__init__.py
@@ -1,0 +1,7 @@
+""" Collection of Utils for Active Learning """
+
+# Copyright (c) 2020. Lightly AG and its affiliates.
+# All Rights Reserved
+
+from lightly.active_learning.utils.bounding_box import BoundingBox
+from lightly.active_learning.utils.object_detection_output import ObjectDetectionOutput

--- a/lightly/api/__init__.py
+++ b/lightly/api/__init__.py
@@ -3,4 +3,5 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+from lightly.api.api_workflow_client import ApiWorkflowClient
 from lightly.api import routes

--- a/tests/imports/test_nested_imports.py
+++ b/tests/imports/test_nested_imports.py
@@ -7,17 +7,26 @@ import lightly
 class TestNestedImports(unittest.TestCase):
 
     def test_nested_imports(self):
-        # active learning (commented out don't work)
-        #lightly.active_learning.agents.agent.ActiveLearningAgent
-        #lightly.active_learning.agents.ActiveLearningAgent
+        # active learning
+        lightly.active_learning.agents.agent.ActiveLearningAgent
+        lightly.active_learning.agents.ActiveLearningAgent
         lightly.active_learning.config.sampler_config.SamplerConfig
-        #lightly.active_learning.scorers.classification.ScorerClassification
+        lightly.active_learning.config.SamplerConfig
+        lightly.active_learning.scorers.classification.ScorerClassification
+        lightly.active_learning.scorers.ScorerClassification
+        lightly.active_learning.scorers.detection.ScorerObjectDetection
+        lightly.active_learning.scorers.ScorerObjectDetection
+        lightly.active_learning.utils.bounding_box.BoundingBox
+        lightly.active_learning.utils.BoundingBox
+        lightly.active_learning.utils.object_detection_output.ObjectDetectionOutput
+        lightly.active_learning.utils.ObjectDetectionOutput
 
         # api imports
         lightly.api.routes.users.docker.get_authorization
         lightly.api.routes.users.docker.get_soft_authorization
         lightly.api.routes.users.docker.post_diagnostics
         lightly.api.api_workflow_client.ApiWorkflowClient
+        lightly.api.ApiWorkflowClient
         lightly.api.bitmask.BitMask
 
         # data imports

--- a/tests/imports/test_seminested_imports.py
+++ b/tests/imports/test_seminested_imports.py
@@ -9,10 +9,10 @@ class TestSemiNestedImports(unittest.TestCase):
     def test_seminested_imports(self):
         from lightly import active_learning
         # active learning (commented out don't work)
-        #lightly.active_learning.agents.agent.ActiveLearningAgent
-        #lightly.active_learning.agents.ActiveLearningAgent
-        active_learning.config.sampler_config.SamplerConfig
-        #lightly.active_learning.scorers.classification.ScorerClassification
+        active_learning.agents.ActiveLearningAgent
+        active_learning.config.SamplerConfig
+        active_learning.scorers.ScorerClassification
+        active_learning.scorers.ScorerObjectDetection
 
         # api imports
         from lightly import api


### PR DESCRIPTION
# 304 fix import api workflow client 

Closes #304.

Added the declaration of the `ApiWorkflowClient` to the `lightly.api.__init__` so that it can now be imported like this:
```python
from lightly.api import ApiWorkflowClient
```

I also exposed `BoundingBox` and `ObjectDetectionOutput` in `lightly.active_learning.utils.__init__`. The following now works:
```python
from lightly.active_learning.utils import BoundingBox
from lightly.active_learning.utils import ObjectDetectionOutput
```

Lastly, I added a few more import tests.