### PR TITLE
Use pl callback from version 1.3 on

### DIFF
--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -7,6 +7,7 @@ import copy
 
 import pytorch_lightning as pl
 import pytorch_lightning.core.lightning as lightning
+from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 import torch.nn as nn
 
 from lightly.embedding._callback import CustomModelCheckpoint
@@ -114,11 +115,21 @@ class BaseEmbedding(lightning.LightningModule):
                 Where to save the checkpoint.
 
         """
-        # initialize custom model checkpoint
-        self.checkpoint_callback = CustomModelCheckpoint()
-        self.checkpoint_callback.save_last = save_last
-        self.checkpoint_callback.save_top_k = save_top_k
-        self.checkpoint_callback.monitor = monitor
 
-        dirpath = self.cwd if dirpath is None else dirpath
-        self.checkpoint_callback.dirpath = dirpath
+        if pl.__version__[:3] in ['1.0', '1.1', '1.2']:
+            # initialize custom model checkpoint
+            self.checkpoint_callback = CustomModelCheckpoint()
+            self.checkpoint_callback.save_last = save_last
+            self.checkpoint_callback.save_top_k = save_top_k
+            self.checkpoint_callback.monitor = monitor
+
+            dirpath = self.cwd if dirpath is None else dirpath
+            self.checkpoint_callback.dirpath = dirpath
+        else:
+            self.checkpoint_callback = ModelCheckpoint(
+                dirpath=self.cwd if dirpath is None else dirpath,
+                filename='lightly_epoch_{epoch:d}',
+                save_last=save_last,
+                save_top_k=save_top_k,
+                monitor=monitor,
+                auto_insert_metric_name=False)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 
 hydra-core>=1.0.0
 numpy>=1.18.1
-pytorch_lightning>=1.0.4,<=1.2.10
+pytorch_lightning>=1.0.4
 requests>=2.23.0
 torchvision
 tqdm>=4.44


### PR DESCRIPTION
### Changes

closes #361 

We introduced a hack for previous PyTorch Lightning versions to customize the way checkpoints are saved. For example, we wanted to get rid of the `checkpoint=1.ckpt` in the checkpoint filename.
With the new PyTorch Lightning version they introduce all sorts of handy changes which make our hack obsolete. This PR switches to a Lightning checkpoint callback.

- we can still load old checkpoints
- new checkpoints are saved with the same filename as the old version
- now it works with PyTorch Lightning 1.3 :)