### PR TITLE
make upload more performant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ lightly_outputs
 .eggs
 tests/UNMOCKED_end2end_tests/call_test_api.py
 tests/UNMOCKED_end2end_tests/get_versions_all_apis.py
+tests/UNMOCKED_end2end_tests/call_benchmark_upload_private.py

--- a/lightly/__init__.py
+++ b/lightly/__init__.py
@@ -92,11 +92,11 @@ except NameError:
 
 
 if __LIGHTLY_SETUP__:
-    # setting up lightly
+    # setting up lightly
     msg = f'Partial import of {__name__}=={__version__} during build process.' 
     print(msg)
 else:
-    # see if prefetch_generator is available
+    # see if prefetch_generator is available
     try:
         import prefetch_generator
     except ImportError:

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -75,6 +75,9 @@ class _UploadDatasetMixin:
         pbar = tqdm.tqdm(unit='imgs', total=len(dataset))
         tqdm_lock = tqdm.tqdm.get_lock()
 
+        # calculate the files size more efficiently
+        lightly_utils.image_processing.metadata._size_in_bytes = lambda img: 0
+
         # define lambda function for concurrent upload
         def lambda_(i):
             # load image
@@ -136,8 +139,8 @@ class _UploadDatasetMixin:
             return False
 
         # calculate metadata, and check if corrupted
-        lightly_utils.image_processing.metadata._size_in_bytes = lambda img: os.path.getsize(filepath)
         metadata = image_processing.Metadata(image).to_dict()
+        metadata["sizeInBytes"] = os.path.getsize(filepath)
 
         # try to get exif data
         try:

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -79,7 +79,7 @@ class _UploadDatasetMixin:
         def lambda_(i):
             # load image
             image, label, filename = dataset[i]
-            filepath = dataset.get_filepath_from_filename(filename)
+            filepath = dataset.get_filepath_from_filename(filename, image)
             # try to upload image
             try:
                 self._upload_single_image(

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -1,6 +1,9 @@
+import os
 import warnings
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Union
+
+import lightly_utils.image_processing
 import tqdm
 
 from lightly.openapi_generated.swagger_client import TagCreator
@@ -76,12 +79,14 @@ class _UploadDatasetMixin:
         def lambda_(i):
             # load image
             image, label, filename = dataset[i]
+            filepath = dataset.get_filepath_from_filename(filename)
             # try to upload image
             try:
                 self._upload_single_image(
                     image=image,
                     label=label,
                     filename=filename,
+                    filepath=filepath,
                     mode=mode,
                 )
                 success = True
@@ -117,7 +122,7 @@ class _UploadDatasetMixin:
         initial_tag_create_request = InitialTagCreateRequest(img_type=img_type, creator=TagCreator.USER_PIP)
         self.tags_api.create_initial_tag_by_dataset_id(body=initial_tag_create_request, dataset_id=self.dataset_id)
 
-    def _upload_single_image(self, image, label, filename: str, mode):
+    def _upload_single_image(self, image, label, filename: str, filepath: str, mode):
         """Uploads a single image to the Lightly platform.
 
         """
@@ -131,6 +136,7 @@ class _UploadDatasetMixin:
             return False
 
         # calculate metadata, and check if corrupted
+        lightly_utils.image_processing.metadata._size_in_bytes = lambda img: os.path.getsize(filepath)
         metadata = image_processing.Metadata(image).to_dict()
 
         # try to get exif data
@@ -177,21 +183,21 @@ class _UploadDatasetMixin:
             thumbnail.thumbnail.close()
 
         if not metadata['is_corrupted'] and mode == "full":
-            image_to_upload = PIL_to_bytes(image)
+            with open(filepath, 'rb') as image_to_upload:
 
-            signed_url = retry(
-                self.samples_api.get_sample_image_write_url_by_id,
-                dataset_id=self.dataset_id,
-                sample_id=sample_id,
-                is_thumbnail=False
-            )
+                signed_url = retry(
+                    self.samples_api.get_sample_image_write_url_by_id,
+                    dataset_id=self.dataset_id,
+                    sample_id=sample_id,
+                    is_thumbnail=False
+                )
 
-            # try to upload full image
-            retry(
-                self.upload_file_with_signed_url,
-                image_to_upload,
-                signed_url
-            )
+                # try to upload full image
+                retry(
+                    self.upload_file_with_signed_url,
+                    image_to_upload,
+                    signed_url
+                )
 
             image.close()
 

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -277,6 +277,9 @@ class LightlyDataset:
         for i, filename in zip(indices, filenames):
             _dump_image(self.dataset, output_dir, filename, i, fmt=format)
 
+    def get_filepath_from_filename(self, filename: str):
+        return os.path.join(self.input_dir, filename)
+
     @property
     def transform(self):
         """Getter for the transform of the dataset.

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -5,6 +5,9 @@
 
 import os
 import shutil
+import tempfile
+
+import PIL.Image
 from PIL import Image
 from typing import List, Union, Callable
 
@@ -277,8 +280,29 @@ class LightlyDataset:
         for i, filename in zip(indices, filenames):
             _dump_image(self.dataset, output_dir, filename, i, fmt=format)
 
-    def get_filepath_from_filename(self, filename: str):
-        return os.path.join(self.input_dir, filename)
+    def get_filepath_from_filename(self, filename: str, image: PIL.Image.Image = None):
+        """Returns the filepath given the filename of the image
+
+        Args:
+            filename:
+                The filename of the image
+            image:
+                The image corresponding to the filename
+
+        Returns:
+
+        """
+        if hasattr(self, 'input_dir') and isinstance(self.input_dir, str):
+            return os.path.join(self.input_dir, filename)
+        else:
+            if image is None:
+                raise ValueError("This LightlyDataset was created from a torch dataset and thus has no input_dir."
+                                 "Thus you must provide the image to be able to save it and return the path to it.")
+            folder_path = tempfile.mkdtemp()
+            filepath = os.path.join(folder_path,filename) + '.jpg'
+            image.save(filepath)
+            return filepath
+
 
     @property
     def transform(self):

--- a/tests/UNMOCKED_end2end_tests/benchmark_upload.py
+++ b/tests/UNMOCKED_end2end_tests/benchmark_upload.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 from hydra.experimental import initialize, compose
 
@@ -20,9 +21,10 @@ def benchmark_upload(path_to_dataset, token):
         token:
             The token of the Lightly Web platform
 
-    Returns:
 
     """
+    start = time.time()
+
     api_workflow_client = ApiWorkflowClient(token=token)
 
     # create the dataset
@@ -40,6 +42,9 @@ def benchmark_upload(path_to_dataset, token):
 
     #delete the dataset again
     api_workflow_client.delete_dataset_by_id(api_workflow_client.dataset_id)
+
+    duration = time.time() - start
+    print(f"Finished and need {duration:.3f}s in total.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes https://github.com/lightly-ai/lightly-core/issues/763

## Description
Formerly, the PIL image was saved twice as image again, causing a large overhead, especially for large images. This PR computes the file size on the image which is already on the disk and also uses it to be uploaded.
This increases the upload speed already x2 for small images and even more on larger images.

## Performance before this PR:
Uploading 241 images from the clothing dataset with 12 workers to prod takes 79seconds.
<img width="948" alt="image" src="https://user-images.githubusercontent.com/20324507/122597096-2ffb2b80-d06b-11eb-8942-291a35f89ae8.png">
## Performance with this PR:
The same uploads takes 37seconds and is thus more than twice as fast.
<img width="670" alt="image" src="https://user-images.githubusercontent.com/20324507/122597214-5de07000-d06b-11eb-806b-9986f0f0ec76.png">

## Change of workflow

### Before
1. image on disk -> `PIL_image`
2.1 `PIL_image` -> calculate metadata
2.2 `PIL_image` -> save in bytes (as png in quality 100) -> calculate size
2.3 `PIL_image` -> save in bytes (as png in quality 100) -> upload (yes, two separate save in bytes)

### after
1. image on disk -> PIL_image
2.1 `PIL_image` -> calculate metadata
2.2 image on disk -> get size with `os.path.getsize()`
2.3 image on disk -> open -> upload

With the new workflow, jpeg-images are uploaded as they are, without saving them as high-quality png. This reduces the actual file size, both in the metadata and of the uploaded file.


