### PR TITLE
first draft of refactoring SSL models: implemented for SimCLR, MoCo

### DIFF
--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -181,10 +181,27 @@ def load_from_state_dict(model,
                          state_dict,
                          strict: bool = True,
                          apply_filter: bool = True,
-                         num_splits: int = 0):
+                         num_splits: int = 0,
+                         replace_projection_head_with_head: bool = True):
     """Loads the model weights from the state dictionary.
 
     """
+    # Step 0
+    if replace_projection_head_with_head and 'projection_head' in state_dict:
+        # Replace the state dict to prevent the error when loading a legacy
+        # embedding model
+        """
+        RuntimeError: Error(s) in loading state_dict for SimCLR: 32
+    
+        Missing key(s) in state_dict: "head.layers.0.weight", 
+        "head.layers.0.bias", "head.layers.2.weight", "head.layers.2.bias".33
+    
+        Unexpected key(s) in state_dict: "projection_head.layers.0.weight", 
+        "projection_head.layers.0.bias", "projection_head.layers.2.weight", 
+        "projection_head.layers.2.bias".
+        """
+        state_dict['head'] = state_dict['projection_head']
+        del state_dict['projection_head']
 
     # step 1: filter state dict
     if apply_filter:

--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -191,7 +191,6 @@ def load_from_state_dict(model,
     """Loads the model weights from the state dictionary.
 
     """
-    '.0.weight'
     # step 1: filter state dict
     if apply_filter:
         state_dict = _filter_state_dict(state_dict)

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -106,23 +106,6 @@ def _embed_cli(cfg, is_cli_call=True):
     ).to(device)
 
     if state_dict is not None:
-
-        # Replace the state dict to prevent the error when loading a legacy
-        # embedding model
-        """
-        RuntimeError: Error(s) in loading state_dict for SimCLR: 32
-        
-        Missing key(s) in state_dict: "head.layers.0.weight", 
-        "head.layers.0.bias", "head.layers.2.weight", "head.layers.2.bias".33
-        
-        Unexpected key(s) in state_dict: "projection_head.layers.0.weight", 
-        "projection_head.layers.0.bias", "projection_head.layers.2.weight", 
-        "projection_head.layers.2.bias".
-        """
-        if 'projection_head' in state_dict:
-            state_dict['head'] = state_dict['projection_head']
-            del state_dict['projection_head']
-
         load_from_state_dict(model, state_dict)
 
     encoder = SelfSupervisedEmbedding(model, None, None, None)

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -33,7 +33,6 @@ from lightly.cli._helpers import cpu_count
 
 
 def _embed_cli(cfg, is_cli_call=True):
-
     checkpoint = cfg['checkpoint']
 
     input_dir = cfg['input_dir']
@@ -107,6 +106,23 @@ def _embed_cli(cfg, is_cli_call=True):
     ).to(device)
 
     if state_dict is not None:
+
+        # Replace the state dict to prevent the error when loading a legacy
+        # embedding model
+        """
+        RuntimeError: Error(s) in loading state_dict for SimCLR: 32
+        
+        Missing key(s) in state_dict: "head.layers.0.weight", 
+        "head.layers.0.bias", "head.layers.2.weight", "head.layers.2.bias".33
+        
+        Unexpected key(s) in state_dict: "projection_head.layers.0.weight", 
+        "projection_head.layers.0.bias", "projection_head.layers.2.weight", 
+        "projection_head.layers.2.bias".
+        """
+        if 'projection_head' in state_dict:
+            state_dict['head'] = state_dict['projection_head']
+            del state_dict['projection_head']
+
         load_from_state_dict(model, state_dict)
 
     encoder = SelfSupervisedEmbedding(model, None, None, None)

--- a/lightly/models/__init__.py
+++ b/lightly/models/__init__.py
@@ -20,3 +20,4 @@ from lightly.models.moco import MoCo
 from lightly.models.nnclr import NNCLR
 from lightly.models.zoo import ZOO
 from lightly.models.zoo import checkpoints
+from lightly.models.base_embedding_model import BaseEmbeddingModel

--- a/lightly/models/base_embedding_model.py
+++ b/lightly/models/base_embedding_model.py
@@ -1,0 +1,86 @@
+""" Base Embedding Model """
+
+# Copyright (c) 2020. Lightly AG and its affiliates.
+# All Rights Reserved
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+
+from lightly.models.modules.heads import ProjectionHead
+
+
+class BaseEmbeddingModel(nn.Module):
+    def __init__(self,
+                 backbone: nn.Module,
+                 head: ProjectionHead
+                 ):
+        super(BaseEmbeddingModel, self).__init__()
+        self.backbone = backbone
+        self.head = head
+
+    def _base_forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass throught the backbone and head"""
+        features = self.backbone(x).flatten(start_dim=1)
+        out = self.head(features)
+        return out, features
+
+
+    def forward(self,
+                x0: torch.Tensor,
+                x1: torch.Tensor = None,
+                return_features: bool = False):
+        """Forward pass through the embedding mdoel.
+
+        Extracts features with the backbone and applies the projection
+        head and prediction head(s) to the output space. If both x0 and x1 are not
+        None, both will be passed through the backbone, projection, and
+        prediction head. If x1 is None, only x0 will be forwarded.
+
+        Args:
+            x0:
+                Tensor of shape bsz x channels x W x H.
+            x1:
+                Tensor of shape bsz x channels x W x H.
+            return_features:
+                Whether or not to return the intermediate features backbone(x).
+
+        Returns:
+            The output prediction and projection of x0 and (if x1 is not None)
+            the output prediction and projection of x1. If return_features is
+            True, the output for each x is a tuple (out, f) where f are the
+            features before the projection head.
+            
+        Examples:
+            >>> # single input, single output
+            >>> out = model(x) 
+            >>> 
+            >>> # single input with return_features=True
+            >>> out, f = model(x, return_features=True)
+            >>>
+            >>> # two inputs, two outputs
+            >>> out0, out1 = model(x0, x1)
+            >>>
+            >>> # two inputs, two outputs with return_features=True
+            >>> (out0, f0), (out1, f1) = model(x0, x1, return_features=True)
+        """
+
+        # forward pass of first input x0
+        out0, f0 = self._base_forward(x0)
+
+        # return out0 if x1 is None
+        if x1 is None:
+            # append features if requested
+            if return_features:
+                return (out0, f0)
+            else:
+                return out0
+
+        # forward pass of second input x1
+        out1, f1 = self._base_forward(x1)
+
+        # append features if requested
+        if return_features:
+            return (out0, f0), (out1, f1)
+        else:
+            return out0, out1

--- a/lightly/models/base_embedding_model.py
+++ b/lightly/models/base_embedding_model.py
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -29,7 +29,15 @@ class BaseEmbeddingModel(nn.Module):
     def forward(self,
                 x0: torch.Tensor,
                 x1: torch.Tensor = None,
-                return_features: bool = False):
+                return_features: bool = False)\
+            -> Union[
+                torch.Tensor,
+                Tuple[torch.Tensor, torch.Tensor],
+                Tuple[
+                    Tuple[torch.Tensor, torch.Tensor],
+                    Tuple[torch.Tensor, torch.Tensor],
+                ],
+            ]:
         """Forward pass through the embedding mdoel.
 
         Extracts features with the backbone and applies the projection

--- a/lightly/models/base_embedding_model.py
+++ b/lightly/models/base_embedding_model.py
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
-from typing import List, Tuple
+from typing import Tuple
 
 import torch
 import torch.nn as nn
@@ -19,12 +19,12 @@ class BaseEmbeddingModel(nn.Module):
         self.backbone = backbone
         self.head = head
 
-    def _base_forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Forward pass throught the backbone and head"""
+    def _base_forward(self, x: torch.Tensor) \
+            -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward pass through the backbone and head"""
         features = self.backbone(x).flatten(start_dim=1)
         out = self.head(features)
         return out, features
-
 
     def forward(self,
                 x0: torch.Tensor,
@@ -33,9 +33,10 @@ class BaseEmbeddingModel(nn.Module):
         """Forward pass through the embedding mdoel.
 
         Extracts features with the backbone and applies the projection
-        head and prediction head(s) to the output space. If both x0 and x1 are not
-        None, both will be passed through the backbone, projection, and
-        prediction head. If x1 is None, only x0 will be forwarded.
+        head and prediction head(s) to the output space. If both x0 and x1
+        are not None, both will be passed through the
+        backbone, projection, and prediction head. If x1 is None, only x0
+        will be forwarded.
 
         Args:
             x0:
@@ -50,7 +51,7 @@ class BaseEmbeddingModel(nn.Module):
             the output prediction and projection of x1. If return_features is
             True, the output for each x is a tuple (out, f) where f are the
             features before the projection head.
-            
+
         Examples:
             >>> # single input, single output
             >>> out = model(x) 

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -114,7 +114,7 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
                 x1, shuffle = self._batch_shuffle(x1)
 
             # run x1 through momentum encoder
-            out1, f1 = self.model_moco.forward(x0, return_features=True)
+            out1, f1 = self.model_moco.forward(x1, return_features=True)
         
             # unshuffle for batchnorm
             if self.batch_shuffle:

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -6,10 +6,11 @@
 import torch
 import torch.nn as nn
 
+from lightly.models.base_embedding_model import BaseEmbeddingModel
 from lightly.models.modules import SimCLRProjectionHead
 
 
-class SimCLR(nn.Module):
+class SimCLR(BaseEmbeddingModel):
     """Implementation of the SimCLR[0] architecture
 
     Recommended loss: :py:class:`lightly.loss.ntx_ent_loss.NTXentLoss`
@@ -31,70 +32,5 @@ class SimCLR(nn.Module):
                  num_ftrs: int = 32,
                  out_dim: int = 128):
 
-        super(SimCLR, self).__init__()
-
-        self.backbone = backbone
-        self.projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
-
-    def forward(self,
-                x0: torch.Tensor,
-                x1: torch.Tensor = None,
-                return_features: bool = False):
-        """Embeds and projects the input images.
-
-        Extracts features with the backbone and applies the projection
-        head to the output space. If both x0 and x1 are not None, both will be
-        passed through the backbone and projection head. If x1 is None, only
-        x0 will be forwarded.
-
-        Args:
-            x0:
-                Tensor of shape bsz x channels x W x H.
-            x1:
-                Tensor of shape bsz x channels x W x H.
-            return_features:
-                Whether or not to return the intermediate features backbone(x).
-
-        Returns:
-            The output projection of x0 and (if x1 is not None) the output
-            projection of x1. If return_features is True, the output for each x
-            is a tuple (out, f) where f are the features before the projection
-            head.
-
-        Examples:
-            >>> # single input, single output
-            >>> out = model(x) 
-            >>> 
-            >>> # single input with return_features=True
-            >>> out, f = model(x, return_features=True)
-            >>>
-            >>> # two inputs, two outputs
-            >>> out0, out1 = model(x0, x1)
-            >>>
-            >>> # two inputs, two outputs with return_features=True
-            >>> (out0, f0), (out1, f1) = model(x0, x1, return_features=True)
-
-        """
-        
-        # forward pass of first input x0
-        f0 = self.backbone(x0).flatten(start_dim=1)
-        out0 = self.projection_head(f0)
-
-        # append features if requested
-        if return_features:
-            out0 = (out0, f0)
-
-        # return out0 if x1 is None
-        if x1 is None:
-            return out0
-
-        # forward pass of second input x1
-        f1 = self.backbone(x1).flatten(start_dim=1)
-        out1 = self.projection_head(f1)
-
-        # append features if requested
-        if return_features:
-            out1 = (out1, f1)
-
-        # return both outputs
-        return out0, out1
+        projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
+        super(SimCLR, self).__init__(backbone=backbone, head=projection_head)

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -34,14 +34,3 @@ class SimCLR(BaseEmbeddingModel):
 
         projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
         super(SimCLR, self).__init__(backbone=backbone, head=projection_head)
-
-        # Allow pretrained models to keep working
-        # Otherwise the test of the CLI on a real dataset (on the setup.py) returns
-        """
-        RuntimeError: Error(s) in loading state_dict for SimCLR: 32
-	    Missing key(s) in state_dict: "head.layers.0.weight", "head.layers.0.bias", 
-	    "head.layers.2.weight", "head.layers.2.bias". 33
-	    Unexpected key(s) in state_dict: "projection_head.layers.0.weight", "projection_head.layers.0.bias", 
-	    "projection_head.layers.2.weight", "projection_head.layers.2.bias".
-        """
-        self.projection_head = self.head

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -34,3 +34,14 @@ class SimCLR(BaseEmbeddingModel):
 
         projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
         super(SimCLR, self).__init__(backbone=backbone, head=projection_head)
+
+        # Allow pretrained models to keep working
+        # Otherwise the test of the CLI on a real dataset (on the setup.py) returns
+        """
+        RuntimeError: Error(s) in loading state_dict for SimCLR: 32
+	    Missing key(s) in state_dict: "head.layers.0.weight", "head.layers.0.bias", 
+	    "head.layers.2.weight", "head.layers.2.bias". 33
+	    Unexpected key(s) in state_dict: "projection_head.layers.0.weight", "projection_head.layers.0.bias", 
+	    "projection_head.layers.2.weight", "projection_head.layers.2.bias".
+        """
+        self.projection_head = self.head

--- a/tests/imports/test_from_imports.py
+++ b/tests/imports/test_from_imports.py
@@ -59,6 +59,7 @@ class TestFromImports(unittest.TestCase):
         from lightly.models import checkpoints
         from lightly.models.zoo import checkpoints
         from lightly.models.batchnorm import get_norm_layer
+        from lightly.models.base_embedding_model import BaseEmbeddingModel
 
         # transforms imports
         from lightly.transforms import GaussianBlur

--- a/tests/imports/test_nested_imports.py
+++ b/tests/imports/test_nested_imports.py
@@ -69,6 +69,7 @@ class TestNestedImports(unittest.TestCase):
         lightly.models.checkpoints
         lightly.models.zoo.checkpoints
         lightly.models.batchnorm.get_norm_layer
+        lightly.models.BaseEmbeddingModel
 
         # transforms imports
         lightly.transforms.GaussianBlur

--- a/tests/imports/test_seminested_imports.py
+++ b/tests/imports/test_seminested_imports.py
@@ -68,6 +68,7 @@ class TestSemiNestedImports(unittest.TestCase):
         models.checkpoints
         models.zoo.checkpoints
         models.batchnorm.get_norm_layer
+        models.BaseEmbeddingModel
 
         # transforms imports
         from lightly import transforms

--- a/tests/models/test_ModelsSimCLR.py
+++ b/tests/models/test_ModelsSimCLR.py
@@ -64,7 +64,7 @@ class TestModelsSimCLR(unittest.TestCase):
 
                 # check that projection head output has right dimension
                 with torch.no_grad():
-                    out_projection = model.projection_head(
+                    out_projection = model.head(
                         out_features.squeeze()
                     )
                 self.assertEqual(out_projection.shape[1], out_dim)


### PR DESCRIPTION
closes #379

# STALLED FOR THE MOMENT
# go to https://github.com/lightly-ai/lightly/pull/484 instead

## Good article on features of SSL models
https://towardsdatascience.com/a-framework-for-contrastive-self-supervised-learning-and-designing-a-new-approach-3caab5d29619
## Description
### Base Embedding Model
The base embedding model does a forward pass for x0, x1 through the backbone and head.

https://github.com/lightly-ai/lightly/blob/5774fcc3d90d64acff3bcc1345e07907bd165d8e/lightly/models/base_embedding_model.py#L13-L20

https://github.com/lightly-ai/lightly/blob/5774fcc3d90d64acff3bcc1345e07907bd165d8e/lightly/models/base_embedding_model.py#L29-L40

It needs to distinguish four cases:
```python
out = model(x) 
out, f = model(x, return_features=True)
out0, out1 = model(x0, x1)
(out0, f0), (out1, f1) = model(x0, x1, return_features=True)
```
This does not work for SimSiam with lines like
https://github.com/lightly-ai/lightly/blob/5774fcc3d90d64acff3bcc1345e07907bd165d8e/lightly/models/simsiam.py#L106

### refactored SimCLR model
It becomes very small and easy to use:
https://github.com/lightly-ai/lightly/blob/813d1b39d987af1ee86642dd59ce65c5f504c1af/lightly/models/simclr.py#L30-L36

### refactored MoCo model
It is basically two models inside:
https://github.com/lightly-ai/lightly/blob/813d1b39d987af1ee86642dd59ce65c5f504c1af/lightly/models/moco.py#L51-L55