### PR TITLE
refactor NTXent loss

### DIFF
--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -162,7 +162,7 @@ class NTXentLoss(MemoryBankModule):
 
             if self.mask_negative_samples is None \
                     or 2 * batch_size != self.mask_negative_samples.shape[0]:
-                #
+                # if the mask_negative_samples is not correct or has the wrong size
                 self.mask_negative_samples = \
                     self._torch_get_mask_negative_samples(batch_size, device=device)
 
@@ -177,7 +177,7 @@ class NTXentLoss(MemoryBankModule):
             # sim_pos is of shape (2 * batch_size, 1)
             # sim_neg is of shape (2 * batch_size, 2 * (batch_size -1))
 
-        # The goal is to maximize sim_pos in relation sim_neg.
+        # The goal is to maximize sim_pos in relation to sim_neg.
         # This goal can be targeted with the cross-entropy-loss
 
         logits = torch.cat([sim_pos, sim_neg], dim=1)

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -126,9 +126,9 @@ class NTXentLoss(MemoryBankModule):
             # the logits are the similarity matrix divided by the temperature
             logits = torch.einsum('nc,mc->nm', output, output) / self.temperature
             # We need to removed the similarities of samples to themselves
-            logits = logits[~torch.eye(2*batch_size, dtype=torch.bool)].view(2*batch_size, -1)
+            logits = logits[~torch.eye(2*batch_size, dtype=torch.bool, device=out0.device)].view(2*batch_size, -1)
 
-            # The labels point of a sample in out_i to its equivalent in out_(1-i)
+            # The labels point from a sample in out_i to its equivalent in out_(1-i)
             labels = torch.arange(batch_size)
             labels = torch.cat([labels + batch_size - 1, labels]).long()
 

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -98,7 +98,6 @@ class NTXentLoss(MemoryBankModule):
                 out1:
                     Output projections of the second set of transformed images.
                     Shape: (batch_size, embedding_size)
-                    out0[i] and out1[i] are two different augmentation of the same image.
 
             Returns:
                 Contrastive Cross Entropy Loss value.

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -52,7 +52,6 @@ class NTXentLoss(MemoryBankModule):
         super(NTXentLoss, self).__init__(size=memory_bank_size)
         self.temperature = temperature
         self.cross_entropy = torch.nn.CrossEntropyLoss(reduction="mean")
-        self.mask_negative_samples = None
         self.eps = 1e-8
 
         if abs(self.temperature) < self.eps:

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -67,13 +67,13 @@ class NTXentLoss(MemoryBankModule):
         being True except on three diagonals. These three diagonals are
         the main diagonal and the diagonals of the other two quadrants.
 
-        Example for batch_size=3 with x=False and _=True:
-        x _ _ x _  _
-        _ x _ _ x  _
-        _ _ x _ _  x
-        x _ _ x _  _
-        _ x _ _ x  _
-        _ _ x _ _  x
+        Example for batch_size=3 with X=False and _=True:
+        X _ _ X _ _
+        _ X _ _ X _
+        _ _ X _ _ X
+        X _ _ X _ _
+        _ X _ _ X _
+        _ _ X _ _ X
 
         """
         diag = torch.eye(2 * batch_size, device=device)

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -130,6 +130,7 @@ class NTXentLoss(MemoryBankModule):
             # of the i-th sample in the batch to its positive pair
             sim_pos = torch.einsum('nc,nc->n', out0, out1).unsqueeze(-1)
 
+
             # use negatives from memory bank
             negatives = negatives.to(device)
 
@@ -137,7 +138,7 @@ class NTXentLoss(MemoryBankModule):
             # of the i-th sample to the j-th negative sample
             sim_neg_out0 = torch.einsum('nc,ck->nk', out0, negatives.clone().detach())
             sim_neg_out1 = torch.einsum('nc,ck->nk', out1, negatives.clone().detach())
-            sim_neg = sim_neg_out0 + sim_neg_out1
+            sim_neg = (sim_neg_out0 + sim_neg_out1)/2
 
 
         else:

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -132,7 +132,7 @@ class NTXentLoss(MemoryBankModule):
                 return tensor
 
             mask_base = torch.eye(batch_size, dtype=torch.bool, device=out0.device)
-            mask_0 = torch.zeros_like(mask_base)
+            mask_0 = torch.zeros_like(mask_base, device=out0.device)
 
             # the positive samples are on the diagonals of the upper right and lower left quadrant
             mask_pos = concat_to_2x2(mask_0, mask_base, mask_base, mask_0)

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -59,29 +59,6 @@ class NTXentLoss(MemoryBankModule):
             raise ValueError('Illegal temperature: abs({}) < 1e-8'
                              .format(self.temperature))
 
-    def _torch_get_mask_negative_samples(self, batch_size, device=None):
-        """ Creates a matrix being true at values of the similarity matrix for
-        negative samples.
-
-        It creates a square matrix of size (2*batch_size, 2*batch_size)
-        being True except on three diagonals. These three diagonals are
-        the main diagonal and the diagonals of the other two quadrants.
-
-        Example for batch_size=3 with X=False and _=True:
-        X _ _ X _ _
-        _ X _ _ X _
-        _ _ X _ _ X
-        X _ _ X _ _
-        _ X _ _ X _
-        _ _ X _ _ X
-
-        """
-        diag = torch.eye(2 * batch_size, device=device)
-        diag[batch_size:, :batch_size] += torch.eye(batch_size, device=device)
-        diag[:batch_size, batch_size:] += torch.eye(batch_size, device=device)
-        mask = (1 - diag).type(torch.bool)
-        return mask
-
     def forward(self,
                 out0: torch.Tensor,
                 out1: torch.Tensor):

--- a/tests/loss/test_NTXentLoss.py
+++ b/tests/loss/test_NTXentLoss.py
@@ -1,4 +1,6 @@
 import unittest
+
+import numpy as np
 import torch
 
 from lightly.loss import NTXentLoss
@@ -8,15 +10,44 @@ class TestNTXentLoss(unittest.TestCase):
 
     def test_with_values(self):
         out0 = [[1., 1., 1.], [-1., -1., -1.]]
-        out1 = [[1., 1., 0.], [-1., -1., 0.]]
+        out1 = [[1., 1., -1.], [-1., -1., 1.]]
         out0 = torch.FloatTensor(out0)
         out1 = torch.FloatTensor(out1)
+        sim_matrix = [[]]
 
-        loss = NTXentLoss()
-        l1 = loss(out0, out1)
-        l2 = loss(out1, out0)
+        loss_function = NTXentLoss()
+        l1 = loss_function(out0, out1)
+        l2 = loss_function(out1, out0)
         self.assertAlmostEqual(float(l1), 0.0625955, places=5)
         self.assertAlmostEqual(float(l2), 0.0625955, places=5)
+
+    def calc_loss_manual(self, out0: np.ndarray, out1: np.ndarray, temperature: float) -> loss:
+        # using the pseudocode directly from https://arxiv.org/pdf/2002.05709.pdf Algorithm1
+        z = np.concatenate([out0, out1], axis=1)
+        N = len(out0)
+
+        s_i_j = np.zeros((2 * len(out0), 2 * len(out1)))
+        for i in range(2 * N):
+            for j in range(2 * N):
+                s_i_j[i, j] = z[i].T * z[j] / (np.linalg.norm(z[i]) * np.linalg.norm(z[j]))
+
+        logit_i_j = np.exp(s_i_j / temperature)
+
+        l_i_j = np.zeros_like(logit_i_j)
+        for i in range(2 * N):
+            for j in range(2 * N):
+                nominator = logit_i_j[i, j]
+                denominator = 0
+                for k in range(2 * N):
+                    if k != i:
+                        denominator += logit_i_j[i, k]
+                l_i_j[i, j] = -1 * np.log(nominator/denominator)
+
+        loss = 0
+        for k in range(N):
+            loss += l_i_j[2*k-1, 2*k] + l_i_j[2*k, 2*k-1]
+        loss /= (2*N)
+        return loss
 
     def test_with_values_and_memory_bank(self):
         out0 = [[1., 1., 1.], [-1., -1., -1.]]
@@ -31,18 +62,17 @@ class TestNTXentLoss(unittest.TestCase):
         for l in [l1, l2]:
             self.assertAlmostEqual(float(l), 4.5, delta=0.5)
 
-
     def test_get_correlated_mask(self):
         loss = NTXentLoss()
         for bsz in range(1, 100):
             mask = loss._torch_get_correlated_mask(bsz)
 
             # correct number of zeros in mask
-            self.assertAlmostEqual(mask.sum(), 4*(bsz*bsz - bsz))
+            self.assertAlmostEqual(mask.sum(), 4 * (bsz * bsz - bsz))
 
             # if mask is correct,
             # (1 - mask) * v adds up the first and second half of v
-            v = torch.randn((2*bsz))
+            v = torch.randn((2 * bsz))
             mv = torch.mv(1. - mask.float(), v)
             vv = (v[bsz:] + v[:bsz]).repeat(2)
             self.assertAlmostEqual((mv - vv).pow(2).sum(), 0.)
@@ -50,7 +80,6 @@ class TestNTXentLoss(unittest.TestCase):
     def test_forward_pass(self):
         loss = NTXentLoss(memory_bank_size=0)
         for bsz in range(1, 20):
-
             batch_1 = torch.randn((bsz, 32))
             batch_2 = torch.randn((bsz, 32))
 
@@ -62,7 +91,6 @@ class TestNTXentLoss(unittest.TestCase):
     def test_forward_pass_1d(self):
         loss = NTXentLoss(memory_bank_size=0)
         for bsz in range(1, 20):
-
             batch_1 = torch.randn((bsz, 1))
             batch_2 = torch.randn((bsz, 1))
 
@@ -74,7 +102,6 @@ class TestNTXentLoss(unittest.TestCase):
     def test_forward_pass_neg_temp(self):
         loss = NTXentLoss(temperature=-1., memory_bank_size=0)
         for bsz in range(1, 20):
-
             batch_1 = torch.randn((bsz, 32))
             batch_2 = torch.randn((bsz, 32))
 
@@ -82,7 +109,7 @@ class TestNTXentLoss(unittest.TestCase):
             l1 = loss(batch_1, batch_2)
             l2 = loss(batch_2, batch_1)
             self.assertAlmostEqual((l1 - l2).pow(2).item(), 0.)
-    
+
     def test_forward_pass_memory_bank(self):
         loss = NTXentLoss(memory_bank_size=64)
         for bsz in range(1, 20):
@@ -104,7 +131,6 @@ class TestNTXentLoss(unittest.TestCase):
         if torch.cuda.is_available():
             loss = NTXentLoss(memory_bank_size=0)
             for bsz in range(1, 20):
-
                 batch_1 = torch.randn((bsz, 32)).cuda()
                 batch_2 = torch.randn((bsz, 32)).cuda()
 
@@ -114,4 +140,3 @@ class TestNTXentLoss(unittest.TestCase):
                 self.assertAlmostEqual((l1 - l2).pow(2).item(), 0.)
         else:
             pass
-

--- a/tests/loss/test_NTXentLoss.py
+++ b/tests/loss/test_NTXentLoss.py
@@ -6,6 +6,32 @@ from lightly.loss import NTXentLoss
 
 class TestNTXentLoss(unittest.TestCase):
 
+    def test_with_values(self):
+        out0 = [[1., 1., 1.], [-1., -1., -1.]]
+        out1 = [[1., 1., 0.], [-1., -1., 0.]]
+        out0 = torch.FloatTensor(out0)
+        out1 = torch.FloatTensor(out1)
+
+        loss = NTXentLoss()
+        l1 = loss(out0, out1)
+        l2 = loss(out1, out0)
+        self.assertAlmostEqual(float(l1), 0.0625955, places=5)
+        self.assertAlmostEqual(float(l2), 0.0625955, places=5)
+
+    def test_with_values_and_memory_bank(self):
+        out0 = [[1., 1., 1.], [-1., -1., -1.]]
+        out1 = [[1., 1., 0.], [-1., -1., 0.]]
+        out0 = torch.FloatTensor(out0)
+        out1 = torch.FloatTensor(out1)
+
+        torch.manual_seed(42)
+        loss = NTXentLoss(memory_bank_size=64)
+        l1 = loss(out0, out1)
+        l2 = loss(out1, out0)
+        for l in [l1, l2]:
+            self.assertAlmostEqual(float(l), 4.5, delta=0.5)
+
+
     def test_get_correlated_mask(self):
         loss = NTXentLoss()
         for bsz in range(1, 100):

--- a/tests/loss/test_NTXentLoss.py
+++ b/tests/loss/test_NTXentLoss.py
@@ -77,27 +77,13 @@ class TestNTXentLoss(unittest.TestCase):
         loss_function = NTXentLoss(temperature=temperature)
         loss = float(loss_function(out0, out1))
         expected_loss = -1 * np.log(1 / (2 * n_samples - 1))
+        self.assertAlmostEqual(loss, expected_loss, places=1)
+
         loss_function_with_bank = NTXentLoss(temperature=temperature, memory_bank_size=memory_bank_size)
         for i in range(2):
             loss_with_memory_bank = float(loss_function_with_bank(out0, out1))
-        self.assertAlmostEqual(loss, expected_loss, places=1)
-
-
         expected_loss_memory_bank = -1 * np.log(1 / (memory_bank_size+1))
         self.assertAlmostEqual(loss_with_memory_bank, expected_loss_memory_bank, places=3)
-
-    def test_with_values_and_memory_bank(self):
-        out0 = [[1., 1., 1.], [-1., -1., -1.]]
-        out1 = [[1., 1., 0.], [-1., -1., 0.]]
-        out0 = torch.FloatTensor(out0)
-        out1 = torch.FloatTensor(out1)
-
-        torch.manual_seed(42)
-        loss = NTXentLoss(memory_bank_size=64)
-        l1 = loss(out0, out1)
-        l2 = loss(out1, out0)
-        for l in [l1, l2]:
-            self.assertAlmostEqual(float(l), 4.5, delta=0.5)
 
     def test_get_correlated_mask(self):
         loss = NTXentLoss()

--- a/tests/loss/test_NTXentLoss.py
+++ b/tests/loss/test_NTXentLoss.py
@@ -63,42 +63,30 @@ class TestNTXentLoss(unittest.TestCase):
         return loss
 
     def test_with_correlated_embedding(self):
-        n_samples = 8
-        temperature = 3
-        memory_bank_size = n_samples
-        out0 = np.random.random((n_samples, 1))
-        out1 = np.random.random((n_samples, 1))
-        out0 = np.concatenate([out0, 2 * out0], axis=1)
-        out1 = np.concatenate([out1, 2 * out1], axis=1)
-        out0 = torch.FloatTensor(out0)
-        out1 = torch.FloatTensor(out1)
-        out0.requires_grad = True
+        for n_samples in [1, 2, 8, 16]:
+            for memory_bank_size in [1, 2, 8, 15, 16, 17]:
+                for temperature in [0.1, 1, 7]:
+                    with self.subTest(msg=f"n_samples: {n_samples}, memory_bank_size: {memory_bank_size},"
+                                          f"temperature: {temperature}"):
+                        out0 = np.random.random((n_samples, 1))
+                        out1 = np.random.random((n_samples, 1))
+                        out0 = np.concatenate([out0, 2 * out0], axis=1)
+                        out1 = np.concatenate([out1, 2 * out1], axis=1)
+                        out0 = torch.FloatTensor(out0)
+                        out1 = torch.FloatTensor(out1)
+                        out0.requires_grad = True
 
-        loss_function = NTXentLoss(temperature=temperature)
-        loss = float(loss_function(out0, out1))
-        expected_loss = -1 * np.log(1 / (2 * n_samples - 1))
-        self.assertAlmostEqual(loss, expected_loss, places=1)
+                        loss_function = NTXentLoss(temperature=temperature)
+                        loss = float(loss_function(out0, out1))
+                        expected_loss = -1 * np.log(1 / (2 * n_samples - 1))
+                        self.assertAlmostEqual(loss, expected_loss, places=5)
 
-        loss_function_with_bank = NTXentLoss(temperature=temperature, memory_bank_size=memory_bank_size)
-        for i in range(2):
-            loss_with_memory_bank = float(loss_function_with_bank(out0, out1))
-        expected_loss_memory_bank = -1 * np.log(1 / (memory_bank_size+1))
-        self.assertAlmostEqual(loss_with_memory_bank, expected_loss_memory_bank, places=3)
-
-    def test_get_correlated_mask(self):
-        loss = NTXentLoss()
-        for bsz in range(1, 100):
-            mask = loss._torch_get_mask_negative_samples(bsz)
-
-            # correct number of zeros in mask
-            self.assertAlmostEqual(mask.sum(), 4 * (bsz * bsz - bsz))
-
-            # if mask is correct,
-            # (1 - mask) * v adds up the first and second half of v
-            v = torch.randn((2 * bsz))
-            mv = torch.mv(1. - mask.float(), v)
-            vv = (v[bsz:] + v[:bsz]).repeat(2)
-            self.assertAlmostEqual((mv - vv).pow(2).sum(), 0.)
+                        loss_function_with_bank = NTXentLoss(temperature=temperature, memory_bank_size=memory_bank_size)
+                        for i in range(int(memory_bank_size/n_samples)+2):
+                            # fill the memory bank over multiple rounds
+                            loss_with_memory_bank = float(loss_function_with_bank(out0, out1))
+                        expected_loss_memory_bank = -1 * np.log(1 / (memory_bank_size+1))
+                        self.assertAlmostEqual(loss_with_memory_bank, expected_loss_memory_bank, places=5)
 
     def test_forward_pass(self):
         loss = NTXentLoss(memory_bank_size=0)

--- a/tests/loss/test_NTXentLoss.py
+++ b/tests/loss/test_NTXentLoss.py
@@ -62,6 +62,30 @@ class TestNTXentLoss(unittest.TestCase):
         loss /= (2 * N)
         return loss
 
+    def test_with_correlated_embedding(self):
+        n_samples = 8
+        temperature = 3
+        memory_bank_size = n_samples
+        out0 = np.random.random((n_samples, 1))
+        out1 = np.random.random((n_samples, 1))
+        out0 = np.concatenate([out0, 2 * out0], axis=1)
+        out1 = np.concatenate([out1, 2 * out1], axis=1)
+        out0 = torch.FloatTensor(out0)
+        out1 = torch.FloatTensor(out1)
+        out0.requires_grad = True
+
+        loss_function = NTXentLoss(temperature=temperature)
+        loss = float(loss_function(out0, out1))
+        expected_loss = -1 * np.log(1 / (2 * n_samples - 1))
+        loss_function_with_bank = NTXentLoss(temperature=temperature, memory_bank_size=memory_bank_size)
+        for i in range(2):
+            loss_with_memory_bank = float(loss_function_with_bank(out0, out1))
+        self.assertAlmostEqual(loss, expected_loss, places=1)
+
+
+        expected_loss_memory_bank = -1 * np.log(1 / (memory_bank_size+1))
+        self.assertAlmostEqual(loss_with_memory_bank, expected_loss_memory_bank, places=3)
+
     def test_with_values_and_memory_bank(self):
         out0 = [[1., 1., 1.], [-1., -1., -1.]]
         out1 = [[1., 1., 0.], [-1., -1., 0.]]


### PR DESCRIPTION
closes #268

## Description
- [ ] My change is breaking
- For the unittests: wrote down an alternative calculation of the NTXent loss following exactly the pseudocode in the paper.
https://github.com/lightly-ai/lightly/blob/05bb9bd6c93c537763e8be8dc1f776db7ef4b793/tests/loss/test_NTXentLoss.py#L30-L31
Then it is checked whether the torch implementation and manual implementations with for-loops and numpy yield the same results.
- Deleted unused functions in the NTXent loss class
- Made the code a bit simpler and calculated the similarity matrix with Einstein summation.
- Added a higher number of comments to make it easier to understand what is going on. 

## Performance Comparison
with `out0.shape == out1.shape == (256, 64)` and 10000 repetitions

- old implementation on MBP CPU: 36s
- new implementation on MBP CPU: 20s

Flaws of evaluation: did not test with back propagation/gradient

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [x] I have added/adapted the tests accordingly.
- [ ] I have manually tested the change. if_yes_describe_how

## Documentation
- [x] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation ( `.rst` files).
- [ ] I have updated the documentation accordingly.
- [ ] The autodocs update the documentation accordingly.
