### PR TITLE
Reduce min tqdm version and trigger github tests for pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -1,5 +1,5 @@
 name: check setup.py
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -1,5 +1,5 @@
 name: check setup.py
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ numpy>=1.18.1
 pytorch_lightning>=1.0.4
 requests>=2.23.0
 torchvision
-tqdm>=4.44
+tqdm>=4.41
 certifi >= 14.05.14
 six >= 1.10
 python_dateutil >= 2.5.3


### PR DESCRIPTION
### Changes

closes #327 

- decrease minimum required tqdm version from 4.44 to 4.41 (4.41 seems to be the default on some systems and lightly just runs fine with it)
- make sure we trigger the github actions (tests) for pull requests too. This makes sure external contributors creating a pull request trigger the tests