### PR TITLE
bug active learning agent not working with scorer.model output being a generator

### DIFF
--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -190,14 +190,15 @@ class ActiveLearningAgent:
         # calculate active learning scores
         scores_dict = None
         if al_scorer is not None:
+            scores_dict = al_scorer.calculate_scores()
             no_query_samples = len(self.query_set)
-            no_query_samples_with_scores = len(al_scorer.model_output)
+            no_query_samples_with_scores = len(list(scores_dict.values())[0])
             if no_query_samples != no_query_samples_with_scores:
                 raise ValueError(
                     f'Number of query samples ({no_query_samples}) must match '
                     f'the number of predictions ({no_query_samples_with_scores})!'
                 )
-            scores_dict = al_scorer.calculate_scores()
+
 
         # perform the sampling
         new_tag_data = self.api_workflow_client.sampling(

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -192,7 +192,7 @@ class ActiveLearningAgent:
         if al_scorer is not None:
             scores_dict = al_scorer.calculate_scores()
 
-            # Check if the number the length of the query_set and the scores are the same
+            # Check if the length of the query_set and each of the scores are the same
             no_query_samples = len(self.query_set)
             for score in scores_dict.values():
                 no_query_samples_with_scores = len(score)

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -191,13 +191,16 @@ class ActiveLearningAgent:
         scores_dict = None
         if al_scorer is not None:
             scores_dict = al_scorer.calculate_scores()
+
+            # Check if the number the length of the query_set and the scores are the same
             no_query_samples = len(self.query_set)
-            no_query_samples_with_scores = len(list(scores_dict.values())[0])
-            if no_query_samples != no_query_samples_with_scores:
-                raise ValueError(
-                    f'Number of query samples ({no_query_samples}) must match '
-                    f'the number of predictions ({no_query_samples_with_scores})!'
-                )
+            for score in scores_dict.values():
+                no_query_samples_with_scores = len(score)
+                if no_query_samples != no_query_samples_with_scores:
+                    raise ValueError(
+                        f'Number of query samples ({no_query_samples}) must match '
+                        f'the number of predictions ({no_query_samples_with_scores})!'
+                    )
 
 
         # perform the sampling

--- a/tests/active_learning/test_active_learning_agent.py
+++ b/tests/active_learning/test_active_learning_agent.py
@@ -72,7 +72,7 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
         method = SamplingMethod.CORAL
         n_samples = len(agent.labeled_set) + 2
 
-        n_predictions = len(agent.query_set) - 3  # the -3 should cause an error
+        n_predictions = len(agent.query_set)
         predictions = np.random.rand(n_predictions, no_classes, width, height).astype(np.float32)
         predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]
         predictions_generator = (predictions_normalized[i] for i in range(n_predictions))


### PR DESCRIPTION
closes #404 
 ## Description

- reproduces the error by creating a corresponding unittest
- fixes the error by making the check on the values of the `scores_dict`, not on the `model_output`
