### PR TITLE
created unmocked scripts to test the api latency and upload performance

### DIFF
--- a/tests/UNMOCKED_end2end_tests/README.md
+++ b/tests/UNMOCKED_end2end_tests/README.md
@@ -1,6 +1,7 @@
 This repository contains scripts to test the python package with a server. 
-You only need an account on the server and a dataset.
 
+## Testing the Server API with active lerning
+You only need an account on the server and a dataset.
 Once you have a token from our production server `https://app.lightly.ai`, you can run:
 
 ```bash
@@ -12,3 +13,13 @@ If you want to test on another server, e.g. staging, get your token from there a
 export LIGHTLY_SERVER_LOCATION=https://api-staging.lightly.ai
 python tests/UNMOCKED_end2end_tests/test_api.py path/to/dataset TOKEN_FROM_STAGING
 ```
+
+## Testing the API latency
+This needs a token, but no dataset
+```bash
+TOKEN="MY_TOKEN" && python tests/UNMOCKED_end2end_tests/test_api_latency.py
+```
+
+## Testing the upload speed
+Use the pycharm profile with yappi to run the function [benchmark_upload.py:benchmark_upload()](benchmark_upload.py). 
+You can use the following script for example: [call_benchmark_upload](call_benchmark_upload.py)

--- a/tests/UNMOCKED_end2end_tests/benchmark_upload.py
+++ b/tests/UNMOCKED_end2end_tests/benchmark_upload.py
@@ -1,0 +1,45 @@
+import sys
+
+from hydra.experimental import initialize, compose
+
+from lightly.api import ApiWorkflowClient
+from lightly.cli import upload_cli
+
+
+def create_new_dataset(path_to_dataset: str, token: str, dataset_name: str):
+    api_workflow_client = ApiWorkflowClient(token=token)
+
+    # create the dataset
+    api_workflow_client.create_new_dataset_with_unique_name(dataset_basename=dataset_name)
+
+    # upload to the dataset
+    initialize(config_path="../../lightly/cli/config", job_name="test_app")
+    cfg = compose(config_name="config", overrides=[
+        f"input_dir='{path_to_dataset}'",
+        f"token='{token}'",
+        f"dataset_id={api_workflow_client.dataset_id}",
+        f"loader.num_workers=12"
+        ])
+    upload_cli(cfg)
+
+    api_workflow_client.delete_dataset_by_id(api_workflow_client.dataset_id)
+
+
+
+def mock_dataset_upload_to_measure():
+    pass
+
+def benchmark_upload(path_to_dataset, token):
+    create_new_dataset(path_to_dataset, token, "test_benchmark_upload")
+
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1 + 2:
+        path_to_dataset, token = \
+            (sys.argv[1 + i] for i in range(2))
+    else:
+        raise ValueError("ERROR in number of command line arguments, must be 2."
+                         "Example: python test_api path/to/dataset TOKEN")
+
+    benchmark_upload(path_to_dataset=path_to_dataset, token=token)

--- a/tests/UNMOCKED_end2end_tests/benchmark_upload.py
+++ b/tests/UNMOCKED_end2end_tests/benchmark_upload.py
@@ -6,6 +6,23 @@ from lightly.api import ApiWorkflowClient
 from lightly.cli import upload_cli
 
 def benchmark_upload(path_to_dataset, token):
+    """
+    This function creates a new dataset on the Lightly web platform.
+    Then it uploads the dataset to it using the function for the cli command.
+    Last, it deletes the dataset again.
+
+    Call this function with a profiler to see which functions take up the most time
+    and how long the upload takes in total. This knowledge allows to optimize the upload.
+
+    Args:
+        path_to_dataset:
+            Filepath to the dataset to be uploaded.
+        token:
+            The token of the Lightly Web platform
+
+    Returns:
+
+    """
     api_workflow_client = ApiWorkflowClient(token=token)
 
     # create the dataset
@@ -20,6 +37,8 @@ def benchmark_upload(path_to_dataset, token):
         f"loader.num_workers=12"
     ])
     upload_cli(cfg)
+
+    #delete the dataset again
     api_workflow_client.delete_dataset_by_id(api_workflow_client.dataset_id)
 
 
@@ -29,6 +48,6 @@ if __name__ == "__main__":
             (sys.argv[1 + i] for i in range(2))
     else:
         raise ValueError("ERROR in number of command line arguments, must be 2."
-                         "Example: python test_api path/to/dataset TOKEN")
+                         "Example: python benchmark_upload path/to/dataset TOKEN")
 
     benchmark_upload(path_to_dataset=path_to_dataset, token=token)

--- a/tests/UNMOCKED_end2end_tests/benchmark_upload.py
+++ b/tests/UNMOCKED_end2end_tests/benchmark_upload.py
@@ -5,12 +5,11 @@ from hydra.experimental import initialize, compose
 from lightly.api import ApiWorkflowClient
 from lightly.cli import upload_cli
 
-
-def create_new_dataset(path_to_dataset: str, token: str, dataset_name: str):
+def benchmark_upload(path_to_dataset, token):
     api_workflow_client = ApiWorkflowClient(token=token)
 
     # create the dataset
-    api_workflow_client.create_new_dataset_with_unique_name(dataset_basename=dataset_name)
+    api_workflow_client.create_new_dataset_with_unique_name(dataset_basename="benchmark_upload")
 
     # upload to the dataset
     initialize(config_path="../../lightly/cli/config", job_name="test_app")
@@ -19,19 +18,9 @@ def create_new_dataset(path_to_dataset: str, token: str, dataset_name: str):
         f"token='{token}'",
         f"dataset_id={api_workflow_client.dataset_id}",
         f"loader.num_workers=12"
-        ])
+    ])
     upload_cli(cfg)
-
     api_workflow_client.delete_dataset_by_id(api_workflow_client.dataset_id)
-
-
-
-def mock_dataset_upload_to_measure():
-    pass
-
-def benchmark_upload(path_to_dataset, token):
-    create_new_dataset(path_to_dataset, token, "test_benchmark_upload")
-
 
 
 if __name__ == "__main__":

--- a/tests/UNMOCKED_end2end_tests/call_benchmark_upload.py
+++ b/tests/UNMOCKED_end2end_tests/call_benchmark_upload.py
@@ -1,0 +1,8 @@
+import os
+
+from tests.UNMOCKED_end2end_tests.benchmark_upload import benchmark_upload
+
+path_to_dataset = "/path/to/my/dataset"
+token = os.environ[f"TOKEN"]
+
+benchmark_upload(path_to_dataset=path_to_dataset, token=token)

--- a/tests/UNMOCKED_end2end_tests/test_api_latency.py
+++ b/tests/UNMOCKED_end2end_tests/test_api_latency.py
@@ -7,23 +7,24 @@ from tqdm import tqdm
 from lightly.api import ApiWorkflowClient
 from lightly.openapi_generated.swagger_client import Configuration, ApiClient, QuotaApi
 
-token = os.getenv("TOKEN")
-api_client = ApiWorkflowClient(token=token).api_client
-quota_api = QuotaApi(api_client)
+if __name__ == "__main__":
+    token = os.getenv("TOKEN")
+    api_client = ApiWorkflowClient(token=token).api_client
+    quota_api = QuotaApi(api_client)
 
-no_iters = 200
+    no_iters = 200
 
-latencies = np.zeros(no_iters)
-for i in tqdm(range(no_iters)):
-    start = time.time()
-    quota_api.get_quota_maximum_dataset_size()
-    duration = time.time()-start
-    latencies[i] = duration
+    latencies = np.zeros(no_iters)
+    for i in tqdm(range(no_iters)):
+        start = time.time()
+        quota_api.get_quota_maximum_dataset_size()
+        duration = time.time()-start
+        latencies[i] = duration
 
-def format_latency(latency: float):
-    return f"{latency*1000:.1f}ms"
+    def format_latency(latency: float):
+        return f"{latency*1000:.1f}ms"
 
-values = [('min')]
-print(f"Latencies: min: {format_latency(np.min(latencies))}, mean: {format_latency(np.mean(latencies))}, max: {format_latency(np.max(latencies))}")
-print(f"\nPINGING TO GOOGLE")
-response = os.system("ping -c 1 " + "google.com")
+    values = [('min')]
+    print(f"Latencies: min: {format_latency(np.min(latencies))}, mean: {format_latency(np.mean(latencies))}, max: {format_latency(np.max(latencies))}")
+    print(f"\nPINGING TO GOOGLE")
+    response = os.system("ping -c 1 " + "google.com")

--- a/tests/UNMOCKED_end2end_tests/test_api_latency.py
+++ b/tests/UNMOCKED_end2end_tests/test_api_latency.py
@@ -12,10 +12,10 @@ if __name__ == "__main__":
     api_client = ApiWorkflowClient(token=token).api_client
     quota_api = QuotaApi(api_client)
 
-    no_iters = 200
+    n_iters = 200
 
-    latencies = np.zeros(no_iters)
-    for i in tqdm(range(no_iters)):
+    latencies = np.zeros(n_iters)
+    for i in tqdm(range(n_iters)):
         start = time.time()
         quota_api.get_quota_maximum_dataset_size()
         duration = time.time()-start

--- a/tests/UNMOCKED_end2end_tests/test_api_latency.py
+++ b/tests/UNMOCKED_end2end_tests/test_api_latency.py
@@ -1,0 +1,29 @@
+import os
+import time
+
+import numpy as np
+from tqdm import tqdm
+
+from lightly.api import ApiWorkflowClient
+from lightly.openapi_generated.swagger_client import Configuration, ApiClient, QuotaApi
+
+token = os.getenv("TOKEN")
+api_client = ApiWorkflowClient(token=token).api_client
+quota_api = QuotaApi(api_client)
+
+no_iters = 200
+
+latencies = np.zeros(no_iters)
+for i in tqdm(range(no_iters)):
+    start = time.time()
+    quota_api.get_quota_maximum_dataset_size()
+    duration = time.time()-start
+    latencies[i] = duration
+
+def format_latency(latency: float):
+    return f"{latency*1000:.1f}ms"
+
+values = [('min')]
+print(f"Latencies: min: {format_latency(np.min(latencies))}, mean: {format_latency(np.mean(latencies))}, max: {format_latency(np.max(latencies))}")
+print(f"\nPINGING TO GOOGLE")
+response = os.system("ping -c 1 " + "google.com")


### PR DESCRIPTION
closes #410

## Script to test api latency
- It calls the `get_quota()` endpoint 200 times and reports the latency, also in comparison to pinging google.
<img width="502" alt="image" src="https://user-images.githubusercontent.com/20324507/122582828-e1dd2c80-d058-11eb-9e92-6c0013b7517a.png">

## Script to benchmark the upload
- There is a small script to run an upload of a dataset to the server. I tried to implement general benchmarking code with cProfile and Yappi, but they did not provide good information that can be easily analysed. Thus I kept using the PyCharm profiler to get nice graphs.
![image (3)](https://user-images.githubusercontent.com/20324507/122583294-5dd77480-d059-11eb-8e81-1c9d294f9117.png)

## Other
- Updated readme with instructions how to use these scripts