### PR TITLE
Metadata CLI

### DIFF
--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -92,6 +92,10 @@ def _upload_cli(cfg, is_cli_call=True):
         )
         print("Finished upload of embeddings.")
 
+    if custom_metadata is not None and not input_dir:
+        # upload custom metadata separately
+        api_workflow_client.upload_custom_metadata(custom_metadata, verbose=True)
+
     if new_dataset_name_ok:
         print(f'The dataset_id of the newly created dataset is '
               f'{bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')

--- a/tests/cli/test_cli_upload.py
+++ b/tests/cli/test_cli_upload.py
@@ -91,7 +91,15 @@ class TestCLIUpload(MockedApiWorkflowSetup):
         with self.assertWarns(UserWarning):
             lightly.cli.upload_cli(self.cfg)
 
-    def test_upload_metadata_only(self):
+    def test_upload_custom_metadata(self):
         cli_string = f"lightly-upload token='123' dataset_id='xyz' custom_metadata='{self.tfile.name}'"
         self.parse_cli_string(cli_string)
         lightly.cli.upload_cli(self.cfg)
+
+    def test_upload_custom_metadata_only(self):
+        cli_string = f"lightly-upload token='123' dataset_id='xyz' custom_metadata='{self.tfile.name}'"
+        self.parse_cli_string(cli_string)
+        input_dir = self.cfg['input_dir']
+        self.cfg['input_dir'] = ''
+        lightly.cli.upload_cli(self.cfg)
+        self.cfg['input_dir'] = input_dir


### PR DESCRIPTION
# Metadata CLI
Closes #451. 

The custom metadata can be uploaded to an existing dataset with
```shell
lightly-upload token=TOKEN dataset_id=DATASET_ID custom_metadata=/path/to/custom/metadata.json
```