### PR TITLE
printing dataset_id and important filenames/values in blue

### DIFF
--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
-
+import copy
 import os
 import warnings
 
@@ -19,7 +19,7 @@ def _custom_formatwarning(msg, *args, **kwargs):
 
 
 def print_as_warning(message: str):
-    old_format = warnings.formatwarning
+    old_format = copy.copy(warnings.formatwarning)
 
     warnings.formatwarning = _custom_formatwarning
     warnings.warn(message, UserWarning)

--- a/lightly/cli/download_cli.py
+++ b/lightly/cli/download_cli.py
@@ -34,6 +34,7 @@ def _download_cli(cfg, is_cli_call=True):
     if not tag_name or not token or not dataset_id:
         print_as_warning('Please specify all of the parameters tag_name, token and dataset_id')
         print_as_warning('For help, try: lightly-download --help')
+        return
 
     api_workflow_client = ApiWorkflowClient(
         token=token, dataset_id=dataset_id

--- a/lightly/cli/download_cli.py
+++ b/lightly/cli/download_cli.py
@@ -13,6 +13,7 @@ import shutil
 import warnings
 
 import hydra
+from torch.utils.hipify.hipify_python import bcolors
 from tqdm import tqdm
 
 import lightly.data as data
@@ -73,12 +74,13 @@ def _download_cli(cfg, is_cli_call=True):
     samples = [api_workflow_client.filenames_on_server[i] for i in chosen_samples_ids]
 
     # store sample names in a .txt file
-    with open(cfg['tag_name'] + '.txt', 'w') as f:
+    filename = cfg['tag_name'] + '.txt'
+    with open(filename, 'w') as f:
         for item in samples:
             f.write("%s\n" % item)
 
-    msg = 'The list of files in tag {} is stored at: '.format(cfg['tag_name'])
-    msg += os.path.join(os.getcwd(), cfg['tag_name'] + '.txt')
+    filepath = os.path.join(os.getcwd(), filename)
+    msg = f'The list of files in tag {cfg["tag_name"]} is stored at: {bcolors.OKBLUE}{filepath}{bcolors.ENDC}'
     print(msg, flush=True)
 
     if not cfg['input_dir'] and cfg['output_dir']:
@@ -89,7 +91,7 @@ def _download_cli(cfg, is_cli_call=True):
     elif cfg['input_dir'] and cfg['output_dir']:
         input_dir = fix_input_path(cfg['input_dir'])
         output_dir = fix_input_path(cfg['output_dir'])
-        print(f'Copying files from {input_dir} to {output_dir}.')
+        print(f'Copying files from {input_dir} to {bcolors.OKBLUE}{output_dir}{bcolors.ENDC}.')
 
         # create a dataset from the input directory
         dataset = data.LightlyDataset(input_dir=input_dir)

--- a/lightly/cli/download_cli.py
+++ b/lightly/cli/download_cli.py
@@ -17,7 +17,7 @@ from torch.utils.hipify.hipify_python import bcolors
 from tqdm import tqdm
 
 import lightly.data as data
-from lightly.cli._helpers import fix_input_path
+from lightly.cli._helpers import fix_input_path, print_as_warning
 
 from lightly.api.utils import getenv
 from lightly.api.api_workflow_client import ApiWorkflowClient
@@ -31,15 +31,9 @@ def _download_cli(cfg, is_cli_call=True):
     dataset_id = cfg['dataset_id']
     token = cfg['token']
 
-    if not tag_name:
-        print('Please specify a tag name')
-        print('For help, try: lightly-download --help')
-        return
-
-    if not token or not dataset_id:
-        print('Please specify your access token and dataset id')
-        print('For help, try: lightly-download --help')
-        return
+    if not tag_name or not token or not dataset_id:
+        print_as_warning('Please specify all of the parameters tag_name, token and dataset_id')
+        print_as_warning('For help, try: lightly-download --help')
 
     api_workflow_client = ApiWorkflowClient(
         token=token, dataset_id=dataset_id

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -14,6 +14,7 @@ import hydra
 import torch
 import torch.nn as nn
 import torchvision
+from torch.utils.hipify.hipify_python import bcolors
 
 from lightly.data import LightlyDataset
 from lightly.embedding import SelfSupervisedEmbedding
@@ -107,7 +108,7 @@ def _embed_cli(cfg, is_cli_call=True):
     if is_cli_call:
         path = os.path.join(os.getcwd(), 'embeddings.csv')
         save_embeddings(path, embeddings, labels, filenames)
-        print('Embeddings are stored at %s' % (path))
+        print(f'Embeddings are stored at {bcolors.OKBLUE}{path}{bcolors.ENDC}')
         return path
 
     return embeddings, labels, filenames

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -20,6 +20,7 @@ def _lightly_cli(cfg, is_cli_call=True):
     cfg['loader']['shuffle'] = True
     cfg['loader']['drop_last'] = True
     if cfg['trainer']['max_epochs'] > 0:
+        print('#' * 10 + ' Starting to train an embedding model.')
         checkpoint = _train_cli(cfg, is_cli_call)
     else:
         checkpoint = ''
@@ -28,11 +29,15 @@ def _lightly_cli(cfg, is_cli_call=True):
     cfg['loader']['drop_last'] = False
     cfg['checkpoint'] = checkpoint
 
+    print('#' * 10 + ' Starting to embed your dataset.')
     embeddings = _embed_cli(cfg, is_cli_call)
     cfg['embeddings'] = embeddings
 
     if cfg['token'] and (cfg['dataset_id'] or cfg['new_dataset_name']):
-        _upload_cli(cfg)   
+        print('#' * 10 + ' Starting to upload your dataset to the Lightly platform.')
+        _upload_cli(cfg)
+
+    print('#' * 10 + ' Finished')
 
 
 @hydra.main(config_path="config", config_name="config")

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -13,6 +13,8 @@ import torch
 import torch.nn as nn
 import warnings
 
+from torch.utils.hipify.hipify_python import bcolors
+
 from lightly.data import ImageCollateFunction
 from lightly.data import LightlyDataset
 from lightly.embedding import SelfSupervisedEmbedding
@@ -118,7 +120,7 @@ def _train_cli(cfg, is_cli_call=True):
     encoder.init_checkpoint_callback(**cfg['checkpoint_callback'])
     encoder.train_embedding(**cfg['trainer'])
 
-    print('Best model is stored at: %s' % (encoder.checkpoint))
+    print(f'Best model is stored at: {bcolors.OKBLUE}{encoder.checkpoint}{bcolors.ENDC}')
     return encoder.checkpoint
 
 

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -69,8 +69,9 @@ def _upload_cli(cfg, is_cli_call=True):
         api_workflow_client.upload_embeddings(
             path_to_embeddings_csv=path_to_embeddings, name=name
         )
-
-    print(f'The dataset id is {bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')
+    if new_dataset_name_ok:
+        print(f'The dataset_id of the newly created dataset is '
+              f'{bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')
 
 
 @hydra.main(config_path='config', config_name='config')

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -67,6 +67,7 @@ def _upload_cli(cfg, is_cli_call=True):
         api_workflow_client.upload_dataset(
             input=dataset, mode=mode, max_workers=cfg['loader']['num_workers']
         )
+        print(f"Finished the upload of the dataset.")
 
     if path_to_embeddings:
         name = cfg['embedding_name']

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -12,6 +12,7 @@ import warnings
 import hydra
 
 import torchvision
+from torch.utils.hipify.hipify_python import bcolors
 
 from lightly.cli._helpers import fix_input_path
 
@@ -68,6 +69,8 @@ def _upload_cli(cfg, is_cli_call=True):
         api_workflow_client.upload_embeddings(
             path_to_embeddings_csv=path_to_embeddings, name=name
         )
+
+    print(f'The dataset id is {bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')
 
 
 @hydra.main(config_path='config', config_name='config')

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -70,12 +70,12 @@ def _upload_cli(cfg, is_cli_call=True):
 
     if path_to_embeddings:
         name = cfg['embedding_name']
-        print("Starting upload of embeddings...")
+        print("Starting upload of embeddings.")
         api_workflow_client.upload_embeddings(
             path_to_embeddings_csv=path_to_embeddings, name=name
         )
-        print("Finished upload of embeddings...")
-        
+        print("Finished upload of embeddings.")
+
     if new_dataset_name_ok:
         print(f'The dataset_id of the newly created dataset is '
               f'{bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -70,9 +70,12 @@ def _upload_cli(cfg, is_cli_call=True):
 
     if path_to_embeddings:
         name = cfg['embedding_name']
+        print("Starting upload of embeddings...")
         api_workflow_client.upload_embeddings(
             path_to_embeddings_csv=path_to_embeddings, name=name
         )
+        print("Finished upload of embeddings...")
+        
     if new_dataset_name_ok:
         print(f'The dataset_id of the newly created dataset is '
               f'{bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -14,7 +14,7 @@ import hydra
 import torchvision
 from torch.utils.hipify.hipify_python import bcolors
 
-from lightly.cli._helpers import fix_input_path
+from lightly.cli._helpers import fix_input_path, print_as_warning
 
 from lightly.api.utils import getenv
 from lightly.api.api_workflow_client import ApiWorkflowClient
@@ -34,9 +34,10 @@ def _upload_cli(cfg, is_cli_call=True):
     token = cfg['token']
     new_dataset_name = cfg['new_dataset_name']
 
+    cli_api_args_wrong = False
     if not token:
-        warnings.warn('Please specify your access token. For help, try: lightly-upload --help')
-        return
+        print_as_warning('Please specify your access token.')
+        cli_api_args_wrong = True
 
     dataset_id_ok = dataset_id and len(dataset_id) > 0
     new_dataset_name_ok = new_dataset_name and len(new_dataset_name) > 0
@@ -46,8 +47,11 @@ def _upload_cli(cfg, is_cli_call=True):
     elif dataset_id_ok and not new_dataset_name_ok:
         api_workflow_client = ApiWorkflowClient(token=token, dataset_id=dataset_id)
     else:
-        warnings.warn('Please specify either the dataset_id of an existing dataset or a new_dataset_name. '
-                      'For help, try: lightly-upload --help')
+        print_as_warning('Please specify either the dataset_id of an existing dataset or a new_dataset_name.')
+        cli_api_args_wrong = True
+
+    if cli_api_args_wrong:
+        print_as_warning('For help, try: lightly-upload --help')
         return
 
     size = cfg['resize']

--- a/tests/cli/test_cli_download.py
+++ b/tests/cli/test_cli_download.py
@@ -18,7 +18,7 @@ class TestCLIDownload(MockedApiWorkflowSetup):
 
     def setUp(self):
         with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
-            self.cfg = compose(config_name="config", overrides=["token='123'", "dataset_id='XYZ'"])
+            self.cfg = compose(config_name="config")
 
     def create_fake_dataset(self, n_data: int = 5):
         self.dataset = torchvision.datasets.FakeData(size=n_data,
@@ -74,6 +74,7 @@ class TestCLIDownload(MockedApiWorkflowSetup):
         lightly.cli.download_cli(self.cfg)
 
     def test_download_no_tag_name(self):
+        # defaults to initial-tag
         cli_string = "lightly-download token='123' dataset_id='XYZ'"
         self.parse_cli_string(cli_string)
         lightly.cli.download_cli(self.cfg)
@@ -81,12 +82,14 @@ class TestCLIDownload(MockedApiWorkflowSetup):
     def test_download_no_token(self):
         cli_string = "lightly-download dataset_id='XYZ' tag_name='sampled_tag_xyz'"
         self.parse_cli_string(cli_string)
-        lightly.cli.download_cli(self.cfg)
+        with self.assertWarns(UserWarning):
+            lightly.cli.download_cli(self.cfg)
 
     def test_download_no_dataset_id(self):
         cli_string = "lightly-download token='123' tag_name='sampled_tag_xyz'"
         self.parse_cli_string(cli_string)
-        lightly.cli.download_cli(self.cfg)
+        with self.assertWarns(UserWarning):
+            lightly.cli.download_cli(self.cfg)
 
     def test_download_copy_from_input_to_output_dir(self):
         self.create_fake_dataset(n_data=100)

--- a/tests/cli/test_cli_download.py
+++ b/tests/cli/test_cli_download.py
@@ -3,13 +3,12 @@ import re
 import sys
 import tempfile
 
+import torchvision
 from hydra.experimental import compose, initialize
 
 import lightly
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
 
-
-#in download_cli.py: from lightly.api.api_workflow_client import ApiWorkflowClient
 
 class TestCLIDownload(MockedApiWorkflowSetup):
 
@@ -17,11 +16,24 @@ class TestCLIDownload(MockedApiWorkflowSetup):
     def setUpClass(cls) -> None:
         sys.modules["lightly.cli.download_cli"].ApiWorkflowClient = MockedApiWorkflowClient
 
-
     def setUp(self):
         with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
             self.cfg = compose(config_name="config", overrides=["token='123'", "dataset_id='XYZ'"])
 
+    def create_fake_dataset(self, n_data: int = 5):
+        self.dataset = torchvision.datasets.FakeData(size=n_data,
+                                                     image_size=(3, 32, 32))
+
+        self.input_dir = tempfile.mkdtemp()
+
+        sample_names = [f'img_{i}.jpg' for i in range(n_data)]
+        self.sample_names = sample_names
+        for sample_idx in range(n_data):
+            data = self.dataset[sample_idx]
+            path = os.path.join(self.input_dir, sample_names[sample_idx])
+            data[0].save(path)
+
+        self.output_dir = tempfile.mkdtemp()
 
     def parse_cli_string(self, cli_words: str):
         cli_words = cli_words.replace("lightly-download ", "")
@@ -61,10 +73,30 @@ class TestCLIDownload(MockedApiWorkflowSetup):
         self.parse_cli_string(cli_string)
         lightly.cli.download_cli(self.cfg)
 
+    def test_download_no_tag_name(self):
+        cli_string = "lightly-download token='123' dataset_id='XYZ'"
+        self.parse_cli_string(cli_string)
+        lightly.cli.download_cli(self.cfg)
+
+    def test_download_no_token(self):
+        cli_string = "lightly-download dataset_id='XYZ' tag_name='sampled_tag_xyz'"
+        self.parse_cli_string(cli_string)
+        lightly.cli.download_cli(self.cfg)
+
+    def test_download_no_dataset_id(self):
+        cli_string = "lightly-download token='123' tag_name='sampled_tag_xyz'"
+        self.parse_cli_string(cli_string)
+        lightly.cli.download_cli(self.cfg)
+
+    def test_download_copy_from_input_to_output_dir(self):
+        self.create_fake_dataset(n_data=100)
+        cli_string = f"lightly-download token='123' dataset_id='dataset_1_id' tag_name='sampled_tag_xyz' " \
+                     f"input_dir={self.input_dir} output_dir={self.output_dir}"
+        self.parse_cli_string(cli_string)
+        lightly.cli.download_cli(self.cfg)
+
     def tearDown(self) -> None:
         try:
             os.remove(f"{self.cfg['tag_name']}.txt")
         except FileNotFoundError:
             pass
-
-


### PR DESCRIPTION
closes #332 
closes https://github.com/lightly-ai/lightly-core/issues/352

## Description
- [ ] My change is breaking
- The `lightly-upload` command now also prints the `dataset_id` if the `new_dataset_name` was specified.
- Many important filenames/values are now printed in blue.
- The `lightly-magic` command now prints e.g. `########## Starting to embed your dataset.` before each of its three steps
- More unittests for `lightly-download` to also cover new printings in blue
- added helper to print missing cli api arguments as yellow warnings, but without text

`lightly-magic:` (cut off parts of the start)
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/20324507/117176531-49545b00-add0-11eb-957b-4196eaf0c00d.png">
<img width="662" alt="image" src="https://user-images.githubusercontent.com/20324507/117292497-8ec86500-ae70-11eb-84c6-206fc67682c3.png">


`lightly-download:`
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/20324507/117176893-acde8880-add0-11eb-8873-e3fa93576e13.png">
<img width="556" alt="image" src="https://user-images.githubusercontent.com/20324507/117292538-9e47ae00-ae70-11eb-9984-9c99ee82a3f0.png">



## Tests
- [x] My change is covered by existing tests
- [x] My change needs new tests
- [x] I have added/adapted tests accordingly.
- [x] I have manually tested the change. 

If applicable, describe the manual test procedure, e.g:
```bash
pip uninstall lightly
export BRANCH_NAME="332-Return-the-dataset_id-when-creating-a-new-dataset-me"
pip install "git+https://github.com/lightly-ai/lightly.git@$BRANCH_NAME"
lightly-magic new_dataset_name='new_dataset_name_xyz' token=MY_TOKEN trainer.max_epochs=1 input_dir='my_input_dir'
lightly-download token= MY_TOKEN dataset_id='was_in_blue_in_CLI_print' tag_name='initial-tag' input_dir='my_input_dir' output_dir='my_output_dir'
```

## Documentation
- [ ] I have added docstrings to all changed/added public functions/methods.
- [ ] My change requires a change to the documentation ( `.rst` files).
- [ ] I have updated the documentation accordingly.
- [ ] The autodocs update the documentation accordingly.`