### PR TITLE
Bump lightly-utils to 0.0.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,4 +11,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
-lightly_utils==0.0.1
+lightly_utils==0.0.2


### PR DESCRIPTION
# Bump lightly-utils to 0.0.2

Closes #840. Required release is here: https://pypi.org/project/lightly-utils/0.0.2/.