### PR TITLE
allow easy way to upload active learning scores without triggering a sampling

### DIFF
--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -161,6 +161,22 @@ class ActiveLearningAgent:
         )
 
 
+    def upload_scores(self, al_scorer: Scorer):
+        # calculate active learning scores
+        al_scores_dict = al_scorer.calculate_scores()
+
+        # Check if the length of the query_set and each of the scores are the same
+        no_query_samples = len(self.query_set)
+        for score in al_scores_dict.values():
+            no_query_samples_with_scores = len(score)
+            if no_query_samples != no_query_samples_with_scores:
+                raise ValueError(
+                    f'Number of query samples ({no_query_samples}) must match '
+                    f'the number of predictions ({no_query_samples_with_scores})!'
+                )
+        self.api_workflow_client.upload_scores(al_scores_dict, self._query_tag_id)
+
+
     def query(self,
               sampler_config: SamplerConfig,
               al_scorer: Scorer = None) -> Tuple[List[str], List[str]]:
@@ -187,26 +203,12 @@ class ActiveLearningAgent:
             )
             return
 
-        # calculate active learning scores
-        scores_dict = None
-        if al_scorer is not None:
-            scores_dict = al_scorer.calculate_scores()
-
-            # Check if the length of the query_set and each of the scores are the same
-            no_query_samples = len(self.query_set)
-            for score in scores_dict.values():
-                no_query_samples_with_scores = len(score)
-                if no_query_samples != no_query_samples_with_scores:
-                    raise ValueError(
-                        f'Number of query samples ({no_query_samples}) must match '
-                        f'the number of predictions ({no_query_samples_with_scores})!'
-                    )
-
+        if al_scorer:
+            self.upload_scores(al_scorer)
 
         # perform the sampling
         new_tag_data = self.api_workflow_client.sampling(
             sampler_config=sampler_config,
-            al_scores=scores_dict,
             preselected_tag_id=self._preselected_tag_id,
             query_tag_id=self._query_tag_id
         )

--- a/tests/active_learning/test_active_learning_agent.py
+++ b/tests/active_learning/test_active_learning_agent.py
@@ -110,3 +110,19 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
         )
 
         agent.query(sampler_config)
+
+    def test_agent_only_upload_scores(self):
+        self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        agent = ActiveLearningAgent(
+            self.api_workflow_client,
+            preselected_tag_name="preselected_tag_name_xyz",
+        )
+
+        n_predictions = len(agent.query_set)
+        predictions = np.random.rand(n_predictions, 10).astype(np.float32)
+        predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]
+        al_scorer = ScorerClassification(predictions_normalized)
+
+        agent.upload_scores(al_scorer)
+
+


### PR DESCRIPTION
closes #449

## Description
- splits an AL-sampling into two parts: uploading the AL scores and performing the sampling
- allows to upload the AL scores separately from performing a sampling

## Testing 
- added a (mocked) unittest
- performed an unmocked tests agains our API