### PR TITLE
Show current lightly version in version check warning

### DIFF
--- a/lightly/api/version_checking.py
+++ b/lightly/api/version_checking.py
@@ -9,6 +9,8 @@ from lightly.openapi_generated.swagger_client.api_client import ApiClient
 from lightly.openapi_generated.swagger_client.configuration import Configuration
 from lightly.api.utils import getenv
 
+from lightly import __version__
+
 
 def get_versioning_api() -> VersioningApi:
     configuration = Configuration()
@@ -48,7 +50,8 @@ def version_compare(v0, v1):
 
 
 def pretty_print_latest_version(latest_version, width=70):
-    warning = f"There is a newer version of the package available. " \
-              f"For compatability reasons, please upgrade your current version:" \
+    warning = f"You are using lightly version {__version__}. " \
+              f"There is a newer version of the package available. " \
+              f"For compatability reasons, please upgrade your current version: " \
               f"pip install lightly=={latest_version}"
     warnings.warn(Warning(warning))


### PR DESCRIPTION
### Changes

- Just a small change regarding the warning message when using an outdated lightly version. The message now also shows the current version you're using. I thought this is quite handy to figure out whether you're far behind the latest version or not :)

New warning message:
```
/opt/conda/envs/lightly/lib/python3.7/site-packages/lightly/api/version_checking.py:57: Warning: You are using lightly version 1.1.8. There is a newer version of the package available. For compatability reasons, please upgrade your current version: pip install lightly==1.1.9
  warnings.warn(Warning(warning))
```