### PR TITLE
ScorerClassification has better handling of weird model_output + tests

### DIFF
--- a/lightly/active_learning/scorers/classification.py
+++ b/lightly/active_learning/scorers/classification.py
@@ -102,10 +102,12 @@ class ScorerClassification(Scorer):
         super(ScorerClassification, self).__init__(model_output)
 
     def ensure_model_output_is_correct(self, model_output: np.ndarray):
+        if len(model_output) == 0:
+            return
         if len(model_output.shape) != 2:
             raise ValueError("ScorerClassification model_output must be a 2-dimensional array")
-        if model_output.shape[0] == 0 or model_output.shape[1] == 0:
-            raise ValueError("ScorerClassification model_output must not have empty dimensions")
+        if model_output.shape[1] == 0:
+            raise ValueError("ScorerClassification model_output must not have an empty dimension 1")
         if model_output.shape[1] == 1:
             warnings.warn("Trying to use the ScorerClassification on a prediction vector"
                           "with only a single class. This does not make sense.")

--- a/tests/active_learning/test_ScorerClassification.py
+++ b/tests/active_learning/test_ScorerClassification.py
@@ -38,6 +38,22 @@ class TestScorerClassification(unittest.TestCase):
         for val1, val2 in zip(scores["uncertainty_entropy"], _entropy(model_output) / np.log2(3)):
             self.assertAlmostEqual(val1, val2, places=8)
 
+    def test_score_calculation_binary(self):
+        model_output = [
+            [0.7],
+            [0.4]
+        ]
+        model_output = np.array(model_output)
+        scorer = ScorerClassification(model_output)
+        scores = scorer.calculate_scores()
+
+        self.assertListEqual(list(scores["uncertainty_least_confidence"]),
+                             [(1 - 0.7) / (1 - 1. / 2.), (1 - 0.6) / (1 - 1. / 2.)])
+        self.assertListEqual(list(scores["uncertainty_margin"]), [1 - (0.7 - 0.3), 1 - (0.6 - 0.4)])
+        model_output = np.concatenate([model_output, 1-model_output], axis=1)
+        for val1, val2 in zip(scores["uncertainty_entropy"], _entropy(model_output) / np.log2(2)):
+            self.assertAlmostEqual(val1, val2, places=8)
+
     def test_scorer_classification_empty_model_output(self):
         scorer = ScorerClassification(model_output=[])
         scores = scorer.calculate_scores()

--- a/tests/active_learning/test_ScorerClassification.py
+++ b/tests/active_learning/test_ScorerClassification.py
@@ -25,49 +25,54 @@ class TestScorerClassification(unittest.TestCase):
 
     def test_score_calculation_specific(self):
         model_output = [
-                    [0.7, 0.2, 0.1],
-                    [0.4, 0.5, 0.1]
-                ]
+            [0.7, 0.2, 0.1],
+            [0.4, 0.5, 0.1]
+        ]
         model_output = np.array(model_output)
         scorer = ScorerClassification(model_output)
         scores = scorer.calculate_scores()
 
-        self.assertListEqual(list(scores["uncertainty_least_confidence"]), [(1 - 0.7) / (1 - 1./3.), (1 - 0.5) / (1 - 1./3.)])
+        self.assertListEqual(list(scores["uncertainty_least_confidence"]),
+                             [(1 - 0.7) / (1 - 1. / 3.), (1 - 0.5) / (1 - 1. / 3.)])
         self.assertListEqual(list(scores["uncertainty_margin"]), [1 - (0.7 - 0.2), 1 - (0.5 - 0.4)])
-        for val1, val2 in zip(scores["uncertainty_entropy"], _entropy(model_output)/np.log2(3)):
-            self.assertAlmostEqual(val1, val2,places=8)
+        for val1, val2 in zip(scores["uncertainty_entropy"], _entropy(model_output) / np.log2(3)):
+            self.assertAlmostEqual(val1, val2, places=8)
 
+    def test_scorer_classification_empty_model_output(self):
+        scorer = ScorerClassification(model_output=[])
+        scores = scorer.calculate_scores()
+        self.assertEqual(set(scores.keys()), set(ScorerClassification.score_names()))
 
-    def test_scorer_classification_variable_model_output(self):
+    def test_scorer_classification_variable_model_output_dimension(self):
 
         for num_samples in range(5):
             for num_classes in range(5):
 
-                if num_samples > 0:
-                    preds = [1./num_samples] * num_classes
-                else:
-                    preds = []
-                model_output = [preds] * num_samples
+                with self.subTest(msg=f"model_output.shape = ({num_samples},{num_classes})"):
+                    if num_samples > 0:
+                        preds = [1. / num_samples] * num_classes
+                    else:
+                        preds = []
+                    model_output = [preds] * num_samples
 
-                if num_samples == 0 or num_classes == 0:
-                    with self.assertRaises(ValueError):
+                    if num_classes == 0 and num_samples > 0:
+                        with self.assertRaises(ValueError):
+                            scorer = ScorerClassification(model_output=model_output)
+                    else:
                         scorer = ScorerClassification(model_output=model_output)
-                else:
+                        scores = scorer.calculate_scores()
+                        self.assertEqual(set(scores.keys()), set(ScorerClassification.score_names()))
+                        for score_values in scores.values():
+                            self.assertEqual(len(score_values), len(model_output))
+
+    def test_scorer_classification_variable_model_output_tensor_order(self):
+
+        for tensor_order in range(1, 5):
+            model_output = np.ndarray((3,) * tensor_order)
+            with self.subTest(msg=f"model_output.shape = {model_output.shape}"):
+                if tensor_order == 2 or tensor_order == 0:
                     scorer = ScorerClassification(model_output=model_output)
                     scores = scorer.calculate_scores()
-                    self.assertEqual(set(scores.keys()), set(ScorerClassification.score_names()))
-                    for score_values in scores.values():
-                        self.assertEqual(len(score_values), len(model_output))
-
-    def test_scorer_classification_wrong_model_output_tensor_order(self):
-
-        for tensor_order in range(5):
-            model_output = np.ndarray((3,)*tensor_order)
-            if tensor_order != 2:
-                with self.assertRaises(ValueError):
-                    scorer = ScorerClassification(model_output=model_output)
-            else:
-                scorer = ScorerClassification(model_output=model_output)
-                scores = scorer.calculate_scores()
-
-
+                else:
+                    with self.assertRaises(ValueError):
+                        scorer = ScorerClassification(model_output=model_output)

--- a/tests/active_learning/test_ScorerClassification.py
+++ b/tests/active_learning/test_ScorerClassification.py
@@ -38,9 +38,36 @@ class TestScorerClassification(unittest.TestCase):
             self.assertAlmostEqual(val1, val2,places=8)
 
 
-    def test_scorer_classification_empty_model_output(self):
-        scorer = ScorerClassification(model_output=[])
-        scores = scorer.calculate_scores()
-        self.assertEqual(set(scores.keys()), set(ScorerClassification.score_names()))
+    def test_scorer_classification_variable_model_output(self):
+
+        for num_samples in range(5):
+            for num_classes in range(5):
+
+                if num_samples > 0:
+                    preds = [1./num_samples] * num_classes
+                else:
+                    preds = []
+                model_output = [preds] * num_samples
+
+                if num_samples == 0 or num_classes == 0:
+                    with self.assertRaises(ValueError):
+                        scorer = ScorerClassification(model_output=model_output)
+                else:
+                    scorer = ScorerClassification(model_output=model_output)
+                    scores = scorer.calculate_scores()
+                    self.assertEqual(set(scores.keys()), set(ScorerClassification.score_names()))
+                    for score_values in scores.values():
+                        self.assertEqual(len(score_values), len(model_output))
+
+    def test_scorer_classification_wrong_model_output_tensor_order(self):
+
+        for tensor_order in range(5):
+            model_output = np.ndarray((3,)*tensor_order)
+            if tensor_order != 2:
+                with self.assertRaises(ValueError):
+                    scorer = ScorerClassification(model_output=model_output)
+            else:
+                scorer = ScorerClassification(model_output=model_output)
+                scores = scorer.calculate_scores()
 
 


### PR DESCRIPTION
closes #335 

## Description
- [ ] My change is breaking
- Following cases of model_output yield following output now:
- len(model_output) == 0: No error, returns empty list for every score
- otherwise: require model_output to have 2 dimensions, with the second dimension being >= 1. If the second dimension is zero, an error is raised.
- if the second dimension == 1, it is assumed to be a binary classification problem with the `model_output` vector denoting
the probability of class 0. Thus we set `prob_class_1 =  1 - prob_class_0` and concat it to the `model_output` to get `model_output.shape == (n, 2)`.
For the case of the detection model setting  `model_output` to a one-hot encoded vector of all ones (i.e. `model_output = np.ones(shape=(n,1))` ), this does not change the values of the scores, they are still all 0.
- Wrote unittests to test different number of dimensions (a.k.a. tensor order) and different sizes for each dimension. Also wrote tests for the binary classifier with hardcoded specific values.

## Tests
- [x] My change is covered by existing tests.
- [x] My change needs new tests.
- [x] I have added/adapted the tests accordingly.
- [ ] I have manually tested the change.

## Documentation
- no documentation needed

