### PR TITLE
skip uploading samples whose filenames are already upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ lightly_outputs
 tests/UNMOCKED_end2end_tests/call_test_api.py
 tests/UNMOCKED_end2end_tests/get_versions_all_apis.py
 tests/UNMOCKED_end2end_tests/call_benchmark_upload_private.py
+tests/UNMOCKED_end2end_tests/test_magic_on_branch.sh

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -93,6 +93,7 @@ class _UploadDatasetMixin:
             # load image
             image, label, filename = dataset[i]
             if filename in filenames_set:
+                # the sample was already uploaded
                 return True
 
             filepath = dataset.get_filepath_from_filename(filename, image)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -17,7 +17,7 @@ from typing import *
 
 from lightly.openapi_generated.swagger_client import ScoresApi, CreateEntityResponse, SamplesApi, SampleCreateRequest, \
     InitialTagCreateRequest, ApiClient, VersioningApi, QuotaApi, TagArithmeticsRequest, TagBitMaskResponse, \
-    SampleWriteUrls
+    SampleWriteUrls, SampleData
 from lightly.openapi_generated.swagger_client.api.embeddings_api import EmbeddingsApi
 from lightly.openapi_generated.swagger_client.api.jobs_api import JobsApi
 from lightly.openapi_generated.swagger_client.api.mappings_api import MappingsApi
@@ -135,9 +135,21 @@ class MockedMappingsApi(MappingsApi):
 
 
 class MockedSamplesApi(SamplesApi):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sample_create_requests: List[SampleCreateRequest] = []
+
+    def get_samples_by_dataset_id(self, dataset_id, **kwargs) -> List[SampleData]:
+        samples = []
+        for i, body in enumerate(self.sample_create_requests):
+            sample = SampleData(id=f'{i}_xyz', dataset_id='dataset_id_xyz', file_name=body.file_name)
+            samples.append(sample)
+        return samples
+
     def create_sample_by_dataset_id(self, body, dataset_id, **kwargs):
         assert isinstance(body, SampleCreateRequest)
         response_ = CreateEntityResponse(id="xyz")
+        self.sample_create_requests.append(body)
         return response_
 
     def get_sample_image_write_url_by_id(self, dataset_id, sample_id, is_thumbnail, **kwargs):


### PR DESCRIPTION
closes #400

## Description
- wrote unittest that simulates that some sample uploads fail and then the upload of all samples is restarted from scratch
- fixed unittest by only uploading samples whose filenames were not uploaded yet 

## Tests
- Unittest runs through
- A manual test also runs through:
I started a `lightly-upload`, cancelled it inbetween, and started the same upload again.
<img width="1738" alt="image" src="https://user-images.githubusercontent.com/20324507/123925527-49657700-d98b-11eb-8fb7-d418b89954c8.png">

## Not solved
If a sample is created, but the next steps (getting urls, uploading to them) fail, these samples are skipped nonetheless. Thus the dataset on the server might have samples without images. 
