### PR TITLE
Require latest minor version of utils

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,4 +11,4 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
-lightly_utils==0.0.2
+lightly_utils~=0.0.0


### PR DESCRIPTION
# Require latest minor version of utils

Follow-up to #861, part of #926.

This should automatically install the latest 0.0.* version of lightly-utils.