### PR TITLE
add citation in form of bibtex to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ If you want to cite the framework feel free to use this:
 ```bibtex
 @article{susmelj2020lightly,
   title={Lightly},
-  author={Susmelj, Igor, et al.},
+  author={Igor Susmelj, Philipp Wirth, Malte Ebner et al.},
   journal={GitHub. Note: https://github.com/lightly-ai/lightly},
   year={2020}
 }

--- a/README.md
+++ b/README.md
@@ -283,3 +283,15 @@ pylint lightly/core.py
   By building, what we call a self-supervised active learning loop we help companies understand and work with their data more efficiently. This framework acts as an interface
   for our platform to easily upload and download datasets, embeddings and models. Whereas 
   the platform will cost for additional features this frameworks will always remain free of charge (even for commercial use).
+
+## BibTeX
+If you want to cite the framework feel free to use this:
+
+```bibtex
+@article{susmelj2020lightly,
+  title={Lightly},
+  author={Susmelj, Igor, et al.},
+  journal={GitHub. Note: https://github.com/lightly-ai/lightly},
+  year={2020}
+}
+```

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ If you want to cite the framework feel free to use this:
 ```bibtex
 @article{susmelj2020lightly,
   title={Lightly},
-  author={Igor Susmelj, Philipp Wirth, Malte Ebner et al.},
+  author={Igor Susmelj, Matthias Heller, Philipp Wirth, Jeremy Prescott, Malte Ebner et al.},
   journal={GitHub. Note: https://github.com/lightly-ai/lightly},
   year={2020}
 }


### PR DESCRIPTION
closes #435

## Description:
- adds a bibtex entry for citing to the readme
- the structure was taken from https://github.com/PyTorchLightning/pytorch-lightning