### PR TITLE
running lightly magic, the output is weird

### DIFF
--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -71,6 +71,8 @@ trainer:
   gpus: 1                     # Number of gpus to use for training.
   max_epochs: 100             # Number of epochs to train for.
   precision: 32               # If set to 16, will use half-precision.
+  weights_summary: 'top'      # how to print the model architecture, one of {None, 'top', full},
+                                #see https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#weights-summary
 
 # checkpoint_callback namespace: Modify the checkpoint callback
 checkpoint_callback:

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -71,7 +71,7 @@ trainer:
   gpus: 1                     # Number of gpus to use for training.
   max_epochs: 100             # Number of epochs to train for.
   precision: 32               # If set to 16, will use half-precision.
-  weights_summary: 'top'      # how to print the model architecture, one of {None, 'top', full},
+  weights_summary: 'top'      # how to print the model architecture, one of {None, top, full},
                                 #see https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#weights-summary
 
 # checkpoint_callback namespace: Modify the checkpoint callback

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -22,6 +22,7 @@ def _lightly_cli(cfg, is_cli_call=True):
     if cfg['trainer']['max_epochs'] > 0:
         print('#' * 10 + ' Starting to train an embedding model.')
         checkpoint = _train_cli(cfg, is_cli_call)
+        cfg['trainer']['weights_summary'] = None
     else:
         checkpoint = ''
 

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -22,7 +22,6 @@ def _lightly_cli(cfg, is_cli_call=True):
     if cfg['trainer']['max_epochs'] > 0:
         print('#' * 10 + ' Starting to train an embedding model.')
         checkpoint = _train_cli(cfg, is_cli_call)
-        cfg['trainer']['weights_summary'] = None
     else:
         checkpoint = ''
 

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -157,6 +157,9 @@ def train_cli(cfg):
         >>>
         >>> # train model for 10 epochs
         >>> lightly-train input_dir=data/ trainer.max_epochs=10
+        >>>
+        >>> # print a full summary of the model
+        >>> lightly-train input_dir=data/ trainer.weights_summary=full
 
     """
     return _train_cli(cfg)

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -45,11 +45,16 @@ def _train_cli(cfg, is_cli_call=True):
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
 
+    if cfg["trainer"]["weights_summary"] == "None":
+        cfg["trainer"]["weights_summary"] = None
+
     if torch.cuda.is_available():
         device = 'cuda'
     elif cfg['trainer'] and cfg['trainer']['gpus']:
         device = 'cpu'
         cfg['trainer']['gpus'] = 0
+    else:
+        device = 'cpu'
 
     if cfg['loader']['batch_size'] < 64:
         msg = 'Training a self-supervised model with a small batch size: {}! '

--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -78,6 +78,7 @@ class BaseEmbedding(lightning.LightningModule):
                 min_epochs: (int) Minimum number of epochs to train
                 max_epochs: (int) Maximum number of epochs to train
                 gpus: (int) number of gpus to use
+                weights_summary: (str) how to print a summary of the model and weights (number, size)
 
         Returns:
             A trained encoder, ready for embedding datasets.

--- a/tests/cli/test_cli_train.py
+++ b/tests/cli/test_cli_train.py
@@ -1,0 +1,75 @@
+import os
+import re
+import sys
+import tempfile
+
+import torchvision
+from hydra.experimental import compose, initialize
+
+import lightly
+from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
+
+
+class TestCLITrain(MockedApiWorkflowSetup):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.modules["lightly.cli.upload_cli"].ApiWorkflowClient = MockedApiWorkflowClient
+
+    def setUp(self):
+        MockedApiWorkflowSetup.setUp(self)
+        self.create_fake_dataset()
+        with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
+            self.cfg = compose(config_name="config", overrides=[
+                "token='123'",
+                f"input_dir={self.folder_path}",
+                "trainer.max_epochs=0"
+            ])
+
+    def create_fake_dataset(self):
+        n_data = 5
+        self.dataset = torchvision.datasets.FakeData(size=n_data, image_size=(3, 32, 32))
+
+        self.folder_path = tempfile.mkdtemp()
+        sample_names = [f'img_{i}.jpg' for i in range(n_data)]
+        self.sample_names = sample_names
+        for sample_idx in range(n_data):
+            data = self.dataset[sample_idx]
+            path = os.path.join(self.folder_path, sample_names[sample_idx])
+            data[0].save(path)
+
+    def parse_cli_string(self, cli_words: str):
+        cli_words = cli_words.replace("lightly-train ", "")
+        cli_words = re.split("=| ", cli_words)
+        assert len(cli_words) % 2 == 0
+        dict_keys = cli_words[0::2]
+        dict_values = cli_words[1::2]
+        for key, value in zip(dict_keys, dict_values):
+            value = value.strip('\"')
+            value = value.strip('\'')
+            key_parts = key.split(".")
+            if len(key_parts) == 1:
+                self.cfg[key_parts[0]]= value
+            elif len(key_parts) == 2:
+                self.cfg[key_parts[0]][key_parts[1]] = value
+            else:
+                raise ValueError
+
+    def test_parse_cli_string(self):
+        cli_string = "lightly-train trainer.weights_summary=top"
+        self.parse_cli_string(cli_string)
+        assert self.cfg["trainer"]["weights_summary"] == 'top'
+
+    def test_train_weights_summary(self):
+        for weights_summary in ["None", "top", "full"]:
+            cli_string = f"lightly-train trainer.weights_summary={weights_summary}"
+            with self.subTest(cli_string):
+                self.parse_cli_string(cli_string)
+                lightly.cli.train_cli(self.cfg)
+
+    def tearDown(self) -> None:
+        for filename in ["embeddings.csv", "embeddings_sorted.csv"]:
+            try:
+                os.remove(filename)
+            except FileNotFoundError:
+                pass


### PR DESCRIPTION
closes https://github.com/lightly-ai/lightly-core/issues/699

## Description
Adds the option to change the `trainer.weights_summary`. This option is used by pytorch lightning: https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#weights-summary

## Double print
The double printing is caused by a pytorch lightning bug: https://github.com/PyTorchLightning/pytorch-lightning/issues/3458
- on pytorch-lightning==1.04: working, but double print
- on pytorch-lightning==1.3.5: working, without double print

<img width="1364" alt="image" src="https://user-images.githubusercontent.com/20324507/122376754-bb3dc980-cf64-11eb-822a-5f0ed5ad4338.png">


## Tests
- [x] My change needs new tests
- [x] I have added/adapted tests accordingly.
- [x] I have manually tested the change. 

If applicable, describe the manual test procedure, e.g:
```bash
pip uninstall lightly
export BRANCH_NAME="699-running-lightly-magic,-the-output-is-weird-me"
pip install "git+https://github.com/lightly-ai/lightly.git@$BRANCH_NAME"
lightly-train input_dir='/datasets' trainer.max_epochs=0 trainer.weights_summary=None
```

## Documentation
- [x] I have added docstrings to all changed/added public functions/methods.
- [ ] My change requires a change to the documentation ( `.rst` files).
- [ ] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.
