### PR TITLE
Add Jigsaw trasformation

### DIFF
--- a/lightly/transforms/__init__.py
+++ b/lightly/transforms/__init__.py
@@ -11,3 +11,4 @@
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.rotation import RandomRotate
 from lightly.transforms.solarize import RandomSolarization
+from lightly.transforms.jigsaw import Jigsaw

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -3,8 +3,10 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import torch
+from torchvision import transforms
 import numpy as np
-from PIL import ImageOps
+from PIL import Image
 
 
 class Jigsaw(object):
@@ -21,13 +23,16 @@ class Jigsaw(object):
             Size of image.
         crop_size:
             Size of crops.
+        transform:
+            Transformation to apply on each crop.
     """
-    def __init__(self, n_grid=3, img_size=255, crop_size=64):
+    def __init__(self, n_grid=3, img_size=255, crop_size=64, transform=transforms.ToTensor()):
         self.n_grid = n_grid
         self.img_size = img_size
         self.crop_size = crop_size
         self.grid_size = int(img_size / self.n_grid)
         self.side = self.grid_size - self.crop_size
+        self.transform = transform
 
         yy, xx = np.meshgrid(np.arange(n_grid), np.arange(n_grid))
         self.yy = np.reshape(yy * self.grid_size, (n_grid * n_grid,))
@@ -39,7 +44,7 @@ class Jigsaw(object):
             img:
                 PIL image to perform Jigsaw augmentation on
         Returns:
-            List of cropped PIL images
+            Torch tensor with stacked crops.
         """
         r_x = np.random.randint(0, self.side + 1, self.n_grid * self.n_grid)
         r_y = np.random.randint(0, self.side + 1, self.n_grid * self.n_grid)
@@ -49,4 +54,5 @@ class Jigsaw(object):
             crops.append(img[self.xx[i] + r_x[i]: self.xx[i] + r_x[i] + self.crop_size,
                          self.yy[i] + r_y[i]: self.yy[i] + r_y[i] + self.crop_size, :])
         crops = [Image.fromarray(crop) for crop in crops]
+        crops = torch.stack([self.transform(crop) for crop in crops])
         return crops

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -25,6 +25,14 @@ class Jigsaw(object):
             Size of crops.
         transform:
             Transformation to apply on each crop.
+    
+    Examples:
+        >>> from lightly.transforms import Jigsaw
+        >>>
+        >>> jigsaw_crop = Jigsaw(n_grid=3, img_size=255, crop_size=64, transform=transforms.ToTensor())
+        >>>
+        >>> # img is a PIL image
+        >>> crops = jigsaw_crops(img)
     """
     def __init__(self, n_grid=3, img_size=255, crop_size=64, transform=transforms.ToTensor()):
         self.n_grid = n_grid
@@ -42,7 +50,8 @@ class Jigsaw(object):
         """Performs the Jigsaw augmentation
         Args:
             img:
-                PIL image to perform Jigsaw augmentation on
+                PIL image to perform Jigsaw augmentation on.
+
         Returns:
             Torch tensor with stacked crops.
         """

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -1,0 +1,52 @@
+""" Jigsaw Crop """
+
+# Copyright (c) 2021. Lightly AG and its affiliates.
+# All Rights Reserved
+
+import numpy as np
+from PIL import ImageOps
+
+
+class Jigsaw(object):
+    """Implementation of Jigsaw image augmentation, inspired from PyContrast library.
+    
+    Generates n_grid**2 random crops and returns a list.
+    
+    This augmentation is instrumental to PIRL.
+    
+    Attributes:
+        n_grid:
+            Side length of the meshgrid, sqrt of the number of crops.
+        img_size:
+            Size of image.
+        crop_size:
+            Size of crops.
+    """
+    def __init__(self, n_grid=3, img_size=255, crop_size=64):
+        self.n_grid = n_grid
+        self.img_size = img_size
+        self.crop_size = crop_size
+        self.grid_size = int(img_size / self.n_grid)
+        self.side = self.grid_size - self.crop_size
+
+        yy, xx = np.meshgrid(np.arange(n_grid), np.arange(n_grid))
+        self.yy = np.reshape(yy * self.grid_size, (n_grid * n_grid,))
+        self.xx = np.reshape(xx * self.grid_size, (n_grid * n_grid,))
+
+    def __call__(self, img):
+        """Performs the Jigsaw augmentation
+        Args:
+            img:
+                PIL image to perform Jigsaw augmentation on
+        Returns:
+            List of cropped PIL images
+        """
+        r_x = np.random.randint(0, self.side + 1, self.n_grid * self.n_grid)
+        r_y = np.random.randint(0, self.side + 1, self.n_grid * self.n_grid)
+        img = np.asarray(img, np.uint8)
+        crops = []
+        for i in range(self.n_grid * self.n_grid):
+            crops.append(img[self.xx[i] + r_x[i]: self.xx[i] + r_x[i] + self.crop_size,
+                         self.yy[i] + r_y[i]: self.yy[i] + r_y[i] + self.crop_size, :])
+        crops = [Image.fromarray(crop) for crop in crops]
+        return crops

--- a/tests/transforms/test_Jigsaw.py
+++ b/tests/transforms/test_Jigsaw.py
@@ -4,7 +4,7 @@ import unittest
 from lightly.transforms import Jigsaw
 
 
-class TestGaussianBlur(unittest.TestCase):
+class TestJigsaw(unittest.TestCase):
 
     def test_on_pil_image(self):
         crop = Jigsaw()

--- a/tests/transforms/test_Jigsaw.py
+++ b/tests/transforms/test_Jigsaw.py
@@ -1,0 +1,12 @@
+from PIL import Image
+import unittest
+
+from lightly.transforms import Jigsaw
+
+
+class TestGaussianBlur(unittest.TestCase):
+
+    def test_on_pil_image(self):
+        crop = Jigsaw()
+        sample = Image.new('RGB', (255,255))
+        crop(sample)


### PR DESCRIPTION
Jigsaw transformation returns n_grid random crops from the input image. This augmentation is essential for multiple Self Supervised Learning tasks. Part of a adding PIRL to the framework, as per #396.