### PR TITLE
384 speed up dataset indexing pw

### DIFF
--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -33,9 +33,7 @@ def _contains_videos(root: str, extensions: tuple):
         True if root contains subdirectories else false.
     """
     with os.scandir(root) as scan_dir:
-        return any(
-            [f.name.lower().endswith(extensions) for f in scan_dir]
-        )
+        return any(f.name.lower().endswith(extensions) for f in scan_dir)
 
 
 def _is_lightly_output_dir(dirname: str):
@@ -62,9 +60,8 @@ def _contains_subdirs(root: str):
 
     """
     with os.scandir(root) as scan_dir:
-        return any(
-            [f.is_dir() for f in scan_dir if not _is_lightly_output_dir(f.name)]
-        )
+        return any(f.is_dir() for f in scan_dir \
+            if not _is_lightly_output_dir(f.name))
 
 
 def _load_dataset_from_folder(root: str, transform):

--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -60,8 +60,8 @@ def _contains_subdirs(root: str):
 
     """
     with os.scandir(root) as scan_dir:
-        return any(f.is_dir() for f in scan_dir \
-            if not _is_lightly_output_dir(f.name))
+        return any(not _is_lightly_output_dir(f.name) for f in scan_dir \
+            if f.is_dir())
 
 
 def _load_dataset_from_folder(root: str, transform):

--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -32,9 +32,9 @@ def _contains_videos(root: str, extensions: tuple):
     Returns:
         True if root contains subdirectories else false.
     """
-    list_dir = os.listdir(root)
+    scan_dir = os.scandir(root)
     is_video = \
-        [f.lower().endswith(extensions) for f in list_dir]
+        [f.name.lower().endswith(extensions) for f in scan_dir]
     return any(is_video)
 
 
@@ -61,10 +61,9 @@ def _contains_subdirs(root: str):
         True if root contains subdirectories else false.
 
     """
-    list_dir = os.listdir(root)
-    list_dir = list(filter(lambda x: not _is_lightly_output_dir(x), list_dir))
+    scan_dir = os.scandir(root)
     is_dir = \
-        [os.path.isdir(os.path.join(root, f)) for f in list_dir]
+        [f.is_dir() for f in scan_dir if not _is_lightly_output_dir(f.name)]
     return any(is_dir)
 
 

--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -32,10 +32,10 @@ def _contains_videos(root: str, extensions: tuple):
     Returns:
         True if root contains subdirectories else false.
     """
-    scan_dir = os.scandir(root)
-    is_video = \
-        [f.name.lower().endswith(extensions) for f in scan_dir]
-    return any(is_video)
+    with os.scandir(root) as scan_dir:
+        return any(
+            [f.name.lower().endswith(extensions) for f in scan_dir]
+        )
 
 
 def _is_lightly_output_dir(dirname: str):
@@ -61,10 +61,10 @@ def _contains_subdirs(root: str):
         True if root contains subdirectories else false.
 
     """
-    scan_dir = os.scandir(root)
-    is_dir = \
-        [f.is_dir() for f in scan_dir if not _is_lightly_output_dir(f.name)]
-    return any(is_dir)
+    with os.scandir(root) as scan_dir:
+        return any(
+            [f.is_dir() for f in scan_dir if not _is_lightly_output_dir(f.name)]
+        )
 
 
 def _load_dataset_from_folder(root: str, transform):

--- a/lightly/data/_image.py
+++ b/lightly/data/_image.py
@@ -3,13 +3,15 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+from typing import List, Tuple
+
 import os
 import torchvision.datasets as datasets
 
 from lightly.data._image_loaders import default_loader
 
 
-def _make_dataset(directory, extensions=None, is_valid_file=None):
+def _make_dataset(directory, extensions=None, is_valid_file=None) -> List[Tuple[str, int]]:
     """Returns a list of all image files with targets in the directory.
 
     Args:
@@ -46,6 +48,8 @@ def _make_dataset(directory, extensions=None, is_valid_file=None):
         if not _is_valid_file(f.name):
             continue
 
+        # convention: the label of all images is 0, based on the fact that
+        # they are all in the same directory
         item = (f.path, 0)
         instances.append(item)
 

--- a/lightly/data/_image.py
+++ b/lightly/data/_image.py
@@ -41,16 +41,15 @@ def _make_dataset(directory, extensions=None, is_valid_file=None):
         _is_valid_file = is_valid_file
 
     instances = []
-    for fname in os.listdir(directory):
+    for f in os.scandir(directory):
 
-        if not _is_valid_file(fname):
+        if not _is_valid_file(f.name):
             continue
 
-        path = os.path.join(directory, fname)
-        item = (path, 0)
+        item = (f.path, 0)
         instances.append(item)
 
-    return instances
+    return sorted(instances, key=lambda x: x[0]) # sort by path
 
 
 class DatasetFolder(datasets.VisionDataset):


### PR DESCRIPTION
# 384 speed up dataset indexing

Closes #384.

I made use of `os.scandir` to get a speed-up of approximately 2.

| Dataset | Images | Before | After |
|----------|---------|---------|------|
| `bdd100k/train` | 70000 | 500ms | 270ms |

The biggest speed-up comes from using `os.scandir` when checking for subdirectories. As described [here](https://docs.python.org/3/library/os.html#os.scandir), `os.scandir` can "significantly increase the performance of code that also needs file type or file attribute information".