### PR TITLE
390 auto num workers pw

### DIFF
--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -27,6 +27,15 @@ def print_as_warning(message: str):
     warnings.formatwarning = old_format
 
 
+def available_cpu_count():
+    """Returns the number of CPUs which can be used by the process.
+
+    This number is not equivalent to the number of CPUs in the system.
+
+    """
+    return len(os.sched_getaffinity(0))
+
+
 def fix_input_path(path):
     """Fix broken relative paths.
 

--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -27,13 +27,13 @@ def print_as_warning(message: str):
     warnings.formatwarning = old_format
 
 
-def available_cpu_count():
-    """Returns the number of CPUs which can be used by the process.
+def cpu_count():
+    """Returns the number of CPUs which are present in the system.
 
-    This number is not equivalent to the number of CPUs in the system.
+    This number is not equivalent to the number of available CPUs to the process.
 
     """
-    return len(os.sched_getaffinity(0))
+    return os.cpu_count()
 
 
 def fix_input_path(path):

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -63,7 +63,7 @@ collate:
 loader:
   batch_size: 16              # Batch size for training / inference.
   shuffle: True               # Whether to reshuffle data each epoch.
-  num_workers: 1              # Number of workers pre-fetching batches.
+  num_workers: -1             # Number of workers pre-fetching batches (-1 == number of available cores).
   drop_last: True             # Wether to drop the last batch during training.
 
 # trainer namespace: Passed to pytorch_lightning.Trainer.

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -29,6 +29,7 @@ from lightly.cli._helpers import get_ptmodel_from_config
 from lightly.cli._helpers import fix_input_path
 from lightly.cli._helpers import load_state_dict_from_url
 from lightly.cli._helpers import load_from_state_dict
+from lightly.cli._helpers import available_cpu_count
 
 
 def _embed_cli(cfg, is_cli_call=True):
@@ -58,12 +59,18 @@ def _embed_cli(cfg, is_cli_call=True):
 
     dataset = LightlyDataset(input_dir, transform=transform)
 
+    # disable drop_last and shuffle
     cfg['loader']['drop_last'] = False
     cfg['loader']['shuffle'] = False
     cfg['loader']['batch_size'] = min(
         cfg['loader']['batch_size'],
         len(dataset)
     )
+
+    # determine the number of available cores
+    if cfg['loader']['num_workers'] < 0:
+        cfg['loader']['num_workers'] = available_cpu_count()
+
     dataloader = torch.utils.data.DataLoader(dataset, **cfg['loader'])
 
     # load the PyTorch state dictionary and map it to the current device    

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -29,7 +29,7 @@ from lightly.cli._helpers import get_ptmodel_from_config
 from lightly.cli._helpers import fix_input_path
 from lightly.cli._helpers import load_state_dict_from_url
 from lightly.cli._helpers import load_from_state_dict
-from lightly.cli._helpers import available_cpu_count
+from lightly.cli._helpers import cpu_count
 
 
 def _embed_cli(cfg, is_cli_call=True):
@@ -69,7 +69,7 @@ def _embed_cli(cfg, is_cli_call=True):
 
     # determine the number of available cores
     if cfg['loader']['num_workers'] < 0:
-        cfg['loader']['num_workers'] = available_cpu_count()
+        cfg['loader']['num_workers'] = cpu_count()
 
     dataloader = torch.utils.data.DataLoader(dataset, **cfg['loader'])
 

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -29,7 +29,7 @@ from lightly.cli._helpers import get_ptmodel_from_config
 from lightly.cli._helpers import fix_input_path
 from lightly.cli._helpers import load_state_dict_from_url
 from lightly.cli._helpers import load_from_state_dict
-from lightly.cli._helpers import available_cpu_count
+from lightly.cli._helpers import cpu_count
 
 
 def _train_cli(cfg, is_cli_call=True):
@@ -61,7 +61,7 @@ def _train_cli(cfg, is_cli_call=True):
 
     # determine the number of available cores
     if cfg['loader']['num_workers'] < 0:
-        cfg['loader']['num_workers'] = available_cpu_count()
+        cfg['loader']['num_workers'] = cpu_count()
 
     state_dict = None
     checkpoint = cfg['checkpoint']

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -29,6 +29,7 @@ from lightly.cli._helpers import get_ptmodel_from_config
 from lightly.cli._helpers import fix_input_path
 from lightly.cli._helpers import load_state_dict_from_url
 from lightly.cli._helpers import load_from_state_dict
+from lightly.cli._helpers import available_cpu_count
 
 
 def _train_cli(cfg, is_cli_call=True):
@@ -57,6 +58,10 @@ def _train_cli(cfg, is_cli_call=True):
         msg += 'You can specify the batch size via the loader key-word: '
         msg += 'loader.batch_size=BSZ'
         warnings.warn(msg)
+
+    # determine the number of available cores
+    if cfg['loader']['num_workers'] < 0:
+        cfg['loader']['num_workers'] = available_cpu_count()
 
     state_dict = None
     checkpoint = cfg['checkpoint']

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -14,7 +14,7 @@ import hydra
 import torchvision
 from torch.utils.hipify.hipify_python import bcolors
 
-from lightly.cli._helpers import fix_input_path, print_as_warning, available_cpu_count
+from lightly.cli._helpers import fix_input_path, print_as_warning, cpu_count
 
 from lightly.api.utils import getenv
 from lightly.api.api_workflow_client import ApiWorkflowClient
@@ -56,7 +56,7 @@ def _upload_cli(cfg, is_cli_call=True):
 
     # determine the number of available cores
     if cfg['loader']['num_workers'] < 0:
-        cfg['loader']['num_workers'] = available_cpu_count()
+        cfg['loader']['num_workers'] = cpu_count()
 
     size = cfg['resize']
     if not isinstance(size, int):

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -14,7 +14,7 @@ import hydra
 import torchvision
 from torch.utils.hipify.hipify_python import bcolors
 
-from lightly.cli._helpers import fix_input_path, print_as_warning
+from lightly.cli._helpers import fix_input_path, print_as_warning, available_cpu_count
 
 from lightly.api.utils import getenv
 from lightly.api.api_workflow_client import ApiWorkflowClient
@@ -53,6 +53,10 @@ def _upload_cli(cfg, is_cli_call=True):
     if cli_api_args_wrong:
         print_as_warning('For help, try: lightly-upload --help')
         return
+
+    # determine the number of available cores
+    if cfg['loader']['num_workers'] < 0:
+        cfg['loader']['num_workers'] = available_cpu_count()
 
     size = cfg['resize']
     if not isinstance(size, int):


### PR DESCRIPTION
# 390 Automatically set num_workers

Closes #390.

- Wrote a helper function to find the number of available CPUs.
- Used the helper function to automatically set `num_workers` if `cfg.loader.num_workers=-1`.
- Set the default value of `cfg.loader.num_workers` to `-1`

