### PR TITLE
481 when pip version older than newest version, it calls api on every command rather than caching the information me

### DIFF
--- a/lightly/__init__.py
+++ b/lightly/__init__.py
@@ -78,8 +78,9 @@ The framework is structured into the following modules:
 # All Rights Reserved
 
 __name__ = 'lightly'
-__version__ = '1.1.18'
+__version__ = '1.1.16'
 
+from multiprocessing import current_process
 
 try:
     # See (https://github.com/PyTorchLightning/pytorch-lightning)
@@ -118,14 +119,18 @@ else:
     from lightly import transforms
     from lightly import utils
 
+    if current_process().name == 'MainProcess':
+        # check for latest version
+        from lightly.api.version_checking import get_latest_version
+        from lightly.api.version_checking import version_compare
+        from lightly.api.version_checking import pretty_print_latest_version
 
-    # check for latest version
-    from lightly.api.version_checking import get_latest_version
-    from lightly.api.version_checking import version_compare
-    from lightly.api.version_checking import pretty_print_latest_version
+        latest_version = get_latest_version(__version__)
+        print(f"Doing version check.")
+        if latest_version is not None:
+            if version_compare(__version__, latest_version) < 0:
+                # local version is behind latest version
+                pretty_print_latest_version(latest_version)
 
-    latest_version = get_latest_version(__version__)
-    if latest_version is not None:
-        if version_compare(__version__, latest_version) < 0:
-            # local version is behind latest version
-            pretty_print_latest_version(latest_version)
+    else:
+        print(f"Skipped version check for process {current_process().name}")

--- a/lightly/__init__.py
+++ b/lightly/__init__.py
@@ -78,7 +78,7 @@ The framework is structured into the following modules:
 # All Rights Reserved
 
 __name__ = 'lightly'
-__version__ = '1.1.16'
+__version__ = '1.1.18'
 
 from multiprocessing import current_process
 
@@ -126,11 +126,8 @@ else:
         from lightly.api.version_checking import pretty_print_latest_version
 
         latest_version = get_latest_version(__version__)
-        print(f"Doing version check.")
         if latest_version is not None:
             if version_compare(__version__, latest_version) < 0:
                 # local version is behind latest version
                 pretty_print_latest_version(latest_version)
 
-    else:
-        print(f"Skipped version check for process {current_process().name}")

--- a/tests/cli/test_cli_embed.py
+++ b/tests/cli/test_cli_embed.py
@@ -1,0 +1,53 @@
+import os
+import re
+import sys
+import tempfile
+
+import torchvision
+from hydra.experimental import compose, initialize
+
+import lightly
+from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
+
+
+class TestCLIEmbed(MockedApiWorkflowSetup):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        sys.modules["lightly.cli.embed_cli"].ApiWorkflowClient = \
+            MockedApiWorkflowClient
+
+    def setUp(self):
+        MockedApiWorkflowSetup.setUp(self)
+        self.create_fake_dataset()
+        with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
+            self.cfg = compose(config_name="config", overrides=[
+                "token='123'",
+                f"input_dir={self.folder_path}",
+                "trainer.max_epochs=0"
+            ])
+
+    def create_fake_dataset(self):
+        n_data = 16
+        self.dataset = torchvision.datasets.FakeData(size=n_data, image_size=(3, 32, 32))
+
+        self.folder_path = tempfile.mkdtemp()
+        sample_names = [f'img_{i}.jpg' for i in range(n_data)]
+        self.sample_names = sample_names
+        for sample_idx in range(n_data):
+            data = self.dataset[sample_idx]
+            path = os.path.join(self.folder_path, sample_names[sample_idx])
+            data[0].save(path)
+
+    def test_embed(self):
+        lightly.cli.embed_cli(self.cfg)
+
+    def tearDown(self) -> None:
+        for filename in ["embeddings.csv", "embeddings_sorted.csv"]:
+            try:
+                os.remove(filename)
+            except FileNotFoundError:
+                pass
+
+
+


### PR DESCRIPTION
closes #481

## Description
The problem is that every worker starts a new instance of python/lightly and thus performs a new version check. 
Check it e.g. with 
```
pip install lightly==1.1.17
lightly-embed input_dir=/datasets/clothing-dataset-small/validation/dress`
```
## Bugfix:
Only do a version check if the process is started as main process, not as child procss

## Output when printing the results of this process type check and when version is set to 1.1.16
This only works before the commit `removed prints needed for reproducing the bug`
```
(venv) User@lightly lightly % lightly-embed input_dir=/datasets/clothing-dataset-small/validation/dress loader.num_workers=7         
Doing version check.
GitHub/lightly/venv/lib/python3.9/site-packages/lightly/api/version_checking.py:57: Warning: You are using lightly version 1.1.16. There is a newer version of the package available. For compatability reasons, please upgrade your current version: pip install lightly==1.1.18
  warnings.warn(Warning(warning))
Doing version check.
  0%|                                                                                                                                                                                                             | 0/2 [00:00<?, ?it/s]Skipped version check for process Process-1
Skipped version check for process Process-4
Skipped version check for process Process-7
Skipped version check for process Process-2
Skipped version check for process Process-3
Skipped version check for process Process-5
Skipped version check for process Process-6
Skipped version check for process Process-1
Skipped version check for process Process-4
Skipped version check for process Process-2
Skipped version check for process Process-6
Skipped version check for process Process-3
Skipped version check for process Process-7
Skipped version check for process Process-5
Compute efficiency: 1.00: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:14<00:00,  7.11s/it]
Embeddings are stored at GitHub/lightly/lightly_outputs/2021-09-02/10-56-29/embeddings.csv
```

## How to test it
```bash
pip uninstall lightly
export BRANCH_NAME="481-when-pip-version-older-than-newest-version,-it-calls-API-on-every-command-rather-than-caching-the-information-me"
pip install "git+https://github.com/lightly-ai/lightly.git@$BRANCH_NAME" 
lightly-embed input_dir=/datasets/clothing-dataset-small/validation/dress
```

## Additional, partly unrelated
Added unittests for the `lightly-embed`. They helped me in finding the bug