### PR TITLE
use ActiveLearningScoreType from api-specs without enum

### DIFF
--- a/lightly/active_learning/scorers/detection.py
+++ b/lightly/active_learning/scorers/detection.py
@@ -262,7 +262,7 @@ class ScorerObjectDetection(Scorer):
         scores_dict_classification = \
             _reduce_classification_scores_over_boxes(model_output=self.model_output)
         for score_name, score in scores_dict_classification.items():
-            scores[f"classification_{score_name}"] = score
+            scores[score_name] = score
 
         return scores
 

--- a/lightly/openapi_generated/swagger_client/models/active_learning_score_type.py
+++ b/lightly/openapi_generated/swagger_client/models/active_learning_score_type.py
@@ -26,14 +26,6 @@ class ActiveLearningScoreType(object):
     """
 
     """
-    allowed enum values
-    """
-    PREDICTION_ENTROPY = "prediction-entropy"
-    PREDICTION_MARGIN = "prediction-margin"
-    OBJECT_FREQUENCY = "object-frequency"
-    BALD = "BALD"
-
-    """
     Attributes:
       swagger_types (dict): The key is attribute name
                             and the value is attribute type.

--- a/lightly/openapi_generated/swagger_client/models/dimensionality_reduction_method.py
+++ b/lightly/openapi_generated/swagger_client/models/dimensionality_reduction_method.py
@@ -29,8 +29,8 @@ class DimensionalityReductionMethod(object):
     allowed enum values
     """
     PCA = "PCA"
-    UMAP = "UMAP"
     TSNE = "TSNE"
+    UMAP = "UMAP"
 
     """
     Attributes:


### PR DESCRIPTION
close #333

## Description
- Generated new code from the updated openapi specs in https://github.com/lightly-ai/lightly-core/issues/505
This will change the ActiveLearningScoreType to be a string instead of an enum. 
- Renamed the `classification_uncertainty_...` score names by removing the `classification_` prefix