### PR TITLE
317 upload scores to query tag pw

### DIFF
--- a/docs/source/getting_started/active_learning.rst
+++ b/docs/source/getting_started/active_learning.rst
@@ -98,18 +98,18 @@ Let's configure the sampling request and request an initial selection next:
    from lightly.active_learning.config import SamplerConfig
    from lightly.openapi_generated.swagger_client import SamplingMethod
 
-   # we want an initial pool of 100 images
-   config = SamplerConfig(n_samples=100, method=SamplingMethod.CORESET, name='initial-selection')
-   initial_selection, added_set = al_agent.query(config)
+   # we want an initial pool of 150 images
+   config = SamplerConfig(n_samples=150, method=SamplingMethod.CORESET, name='initial-selection')
+   al_agent.query(config)
+   initial_selection = al_agent.labeled_set
    
-   # initial_selection contains now 100 filenames
-   assert len(initial_selection) == 100
-   assert len(added_set) == 100
+   # initial_selection now contains 150 filenames
+   assert len(initial_selection) == 150
 
-The query returns the list of filenames corresponding to the initial selection and the list of samples which
-were added to the selection. In the first iteration, the two lists are equal. Additionally, you
-will find that a tag has been created in the web-app under the name "initial-selection".
-Head there to scroll through the samples and download the selected images before annotating them.
+The result of the query is a tag in the web-app under the name "initial-selection". The tag contains
+the images which were selected by the sampling algorithm. Head there to scroll through the samples and
+download the selected images before annotating them. Alternatively, you can access the filenames
+of the selected images via the attribute `labeled_set` as shown above.
 
 
 Active Learning Step
@@ -161,16 +161,20 @@ here is that the argument `n_samples` always refers to the total size of the lab
 
 .. code-block:: Python
 
-   # we want a total of 200 images after the first iteration
+   # we want a total of 200 images after the first iteration (50 new samples)
    # this time, we use the CORAL sampler and provide a scorer to the query
    config = SamplerConfig(n_samples=200, method=SamplingMethod.CORAL, name='al-iteration-1')
-   labeled_set_iteration_1, added_set = al_agent.query(sampler_config, scorer)
+   al_agent.query(sampler_config, scorer)
+
+   labeled_set_iteration_1 = al_agent.labeled_set
+   added_set_iteration_1 = al_agent.added_set
 
    assert len(labeled_set_iteration_1) == 200
-   assert len(added_set) == 100
+   assert len(added_set_iteration_1) == 50
 
-As before, you will receive the filenames of all the images in the labeled set and the filenames
-of the newly added images. Additionally, there will be a new tag named `al-iteration-1` visible in the web-app.
+As before, there will be a new tag named `al-iteration-1` visible in the web-app. Additionally, 
+you can access the filenames of all the images in the labeled set and the filenames which were
+added by this query via the attributes `labeled_set` and `added_set` respectively.
 You can repeat the active learning step until the model achieves the required accuracy.
 
 Scorers

--- a/docs/source/getting_started/active_learning.rst
+++ b/docs/source/getting_started/active_learning.rst
@@ -71,7 +71,7 @@ dataset_id and token.
    # use trainer.max_epochs=0 to skip training
    lightly-magic input_dir='path/to/your/raw/dataset' dataset_id='xyz' token='123' trainer.max_epochs=0
 
-Next, you will need to initialize the `ApiWorkflowClient` and the `ActiveLearningAgent`
+Then, in your Python script, you will need to initialize the `ApiWorkflowClient` and the `ActiveLearningAgent`
 
 .. code-block:: Python
 
@@ -89,7 +89,7 @@ Next, you will need to initialize the `ApiWorkflowClient` and the `ActiveLearnin
    it could be that a large portion of the images is blurry. In that case, it's 
    possible to create a tag in the web-app which only contains the sharp images
    and tell the `ActiveLearningAgent` to only sample from this tag. To do so, set
-   the `query_tag_name` argument in the constructor.
+   the `query_tag_name` argument in the constructor of the agent.
 
 Let's configure the sampling request and request an initial selection next:
 
@@ -100,11 +100,14 @@ Let's configure the sampling request and request an initial selection next:
 
    # we want an initial pool of 100 images
    config = SamplerConfig(n_samples=100, method=SamplingMethod.CORESET, name='initial-selection')
-   initial_selection = al_agent.query(config)
+   initial_selection, added_set = al_agent.query(config)
    
    # initial_selection contains now 100 filenames
+   assert len(initial_selection) == 100
+   assert len(added_set) == 100
 
-The query returns the list of filenames corresponding to the initial selection. Additionally, you
+The query returns the list of filenames corresponding to the initial selection and the list of samples which
+were added to the selection. In the first iteration, the two lists are equal. Additionally, you
 will find that a tag has been created in the web-app under the name "initial-selection".
 Head there to scroll through the samples and download the selected images before annotating them.
 
@@ -113,8 +116,8 @@ Active Learning Step
 ----------------------
 
 After you have annotated your initial selection of images, you can train a model
-on them. The trained model can then be used to figure out, with which images it 
-has problems. These images can then be added to the labeled dataset.
+on them. The trained model can then be used to figure out which images pose problems.
+This section will show you how these images can be added to the labeled dataset.
 
 To continue with active learning with Lightly, you will need the `ApiWorkflowClient` and `ActiveLearningAgent` from before.
 If you perform the next selection step in a new file you have to initialize the client and agent again.
@@ -130,23 +133,22 @@ have to re-initialize them, the tracking of the tags is taken care of for you.
    al_agent = ActiveLearningAgent(api_client, preselected_tag_name='initial-selection')
 
 The next part is what differentiates active learning from simple subsampling; the
-trained model is used to get predictions on the unlabeled data and the sampler then
-decides based on these predictions. To get a list of all filenames in the unlabeled set,
-you can simply call
+trained model is used to get predictions on the data and the sampler then
+decides based on these predictions. To get a list of all filenames for which 
+predictions are required, you can use the `query_set`:
 
 .. code-block:: Python
 
-   # get all filenames in the unlabeled set
-   unlabeled_set = al_agent.unlabeled_set
+   # get all filenames in the query set
+   query_set = al_agent.query_set
 
 Use this list to get predictions on the unlabeled images.
 
 **Important:** The predictions need to be in the same order as the filenames in the
-list returned by the `ActiveLearningAgent` and they need to be stored in a numpy array.
+list returned by the `ActiveLearningAgent`.
 
-Once you have the scores in the right order, make sure to normalize them such that
-the rows sum to one. Then, create a scorer object like so:
-
+For classification, the predictions need to be in a numpy array and normalized,
+such that the rows sum to one. Then, create a scorer object like so:
 
 .. code-block:: Python
 
@@ -162,13 +164,14 @@ here is that the argument `n_samples` always refers to the total size of the lab
    # we want a total of 200 images after the first iteration
    # this time, we use the CORAL sampler and provide a scorer to the query
    config = SamplerConfig(n_samples=200, method=SamplingMethod.CORAL, name='al-iteration-1')
-   labeled_set_iteration_1 = al_agent.query(sampler_config, scorer)
+   labeled_set_iteration_1, added_set = al_agent.query(sampler_config, scorer)
 
    assert len(labeled_set_iteration_1) == 200
+   assert len(added_set) == 100
 
-As before, you will receive the filenames of all the images in the labeled set and there
-will be a new tag named `al-iteration-1` visible in the web-app. You can repeat the active
-learning step until the model achieves the required accuracy.
+As before, you will receive the filenames of all the images in the labeled set and the filenames
+of the newly added images. Additionally, there will be a new tag named `al-iteration-1` visible in the web-app.
+You can repeat the active learning step until the model achieves the required accuracy.
 
 Scorers
 -----------------

--- a/docs/source/tutorials_source/platform/tutorial_active_learning.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning.py
@@ -188,9 +188,9 @@ labeled_set_labels = dataset.get_labels(agent.labeled_set)
 classifier.fit(X=labeled_set_features, y=labeled_set_labels)
 
 # %%
-# 3. Use the classifier to predict on the unlabeled set.
-unlabeled_set_features = dataset.get_features(agent.unlabeled_set)
-predictions = classifier.predict_proba(X=unlabeled_set_features)
+# 3. Use the classifier to predict on the query set.
+query_set_features = dataset.get_features(agent.query_set)
+predictions = classifier.predict_proba(X=query_set_features)
 
 # %%
 # 4. Calculate active learning scores from the prediction.

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -38,7 +38,8 @@ class ActiveLearningAgent:
         >>>
         >>> # make an initial active learning query
         >>> sampler_config = SamplerConfig(n_samples=100, name='initial-set')
-        >>> initial_set, _ = agent.query(sampler_config)
+        >>> agent.query(sampler_config)
+        >>> initial_set = agent.labeled_set
         >>>
         >>> # train and evaluate a model on the initial set
         >>> # make predictions on the query set:
@@ -51,7 +52,8 @@ class ActiveLearningAgent:
         >>>
         >>> # make a second active learning query
         >>> sampler_config = SamplerConfig(n_samples=200, name='second-set')
-        >>> second_set, added_set = agent.query(sampler_config, scorer)
+        >>> agent.query(sampler_config, scorer)
+        >>> added_set = agent.added_set # access only the samples added by this query
 
     """
 
@@ -181,12 +183,6 @@ class ActiveLearningAgent:
             al_scorer:
                 An instance of a class inheriting from Scorer, e.g. a ClassificationScorer.
 
-        Returns:
-            The filenames of the samples in the new labeled_set
-            and the filenames of the samples chosen by the sampler.
-            This added_set was added to the old labeled_set
-            to form the new labeled_set.
-
         """
 
         # handle illogical stopping condition
@@ -194,9 +190,9 @@ class ActiveLearningAgent:
             warnings.warn(
                 f'ActiveLearningAgent.query: The number of samples ({sampler_config.n_samples}) is '
                 f'smaller than the number of preselected samples ({len(self.labeled_set)}).'
-                'Skipping the active learning query and returning the previous labeled set.'
+                'Skipping the active learning query.'
             )
-            return self.labeled_set, []
+            return
 
         # calculate active learning scores
         scores_dict = None
@@ -223,5 +219,3 @@ class ActiveLearningAgent:
         # set the newly chosen tag as the new preselected_tag
         self._preselected_tag_id = new_tag_data.id
         self._preselected_tag_bitmask = self._get_preselected_tag_bitmask()
-
-        return self.labeled_set, self.added_set

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -14,16 +14,10 @@ class ActiveLearningAgent:
     Attributes:
         api_workflow_client:
             The client to connect to the api.
-        preselected_tag_id:
-            The id of the tag containing the already labeled samples, default: None == no labeled samples yet.
-        query_tag_id:
-            The id of the tag defining where to sample from, default: None resolves to initial_tag
-        labeled_set:
-            The filenames of the samples in the labeled set, List[str]
-        unlabeled_set:
-            The filenames of the samples in the unlabeled set, List[str]
+        TODO
 
     Examples:
+        TODO: rework
         >>> # set the token and dataset id
         >>> token = '123'
         >>> dataset_id = 'XYZ'
@@ -49,63 +43,123 @@ class ActiveLearningAgent:
 
     """
 
-    def __init__(self, api_workflow_client: ApiWorkflowClient, query_tag_name: str = None,
+    def __init__(self,
+                 api_workflow_client: ApiWorkflowClient,
+                 query_tag_name: str = None,
                  preselected_tag_name: str = None):
 
         self.api_workflow_client = api_workflow_client
+
+        # set the query_tag_id and preselected_tag_id
+        self._query_tag_id = None
+        self._preselected_tag_id = None
         if query_tag_name is not None or preselected_tag_name is not None:
-            tag_name_id_dict = dict([tag.name, tag.id] for tag in self.api_workflow_client._get_all_tags())
-            if preselected_tag_name is not None:
-                self.preselected_tag_id = tag_name_id_dict[preselected_tag_name]
+            # build lookup table for tag_name to tag_id
+            tag_name_id_dict = {}
+            for tag in self.api_workflow_client._get_all_tags():
+                tag_name_id_dict[tag.name] = tag.id
+            # use lookup table to set ids
             if query_tag_name is not None:
-                self.query_tag_id = tag_name_id_dict[query_tag_name]
+                self._query_tag_id = tag_name_id_dict[query_tag_name]
+            if preselected_tag_name is not None:
+                self._preselected_tag_id = tag_name_id_dict[preselected_tag_name]
 
-        if not hasattr(self, "preselected_tag_id"):
-            self.preselected_tag_id = None
-        if not hasattr(self, "query_tag_id"):
-            self.query_tag_id = None
-        self._set_labeled_and_unlabeled_set()
+        # set the filename lists based on preselected and query tag
+        self._query_tag_bitmask = self._get_query_tag_bitmask()
+        self._preselected_tag_bitmask = self._get_preselected_tag_bitmask()
+        # keep track of the last preselected tag to compute added samples
+        self._old_preselected_tag_bitmask = None
 
-    def _set_labeled_and_unlabeled_set(self, preselected_tag_data: TagData = None):
-        """Sets the labeled and unlabeled set based on the preselected and query tag id
 
-        It loads the bitmaks for the both tag_ids from the server and then
-        extracts the filenames from it given the mapping on the server.
-
-        Args:
-            preselected_tag_data:
-                optional param, then it must not be loaded from the API
+    def _get_query_tag_bitmask(self):
+        """Initializes the query tag bitmask.
 
         """
-
-        if not hasattr(self, "bitmask_labeled_set"):
-            self.bitmask_labeled_set = BitMask.from_hex("0x0")  # empty labeled set
-            self.bitmask_added_set = BitMask.from_hex("0x0")  # empty added set
-        if self.preselected_tag_id is not None:  # else the default values (empty labeled and added set) are kept
-            if preselected_tag_data is None:  # if it is not passed as argument, it must be loaded from the API
-                preselected_tag_data = self.api_workflow_client.tags_api.get_tag_by_tag_id(
-                    self.api_workflow_client.dataset_id, tag_id=self.preselected_tag_id)
-            new_bitmask_labeled_set = BitMask.from_hex(preselected_tag_data.bit_mask_data)
-            self.bitmask_added_set = new_bitmask_labeled_set - self.bitmask_labeled_set
-            self.bitmask_labeled_set = new_bitmask_labeled_set
-
-        if self.query_tag_id is None:
-            bitmask_query_tag = BitMask.from_length(len(self.api_workflow_client.filenames_on_server))
+        if self._query_tag_id is None:
+            # if not specified, all samples belong to the query tag
+            query_tag_bitmask = BitMask.from_length(
+                len(self.api_workflow_client.filenames_on_server)
+            )
         else:
+            # get query tag from api and set bitmask accordingly
             query_tag_data = self.api_workflow_client.tags_api.get_tag_by_tag_id(
-                self.api_workflow_client.dataset_id, tag_id=self.query_tag_id)
-            bitmask_query_tag = BitMask.from_hex(query_tag_data.bit_mask_data)
-        self.bitmask_unlabeled_set = bitmask_query_tag - self.bitmask_labeled_set
+                self.api_workflow_client.dataset_id,
+                tag_id=self._query_tag_id
+            )
+            query_tag_bitmask = BitMask.from_hex(query_tag_data.bit_mask_data)
 
-        self.labeled_set = self.bitmask_labeled_set.masked_select_from_list(self.api_workflow_client.filenames_on_server)
-        self.added_set = self.bitmask_added_set.masked_select_from_list(self.api_workflow_client.filenames_on_server)
-        self.unlabeled_set = self.bitmask_unlabeled_set.masked_select_from_list(self.api_workflow_client.filenames_on_server)
+        return query_tag_bitmask
 
-    def query(self, sampler_config: SamplerConfig, al_scorer: Scorer = None) -> Tuple[List[str], List[str]]:
+    def _get_preselected_tag_bitmask(self):
+        """Initializes the preselected tag bitmask.
+
+        """
+        if self._preselected_tag_id is None:
+            # if not specified, no samples belong to the preselected tag
+            preselected_tag_bitmask = BitMask.from_hex('0x0')
+        else:
+            # get preselected tag from api and set bitmask accordingly
+            preselected_tag_data = self.api_workflow_client.tags_api.get_tag_by_tag_id(
+                self.api_workflow_client.dataset_id,
+                tag_id=self._preselected_tag_id
+            )
+            preselected_tag_bitmask = BitMask.from_hex(preselected_tag_data.bit_mask_data)
+
+        return preselected_tag_bitmask
+
+    @property
+    def query_set(self):
+        """List of filenames for which to calculate active learning scores.
+
+        """
+        return self._query_tag_bitmask.masked_select_from_list(
+            self.api_workflow_client.filenames_on_server
+        )
+
+    @property
+    def labeled_set(self):
+        """List of filenames indicating selected samples.
+
+        """
+        return self._preselected_tag_bitmask.masked_select_from_list(
+            self.api_workflow_client.filenames_on_server
+        )
+
+    @property
+    def unlabeled_set(self):
+        """List of filenames which belong to the query set but are not selected.
+
+        """
+        # unlabeled set is the query set minus the preselected set
+        unlabeled_tag_bitmask = self._query_tag_bitmask - self._preselected_tag_bitmask
+        return unlabeled_tag_bitmask.masked_select_from_list(
+            self.api_workflow_client.filenames_on_server
+        )
+
+    @property
+    def added_set(self):
+        """List of filenames of newly added samples (in the last query).
+
+        Raises:
+            RuntimeError if executed before a query.
+
+        """
+        # the added set only exists after a query
+        if self._old_preselected_tag_bitmask is None:
+            raise RuntimeError('Cannot compute \"added set\" before querying.')
+        # added set is new preselected set minus the old one
+        added_tag_bitmask = self._preselected_tag_bitmask - self._old_preselected_tag_bitmask
+        return added_tag_bitmask.masked_select_from_list(
+            self.api_workflow_client.filenames_on_server
+        )
+
+
+    def query(self,
+              sampler_config: SamplerConfig,
+              al_scorer: Scorer = None) -> Tuple[List[str], List[str]]:
         """Performs an active learning query.
 
-        As part of it, the self.labeled_set and self.unlabeled_set are updated
-        and can be used for the next step.
+        TODO: what happens here?
 
         Args:
             sampler_config:
@@ -120,36 +174,40 @@ class ActiveLearningAgent:
             to form the new labeled_set.
 
         """
-        # check input
+
+        # handle illogical stopping condition
         if sampler_config.n_samples < len(self.labeled_set):
-            warnings.warn("ActiveLearningAgent.query: The number of samples which should be sampled "
-                          "including the current labeled set "
-                          "(sampler_config.n_samples) "
-                          "is smaller than the number of samples in the current labeled set."
-                          "Skipping the sampling and returning the previous labeled set.")
+            warnings.warn(
+                f'ActiveLearningAgent.query: The number of samples ({sampler_config.n_samples}) is '
+                f'smaller than the number of preselected samples ({len(self.labeled_set)}).'
+                'Skipping the active learning query and returning the previous labeled set.'
+            )
             return self.labeled_set, []
 
-        # calculate scores
+        # calculate active learning scores
+        scores_dict = None
         if al_scorer is not None:
-            no_unlabeled_samples = len(self.unlabeled_set)
-            no_samples_with_predictions = len(al_scorer.model_output)
-            if no_unlabeled_samples != no_samples_with_predictions:
-                raise ValueError(f"The scorer must have exactly as many samples as in the unlabeled set,"
-                                 f"but there are {no_samples_with_predictions} predictions in the scorer,"
-                                 f"but {no_unlabeled_samples} in the unlabeled set.")
+            no_query_samples = len(self.query_set)
+            no_query_samples_with_scores = len(al_scorer.model_output)
+            if no_query_samples != no_query_samples_with_scores:
+                raise ValueError(
+                    f'Number of query samples ({no_query_samples}) must match '
+                    f'the number of predictions ({no_query_samples_with_scores})!'
+                )
             scores_dict = al_scorer.calculate_scores()
-        else:
-            scores_dict = None
 
         # perform the sampling
         new_tag_data = self.api_workflow_client.sampling(
             sampler_config=sampler_config,
             al_scores=scores_dict,
-            preselected_tag_id=self.preselected_tag_id,
-            query_tag_id=self.query_tag_id)
+            preselected_tag_id=self._preselected_tag_id,
+            query_tag_id=self._query_tag_id
+        )
 
-        # set the newly chosen tag as the new preselected_tag_id and update the sets
-        self.preselected_tag_id = new_tag_data.id
-        self._set_labeled_and_unlabeled_set(new_tag_data)
+        # update the old preselected_tag
+        self._old_preselected_tag_bitmask = self._preselected_tag_bitmask
+        # set the newly chosen tag as the new preselected_tag
+        self._preselected_tag_id = new_tag_data.id
+        self._preselected_tag_bitmask = self._get_preselected_tag_bitmask()
 
         return self.labeled_set, self.added_set

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -59,7 +59,7 @@ class ActiveLearningAgent:
 
     def __init__(self,
                  api_workflow_client: ApiWorkflowClient,
-                 query_tag_name: str = None,
+                 query_tag_name: str = 'initial-tag',
                  preselected_tag_name: str = None):
 
         self.api_workflow_client = api_workflow_client
@@ -67,16 +67,15 @@ class ActiveLearningAgent:
         # set the query_tag_id and preselected_tag_id
         self._query_tag_id = None
         self._preselected_tag_id = None
-        if query_tag_name is not None or preselected_tag_name is not None:
-            # build lookup table for tag_name to tag_id
-            tag_name_id_dict = {}
-            for tag in self.api_workflow_client._get_all_tags():
-                tag_name_id_dict[tag.name] = tag.id
-            # use lookup table to set ids
-            if query_tag_name is not None:
-                self._query_tag_id = tag_name_id_dict[query_tag_name]
-            if preselected_tag_name is not None:
-                self._preselected_tag_id = tag_name_id_dict[preselected_tag_name]
+
+        # build lookup table for tag_name to tag_id
+        tag_name_id_dict = {}
+        for tag in self.api_workflow_client._get_all_tags():
+            tag_name_id_dict[tag.name] = tag.id
+        # use lookup table to set ids
+        self._query_tag_id = tag_name_id_dict[query_tag_name]
+        if preselected_tag_name is not None:
+            self._preselected_tag_id = tag_name_id_dict[preselected_tag_name]
 
         # set the filename lists based on preselected and query tag
         self._query_tag_bitmask = self._get_query_tag_bitmask()
@@ -89,18 +88,12 @@ class ActiveLearningAgent:
         """Initializes the query tag bitmask.
 
         """
-        if self._query_tag_id is None:
-            # if not specified, all samples belong to the query tag
-            query_tag_bitmask = BitMask.from_length(
-                len(self.api_workflow_client.filenames_on_server)
-            )
-        else:
-            # get query tag from api and set bitmask accordingly
-            query_tag_data = self.api_workflow_client.tags_api.get_tag_by_tag_id(
-                self.api_workflow_client.dataset_id,
-                tag_id=self._query_tag_id
-            )
-            query_tag_bitmask = BitMask.from_hex(query_tag_data.bit_mask_data)
+        # get query tag from api and set bitmask accordingly
+        query_tag_data = self.api_workflow_client.tags_api.get_tag_by_tag_id(
+            self.api_workflow_client.dataset_id,
+            tag_id=self._query_tag_id
+        )
+        query_tag_bitmask = BitMask.from_hex(query_tag_data.bit_mask_data)
 
         return query_tag_bitmask
 

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -14,10 +14,20 @@ class ActiveLearningAgent:
     Attributes:
         api_workflow_client:
             The client to connect to the api.
-        TODO
+        query_set:
+            Set of filenames corresponding to samples which can possibly be selected.
+            Set to all samples in the query tag or to the whole dataset by default.
+        labeled_set:
+            Set of filenames corresponding to samples in the labeled set.
+            Set to all samples in the preselected tag or to an empty list by default.
+        unlabeled_set:
+            Set of filenames corresponding to samples which are in the query set
+            but not in the labeled set.
+        added_set:
+            Set of filenames corresponding to samples which were added to the 
+            labeled set in the last query.
 
     Examples:
-        TODO: rework
         >>> # set the token and dataset id
         >>> token = '123'
         >>> dataset_id = 'XYZ'
@@ -28,18 +38,20 @@ class ActiveLearningAgent:
         >>>
         >>> # make an initial active learning query
         >>> sampler_config = SamplerConfig(n_samples=100, name='initial-set')
-        >>> initial_set = agent.query(sampler_config)
-        >>> unlabeled_set = agent.unlabeled_set
+        >>> initial_set, _ = agent.query(sampler_config)
         >>>
         >>> # train and evaluate a model on the initial set
-        >>> # make predictions on the unlabeled set (keep ordering of filenames)
+        >>> # make predictions on the query set:
+        >>> query_set = agent.query_set
+        >>> # important:
+        >>> # be sure to keep the order of the query set when you make predictions
         >>>
         >>> # create active learning scorer
         >>> scorer = ScorerClassification(predictions)
         >>>
         >>> # make a second active learning query
         >>> sampler_config = SamplerConfig(n_samples=200, name='second-set')
-        >>> second_set = agent.query(sampler_config, scorer)
+        >>> second_set, added_set = agent.query(sampler_config, scorer)
 
     """
 
@@ -159,7 +171,9 @@ class ActiveLearningAgent:
               al_scorer: Scorer = None) -> Tuple[List[str], List[str]]:
         """Performs an active learning query.
 
-        TODO: what happens here?
+        After the query, the labeled set is updated to contain all selected samples,
+        the added set is recalculated as (new labeled set - old labeled set), and
+        the query set stays the same.
 
         Args:
             sampler_config:

--- a/tests/UNMOCKED_end2end_tests/test_api.py
+++ b/tests/UNMOCKED_end2end_tests/test_api.py
@@ -100,7 +100,7 @@ def create_new_dataset_with_embeddings(path_to_dataset: str,
 
 def t_est_active_learning(api_workflow_client: ApiWorkflowClient,
                           method: SamplingMethod = SamplingMethod.CORAL,
-                          query_tag_name: str = None,
+                          query_tag_name: str = 'initial-tag',
                           preselected_tag_name: str = None,
                           n_samples_additional: List[int] = [2, 5]):
     # create the tags with 100 respectively 10 samples if not yet existant
@@ -164,7 +164,7 @@ def t_est_api_with_matrix(path_to_dataset: str,
     )
 
     for method in [SamplingMethod.CORAL, SamplingMethod.CORESET, SamplingMethod.RANDOM]:
-        for query_tag_name in [None, "query_tag_name_xyz"]:
+        for query_tag_name in ['initial-tag', "query_tag_name_xyz"]:
             for preselected_tag_name in [None, "preselected_tag_name_xyz"]:
                 print(f"Starting AL run with method '{method}', query_tag '{query_tag_name}' "
                       f"and preselected_tag '{preselected_tag_name}'.")

--- a/tests/UNMOCKED_end2end_tests/test_api.py
+++ b/tests/UNMOCKED_end2end_tests/test_api.py
@@ -142,7 +142,7 @@ def t_est_active_learning(api_workflow_client: ApiWorkflowClient,
         assert len(agent.unlabeled_set) == total_no_samples - n_samples
 
         # Update the scorer
-        n_samples = len(agent.unlabeled_set)
+        n_samples = len(agent.query_set)
         n_classes = 10
         predictions = np.random.rand(n_samples, n_classes)
         predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]

--- a/tests/active_learning/test_active_learning_agent.py
+++ b/tests/active_learning/test_active_learning_agent.py
@@ -30,7 +30,7 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
                         sampler_config = SamplerConfig(n_samples=n_samples, method=method)
 
                     if sampler_config.method == SamplingMethod.CORAL:
-                        predictions = np.random.rand(len(agent.unlabeled_set), 10).astype(np.float32)
+                        predictions = np.random.rand(len(agent.query_set), 10).astype(np.float32)
                         predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]
                         al_scorer = ScorerClassification(predictions_normalized)
                         labeled_set, added_set = agent.query(sampler_config=sampler_config, al_scorer=al_scorer)
@@ -39,22 +39,54 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
                         labeled_set, added_set = agent.query(sampler_config=sampler_config)
 
                     self.assertEqual(n_old_labeled + len(added_set), len(labeled_set))
-                    assert set(added_set).issubset(labeled_set)
+                    self.assertTrue(set(added_set).issubset(labeled_set))
                     self.assertEqual(len(list(set(agent.labeled_set) & set(agent.unlabeled_set))), 0)
                     self.assertEqual(n_old_unlabeled - len(added_set), len(agent.unlabeled_set))
 
-    def test_agent_wrong_scores(self):
+    def test_agent_wrong_number_of_scores(self):
         self.api_workflow_client.embedding_id = "embedding_id_xyz"
 
         agent = ActiveLearningAgent(self.api_workflow_client, preselected_tag_name="preselected_tag_name_xyz")
         method = SamplingMethod.CORAL
         n_samples = len(agent.labeled_set) + 2
 
-        n_predictions = len(agent.unlabeled_set) - 3  # the -3 should cause en error
+        n_predictions = len(agent.query_set) - 3 # the -3 should cause en error
         predictions = np.random.rand(n_predictions, 10).astype(np.float32)
         predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]
         al_scorer = ScorerClassification(predictions_normalized)
 
         sampler_config = SamplerConfig(n_samples=n_samples, method=method)
         with self.assertRaises(ValueError):
-            labeled_set, added_set = agent.query(sampler_config=sampler_config, al_scorer=al_scorer)
+            agent.query(sampler_config=sampler_config, al_scorer=al_scorer)
+
+    def test_agent_added_set_before_query(self):
+
+        self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        agent = ActiveLearningAgent(
+            self.api_workflow_client,
+            preselected_tag_name="preselected_tag_name_xyz"
+        )
+
+        agent.query_set
+        agent.labeled_set
+        agent.unlabeled_set
+        with self.assertRaises(RuntimeError):
+            agent.added_set
+
+    def test_agent_query_too_few(self):
+
+        self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        agent = ActiveLearningAgent(
+            self.api_workflow_client,
+            preselected_tag_name="preselected_tag_name_xyz",
+        )
+
+        # sample 0 samples
+        sampler_config = SamplerConfig(
+            n_samples=0,
+            method=SamplingMethod.RANDOM
+        )
+
+        labeled, added = agent.query(sampler_config)
+
+        self.assertListEqual(added, [])

--- a/tests/active_learning/test_active_learning_agent.py
+++ b/tests/active_learning/test_active_learning_agent.py
@@ -33,10 +33,12 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
                         predictions = np.random.rand(len(agent.query_set), 10).astype(np.float32)
                         predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]
                         al_scorer = ScorerClassification(predictions_normalized)
-                        labeled_set, added_set = agent.query(sampler_config=sampler_config, al_scorer=al_scorer)
+                        agent.query(sampler_config=sampler_config, al_scorer=al_scorer)
                     else:
                         sampler_config = SamplerConfig(n_samples=n_samples)
-                        labeled_set, added_set = agent.query(sampler_config=sampler_config)
+                        agent.query(sampler_config=sampler_config)
+                    
+                    labeled_set, added_set = agent.labeled_set, agent.added_set
 
                     self.assertEqual(n_old_labeled + len(added_set), len(labeled_set))
                     self.assertTrue(set(added_set).issubset(labeled_set))
@@ -87,6 +89,4 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
             method=SamplingMethod.RANDOM
         )
 
-        labeled, added = agent.query(sampler_config)
-
-        self.assertListEqual(added, [])
+        agent.query(sampler_config)


### PR DESCRIPTION
# 317 uploade scores to query tag

Closes #317.

- exposed `labeled_set`, `unlabeled_set`, `query_set`, and `added_set` to user
- refactored the active learning agent
- upload active learning scores to query tag instead of preselected tag
- updated the docstrings and comments
- updated the documentation and tutorial
- updated the tests

The unmocked tests and the active learning tutorial run through on `api-dev` 
@ `commit 57bb1660402d54b953f05a3bf3562bf301ed63f6 ` 