### PR TITLE
524 fix masked select pw

### DIFF
--- a/lightly/api/bitmask.py
+++ b/lightly/api/bitmask.py
@@ -45,15 +45,11 @@ def _get_nonzero_bits(x: int) -> List[int]:
     return nonzero_bit_indices
 
 
-def _invert(x: int) -> int:
+def _invert(x: int, total_size: int) -> int:
     """Flips every bit of x as if x was an unsigned integer.
     """
     # use XOR of x and 0xFFFFFF to get the inverse
-    # return x ^ (2 ** (x.bit_length()) - 1)
-    # TODO: the solution above can give wrong answers for the case where
-    # the tag representation starts with a zero, therefore it needs to know
-    # the exact number of samples in the dataset to do a correct inverse
-    raise NotImplementedError('This method is not implemented yet...')
+    return x ^ (2 ** total_size - 1)
 
 
 def _union(x: int, y: int) -> int:
@@ -149,11 +145,15 @@ class BitMask:
         """
         return _get_nonzero_bits(self.x)
 
-    def invert(self):
+    def invert(self, total_size: int):
         """Sets every 0 to 1 and every 1 to 0 in the bitstring.
 
+        Args:
+            total_size:
+                Total size of the tag.
+
         """
-        self.x = _invert(self.x)
+        self.x = _invert(self.x, total_size)
 
     def complement(self):
         """Same as invert but with the appropriate name.

--- a/lightly/api/bitmask.py
+++ b/lightly/api/bitmask.py
@@ -200,16 +200,20 @@ class BitMask:
         return self.to_bin() == other.to_bin()
 
     def masked_select_from_list(self, list_: List):
-        """Returns a subset of a list depending on the bitmask
+        """Returns a subset of a list depending on the bitmask.
+
+        The bitmask is read from right to left, i.e. the least significant bit
+        corresponds to index 0.
+
         Examples:
             >>> list_to_subset = [4, 7, 9, 1]
             >>> mask = BitMask.from_bin("0b0101")
             >>> masked_list = mask.masked_select_from_list(list_to_subset)
-            >>> # masked_list = [7, 1]
+            >>> # masked_list = [4, 9]
+
         """
-        bits = self.to_bin()
-        reversed_masked_list = [e for e, bit in zip(reversed(list_),reversed(bits)) if bit == "1"]
-        return list(reversed(reversed_masked_list))
+        indices = self.to_indices()
+        return [list_[index] for index in indices]
 
     def get_kth_bit(self, k: int) -> bool:
         """Returns the boolean value of the kth bit from the right.

--- a/tests/api/test_BitMask.py
+++ b/tests/api/test_BitMask.py
@@ -140,11 +140,22 @@ class TestBitMask(unittest.TestCase):
         self.assertEqual(mask_a, mask_b)
 
     def test_subset_a_list(self):
-        list_ = [4, 7, 9, 1]
-        mask = BitMask.from_bin("0b0101")
-        target_masked_list = [7, 1]
-        masked_list = mask.masked_select_from_list(list_)
-        self.assertEqual(target_masked_list, masked_list)
+        n = 1000
+        list_ = [randint(0, 1) for _ in range(n - 2)] + [0, 1]
+        mask = BitMask.from_length(n)
+        for index, item_ in enumerate(list_):
+            if item_ == 0:
+                mask.unset_kth_bit(index)
+            else:
+                mask.set_kth_bit(index)
+
+        all_ones = mask.masked_select_from_list(list_)
+        mask.x = mask.x ^ (2 ** n - 1) # inverse
+        all_zeros = mask.masked_select_from_list(list_)
+        self.assertGreater(len(all_ones), 0)
+        self.assertGreater(len(all_zeros), 0)
+        self.assertTrue(all([item_ > 0 for item_ in all_ones]))
+        self.assertTrue(all([item_ == 0 for item_ in all_zeros]))
 
     def test_nonzero_bits(self):
 

--- a/tests/api/test_BitMask.py
+++ b/tests/api/test_BitMask.py
@@ -105,7 +105,7 @@ class TestBitMask(unittest.TestCase):
         self.assert_difference("0b0111", "0b1100", "0b0011")
         self.assert_difference("0b10111", "0b01100", "0b10011")
 
-    def random_bitsting(self, length: int):
+    def random_bitstring(self, length: int):
         bitsting = '0b'
         for i in range(length):
             bitsting += str(randint(0, 1))
@@ -115,8 +115,8 @@ class TestBitMask(unittest.TestCase):
         seed(42)
         for rep in range(10):
             for string_length in range(1, 100, 10):
-                bitstring_1 = self.random_bitsting(string_length)
-                bitstring_2 = self.random_bitsting(string_length)
+                bitstring_1 = self.random_bitstring(string_length)
+                bitstring_2 = self.random_bitstring(string_length)
                 target = '0b'
                 for bit_1, bit_2 in zip(bitstring_1[2:], bitstring_2[2:]):
                     if bit_1 == '1' and bit_2 == '0':
@@ -139,7 +139,7 @@ class TestBitMask(unittest.TestCase):
         mask_b = BitMask.from_bin("0b101")
         self.assertEqual(mask_a, mask_b)
 
-    def test_subset_a_list(self):
+    def test_masked_select_from_list(self):
         n = 1000
         list_ = [randint(0, 1) for _ in range(n - 2)] + [0, 1]
         mask = BitMask.from_length(n)
@@ -150,12 +150,40 @@ class TestBitMask(unittest.TestCase):
                 mask.set_kth_bit(index)
 
         all_ones = mask.masked_select_from_list(list_)
-        mask.x = mask.x ^ (2 ** n - 1) # inverse
+        mask.invert(n)
         all_zeros = mask.masked_select_from_list(list_)
         self.assertGreater(len(all_ones), 0)
         self.assertGreater(len(all_zeros), 0)
         self.assertTrue(all([item_ > 0 for item_ in all_ones]))
         self.assertTrue(all([item_ == 0 for item_ in all_zeros]))
+
+
+    def test_masked_select_from_list_example(self):
+        list_ = [1, 2, 3, 4, 5, 6]
+        mask = BitMask.from_bin('0b001101') # expected result is [1, 3, 4]
+        selected = mask.masked_select_from_list(list_)
+        self.assertListEqual(selected, [1, 3, 4])
+
+
+    def test_invert(self):
+        # get random bitstring
+        length = 10
+        bitstring = self.random_bitstring(10)
+ 
+        #get inverse
+        mask = BitMask.from_bin(bitstring)
+        mask.invert(length)
+        inverted = mask.to_bin()
+
+        # remove 0b
+        inverted = inverted[2:]
+        bitstring = bitstring[2:]
+        for i in range(min(len(bitstring), len(inverted))):
+            if bitstring[-i - 1] == '0':
+                self.assertEqual(inverted[-i - 1], '1')
+            else:
+                self.assertEqual(inverted[-i - 1], '0')
+
 
     def test_nonzero_bits(self):
 


### PR DESCRIPTION
# 524 Fix masked select

Closes [#524](https://github.com/lightly-ai/lightly-core/issues/524).

Fixes the buggy implementation of `masked_select` by utilizing the existing function `to_indices` which is implemented identically in the pip package and the api.