### PR TITLE
Add imagenette benchmark

### DIFF
--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -17,7 +17,7 @@ We use the ImageNette dataset provided here: https://github.com/fastai/imagenett
 For our benchmarks we use the 160px version. Training for 800 epochs on a V100
 GPU takes around 4 hours.
 
-The current benchmark contains the followin models:
+The current benchmark contains the following models:
 
 - MoCo
 - SimCLR

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -4,6 +4,38 @@ We show benchmarks of the different models for self-supervised learning
 and their performance on public datasets.
 
 
+We have benchmarks we regularly update for these datasets:
+- CIFAR10 `CIFAR10`_
+- ImageNette `ImageNette`_
+
+
+ImageNette
+-----------------------------------
+
+We use the ImageNette dataset provided here: https://github.com/fastai/imagenette
+
+For our benchmarks we use the 160px version. Training for 800 epochs on a V100
+GPU takes around 4 hours.
+
+The current benchmark contains the followin models:
+
+- MoCo
+- SimCLR
+- SimSiam
+- BarlowTwins
+- BYOL
+
+.. csv-table:: ImageNette benchmark results 
+   :header: "Model", "Epochs", "Batch Size", "kNN test Accuracy", "Peak GPU consumption"
+   :widths: 20, 20, 20, 20, 20
+
+   "MoCo", 800, 256, 0.827, "-"
+   "SimCLR", 800, 256, 0.847, "-"
+   "SimSiam", 800, 256, 0.827, "-"
+   "BarlowTwins", 800, 256, 0.801, "-"
+   "BYOL", 800, 256, 0.851, "-"
+
+
 CIFAR10
 -----------------------------------
 
@@ -26,6 +58,8 @@ The current benchmark contains the followin models:
 - MoCo (with symmetric loss and memory bank with 4096 entries)
 - SimCLR
 - SimSiam (with 2 MLP layers)
+- BarlowTwins
+- BYOL
 
 .. csv-table:: Cifar10 benchmark results 
    :header: "Model", "Epochs", "Batch Size", "kNN test Accuracy", "Peak GPU consumption"

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1,0 +1,441 @@
+# -*- coding: utf-8 -*-
+"""
+Note that this benchmark also supports a multi-GPU setup. If you run it on
+a system with multiple GPUs make sure that you kill all the processes when
+killing the application. Due to the way we setup this benchmark the distributed
+processes might continue the benchmark if one of the nodes is killed.
+If you know how to fix this don't hesitate to create an issue or PR :)
+You can download the ImageNette dataset from here: https://github.com/fastai/imagenette
+"""
+import os
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+import numpy as np
+import pytorch_lightning as pl
+from pytorch_lightning.loggers import TensorBoardLogger
+from torchvision import transforms
+from torchvision.transforms.transforms import CenterCrop
+import lightly
+from lightly.utils import BenchmarkModule
+from lightly.models.modules import NNMemoryBankModule
+
+num_workers = 12
+memory_bank_size = 4096
+
+logs_root_dir = os.path.join(os.getcwd(), 'imagenette_logs')
+
+# set max_epochs to 800 for long run (takes around 10h on a single V100)
+max_epochs = 800
+knn_k = 200
+knn_t = 0.1
+classes = 10
+input_size=128
+num_ftrs=512
+nn_size=2 ** 16
+
+# benchmark
+n_runs = 1 # optional, increase to create multiple runs and report mean + std
+batch_sizes = [256]
+
+# use a GPU if available
+gpus = -1 if torch.cuda.is_available() else 0
+distributed_backend = 'ddp' if torch.cuda.device_count() > 1 else None
+
+# The dataset structure should be like this:
+
+path_to_train = '/datasets/imagenette2-160/train/'
+path_to_test = '/datasets/imagenette2-160/val/'
+
+# Use SimCLR augmentations, additionally, disable blur
+collate_fn = lightly.data.SimCLRCollateFunction(
+    input_size=input_size,
+)
+
+# No additional augmentations for the test set
+test_transforms = torchvision.transforms.Compose([
+    torchvision.transforms.Resize(input_size),
+    torchvision.transforms.CenterCrop(128),
+    torchvision.transforms.ToTensor(),
+    torchvision.transforms.Normalize(
+        mean=lightly.data.collate.imagenet_normalize['mean'],
+        std=lightly.data.collate.imagenet_normalize['std'],
+    )
+])
+
+dataset_train_ssl = lightly.data.LightlyDataset(
+    input_dir=path_to_train
+)
+
+# we use test transformations for getting the feature for kNN on train data
+dataset_train_kNN = lightly.data.LightlyDataset(
+    input_dir=path_to_train,
+    transform=test_transforms
+)
+
+dataset_test = lightly.data.LightlyDataset(
+    input_dir=path_to_test,
+    transform=test_transforms
+)
+
+def get_data_loaders(batch_size: int):
+    """Helper method to create dataloaders for ssl, kNN train and kNN test
+    Args:
+        batch_size: Desired batch size for all dataloaders
+    """
+    dataloader_train_ssl = torch.utils.data.DataLoader(
+        dataset_train_ssl,
+        batch_size=batch_size,
+        shuffle=True,
+        collate_fn=collate_fn,
+        drop_last=True,
+        num_workers=num_workers
+    )
+
+    dataloader_train_kNN = torch.utils.data.DataLoader(
+        dataset_train_kNN,
+        batch_size=batch_size,
+        shuffle=False,
+        drop_last=False,
+        num_workers=num_workers
+    )
+
+    dataloader_test = torch.utils.data.DataLoader(
+        dataset_test,
+        batch_size=batch_size,
+        shuffle=False,
+        drop_last=False,
+        num_workers=num_workers
+    )
+
+    return dataloader_train_ssl, dataloader_train_kNN, dataloader_test
+
+
+class MocoModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        #resnet = lightly.models.ResNetGenerator('resnet-18', num_splits=8)
+        #s#elf.backbone = nn.Sequential(
+        #    *list(resnet.children())[:-1],
+        #    nn.AdaptiveAvgPool2d(1),
+        #)
+
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+
+        # create a moco model based on ResNet
+        self.resnet_moco = \
+            lightly.models.MoCo(self.backbone, num_ftrs=num_ftrs, m=0.99, batch_shuffle=True)
+        # create our loss with the optional memory bank
+        self.criterion = lightly.loss.NTXentLoss(
+            temperature=0.1,
+            memory_bank_size=memory_bank_size)
+
+    def forward(self, x):
+        self.resnet_moco(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        # We use a symmetric loss (model trains faster at little compute overhead)
+        # https://colab.research.google.com/github/facebookresearch/moco/blob/colab-notebook/colab/moco_cifar10_demo.ipynb
+        loss_1 = self.criterion(*self.resnet_moco(x0, x1))
+        loss_2 = self.criterion(*self.resnet_moco(x1, x0))
+        loss = 0.5 * (loss_1 + loss_2)
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_moco.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+
+class SimCLRModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+        # create a simclr model based on ResNet
+        self.resnet_simclr = \
+            lightly.models.SimCLR(self.backbone, num_ftrs=num_ftrs)
+        self.criterion = lightly.loss.NTXentLoss()
+
+    def forward(self, x):
+        self.resnet_simclr(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        x0, x1 = self.resnet_simclr(x0, x1)
+        loss = self.criterion(x0, x1)
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_simclr.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+class NNCLRModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+        # create a simclr model based on ResNet
+        self.resnet_simclr = \
+            lightly.models.NNCLR(self.backbone, num_ftrs=num_ftrs, num_mlp_layers=2)
+        self.criterion = lightly.loss.NTXentLoss()
+
+        self.nn_replacer = NNMemoryBankModule(size=nn_size)
+
+    def forward(self, x):
+        self.resnet_simclr(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        (z0, p0), (z1, p1) = self.resnet_simclr(x0, x1)
+        z0 = self.nn_replacer(z0.detach(), update=False)
+        z1 = self.nn_replacer(z1.detach(), update=True)
+        loss = 0.5 * (self.criterion(z0, p1) + self.criterion(z1, p0))
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_simclr.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+class SimSiamModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+        # create a simsiam model based on ResNet
+        self.resnet_simsiam = \
+            lightly.models.SimSiam(self.backbone, num_ftrs=num_ftrs, num_mlp_layers=2)
+        self.criterion = lightly.loss.SymNegCosineSimilarityLoss()
+
+    def forward(self, x):
+        self.resnet_simsiam(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        x0, x1 = self.resnet_simsiam(x0, x1)
+        loss = self.criterion(x0, x1)
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_simsiam.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+class NNSimSiamModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+        # create a simsiam model based on ResNet
+        self.resnet_simsiam = \
+            lightly.models.SimSiam(self.backbone, num_ftrs=num_ftrs, num_mlp_layers=2)
+        self.criterion = lightly.loss.SymNegCosineSimilarityLoss()
+
+        self.nn_replacer = NNMemoryBankModule(size=nn_size)
+
+    def forward(self, x):
+        self.resnet_simsiam(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        (z0, p0), (z1, p1) = self.resnet_simsiam(x0, x1)
+        z0 = self.nn_replacer(z0.detach(), update=False)
+        z1 = self.nn_replacer(z1.detach(), update=True)
+        loss = self.criterion((z0, p0), (z1, p1))
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_simsiam.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+
+class BarlowTwinsModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+        # create a barlow twins model based on ResNet
+        self.resnet_barlowtwins = \
+            lightly.models.BarlowTwins(
+                self.backbone, 
+                num_ftrs=num_ftrs,
+                proj_hidden_dim=2048,
+                out_dim=2048,
+                num_mlp_layers=2
+                )
+        self.criterion = lightly.loss.BarlowTwinsLoss()
+
+    def forward(self, x):
+        self.resnet_barlowtwins(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        x0, x1 = self.resnet_barlowtwins(x0, x1)
+        loss = self.criterion(x0, x1)
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_barlowtwins.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+class BYOLModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+        # create a byol model based on ResNet
+        self.resnet_byol = \
+            lightly.models.BYOL(self.backbone, num_ftrs=num_ftrs)
+        self.criterion = lightly.loss.SymNegCosineSimilarityLoss()
+
+    def forward(self, x):
+        self.resnet_byol(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        x0, x1 = self.resnet_byol(x0, x1)
+        loss = self.criterion(x0, x1)
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_byol.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+class NNBYOLModel(BenchmarkModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = torchvision.models.resnet18()
+        last_conv_channels = list(resnet.children())[-1].in_features
+        self.backbone = nn.Sequential(
+            *list(resnet.children())[:-1],
+            nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        )
+        # create a byol model based on ResNet
+        self.resnet_byol = \
+            lightly.models.BYOL(self.backbone, num_ftrs=num_ftrs)
+        self.criterion = lightly.loss.SymNegCosineSimilarityLoss()
+
+        self.nn_replacer = NNMemoryBankModule(size=nn_size)
+
+    def forward(self, x):
+        self.resnet_byol(x)
+
+    def training_step(self, batch, batch_idx):
+        (x0, x1), _, _ = batch
+        (z0, p0), (z1, p1) = self.resnet_byol(x0, x1)
+        z0 = self.nn_replacer(z0.detach(), update=False)
+        z1 = self.nn_replacer(z1.detach(), update=True)
+        loss = self.criterion((z0, p0), (z1, p1))
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_byol.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]
+
+model_names = ['MoCo_256', 'SimCLR_256', 'SimSiam_256', 'BarlowTwins_256', 
+               'BYOL_256', 'NNCLR_256', 'NNSimSiam_256', 'NNBYOL_256']
+
+models = [MocoModel, SimCLRModel, SimSiamModel, BarlowTwinsModel, 
+          BYOLModel, NNCLRModel, NNSimSiamModel, NNBYOLModel]
+
+bench_results = []
+gpu_memory_usage = []
+
+# loop through configurations and train models
+for batch_size in batch_sizes:
+    for model_name, BenchmarkModel in zip(model_names, models):
+        runs = []
+        for seed in range(n_runs):
+            pl.seed_everything(seed)
+            dataloader_train_ssl, dataloader_train_kNN, dataloader_test = get_data_loaders(batch_size)
+            benchmark_model = BenchmarkModel(dataloader_train_kNN, classes)
+
+            logger = TensorBoardLogger('imagenette_runs', version=model_name)
+
+            trainer = pl.Trainer(max_epochs=max_epochs, 
+                                gpus=gpus,
+                                logger=logger,
+                                distributed_backend=distributed_backend,
+                                default_root_dir=logs_root_dir)
+            trainer.fit(
+                benchmark_model,
+                train_dataloader=dataloader_train_ssl,
+                val_dataloaders=dataloader_test
+            )
+            gpu_memory_usage.append(torch.cuda.max_memory_allocated())
+            torch.cuda.reset_peak_memory_stats()
+            runs.append(benchmark_model.max_accuracy)
+
+            # delete model and trainer + free up cuda memory
+            del benchmark_model
+            del trainer
+            torch.cuda.empty_cache()
+        bench_results.append(runs)
+
+for result, model, gpu_usage in zip(bench_results, model_names, gpu_memory_usage):
+    result_np = np.array(result)
+    mean = result_np.mean()
+    std = result_np.std()
+    print(f'{model}: {mean:.2f} +- {std:.2f}, GPU used: {gpu_usage / (1024.0**3):.1f} GByte', flush=True)

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -49,7 +49,7 @@ distributed_backend = 'ddp' if torch.cuda.device_count() > 1 else None
 path_to_train = '/datasets/imagenette2-160/train/'
 path_to_test = '/datasets/imagenette2-160/val/'
 
-# Use SimCLR augmentations, additionally, disable blur
+# Use SimCLR augmentations
 collate_fn = lightly.data.SimCLRCollateFunction(
     input_size=input_size,
 )


### PR DESCRIPTION
### Changes

closes https://github.com/lightly-ai/lightly/issues/279

- Add imagenette benchmark
- Add all current models
- Use torchvision resnet backbone

This is WIP since I'm currently running the benchmark to see how the models train. 

This is the accuracy and loss for MoCo with input size 128 and trained for 100 out of 200 epochs (~30 min on a V100)
![image](https://user-images.githubusercontent.com/1522766/118561415-372cd200-b76b-11eb-8e5c-6d4424584832.png)

![image](https://user-images.githubusercontent.com/1522766/120445173-a79d3b00-c388-11eb-9701-8402b0a1fe77.png)