### PR TITLE
ssl model refactoring remove models, provide full examples instead

### DIFF
--- a/lightly/models/examples/moco_system.py
+++ b/lightly/models/examples/moco_system.py
@@ -8,8 +8,8 @@ from lightly.models.modules.momentum_encoder import MomentumEncoder
 
 
 class MocoSystem(pl.LightningModule):
-    def __init__(self, dataloader_kNN, num_classes):
-        super().__init__(dataloader_kNN, num_classes)
+    def __init__(self):
+        super().__init__()
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18', num_splits=8)
         self.backbone = torch.nn.Sequential(
@@ -19,7 +19,6 @@ class MocoSystem(pl.LightningModule):
         # create a moco model based on ResNet
         num_ftrs = 512
         out_dim = 128
-        self.m = 0.999
         self.projection_head = MoCoProjectionHead(num_ftrs, num_ftrs, out_dim)
 
         # define the momentum encoded model
@@ -62,6 +61,6 @@ class MocoSystem(pl.LightningModule):
         optim = torch.optim.SGD(self.resnet_moco.parameters(), lr=6e-2,
                                 momentum=0.9, weight_decay=5e-4)
         max_epochs = 200
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim,
-                                                               T_max=200)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optim, T_max=max_epochs)
         return [optim], [scheduler]

--- a/lightly/models/examples/moco_system.py
+++ b/lightly/models/examples/moco_system.py
@@ -1,0 +1,84 @@
+import pytorch_lightning as pl
+import torch
+
+from lightly.models._momentum import _MomentumEncoderMixin
+from lightly.models.modules.heads import MoCoProjectionHead
+
+import lightly
+
+
+class MocoSystem(pl.LightningModule, _MomentumEncoderMixin):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+        # create a ResNet backbone and remove the classification head
+        resnet = lightly.models.ResNetGenerator('resnet-18', num_splits=8)
+        self.backbone = torch.nn.Sequential(
+            *list(resnet.children())[:-1],
+            torch.nn.AdaptiveAvgPool2d(1),
+        )
+        # create a moco model based on ResNet
+        num_ftrs = 512
+        out_dim = 128
+        self.m = 0.999
+        self.projection_head = MoCoProjectionHead(num_ftrs, num_ftrs, out_dim)
+
+        # define the momentum encoded model
+        self.m = 0.999
+        self.batch_shuffle = True
+        self._init_momentum_encoder()  # takes the backbone and
+        # projection_head and defines the momentum_backbone and
+        # momentum_projection_head
+
+        # create our loss with the optional memory bank
+        self.criterion = lightly.loss.NTXentLoss(
+            temperature=0.1,
+            memory_bank_size=4096)
+
+    def forward(self, x):
+        features = self.backbone(x).flatten(start_dim=1)
+        out = self.projection_head(features)
+        return out
+
+    def forward_momentum(self, x):
+        self._momentum_update(self.m)
+        # shuffle for batchnorm
+        if self.batch_shuffle:
+            x, shuffle = self._batch_shuffle(x)
+
+        # run x through momentum encoder
+        features = self.momentum_backbone(x).flatten(start_dim=1)
+        out = self.momentum_projection_head(features)
+
+        # unshuffle for batchnorm
+        if self.batch_shuffle:
+            features = self._batch_unshuffle(features, shuffle)
+            out = self._batch_unshuffle(out, shuffle)
+
+        return out
+
+    def training_step(self, batch, batch_idx):
+        # We assume that x0 and x1 are different augmentations of the same
+        # image each
+        (x0, x1), _, _ = batch
+        # Run each augmentation separately through the model or momentum model
+        out0 = self.forward(x0)
+        out1 = self.forward_momentum(x1)
+
+        # We use a symmetric loss
+        # (model trains faster at little compute overhead)
+        # https://colab.research.google.com/github/facebookresearch/moco/
+        # blob/colab-notebook/colab/moco_cifar10_demo.ipynb
+        loss_1 = self.criterion(out0, out1)
+        loss_2 = self.criterion(out1, out0)
+        loss = 0.5 * (loss_1 + loss_2)
+
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_moco.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        max_epochs = 200
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optim,
+                                                               T_max=200)
+        return [optim], [scheduler]

--- a/lightly/models/examples/simclr_system.py
+++ b/lightly/models/examples/simclr_system.py
@@ -1,0 +1,52 @@
+import pytorch_lightning as pl
+import torch
+
+import lightly
+from lightly.models.modules.heads import SimCLRProjectionHead
+
+
+class SimClrSystem(pl.LightningModule):
+    def __init__(self, dataloader_kNN, num_classes):
+        super().__init__(dataloader_kNN, num_classes)
+
+        # create a simclr model based on ResNet
+        resnet = lightly.models.ResNetGenerator('resnet-18', num_splits=8)
+        # remove the classification head
+        self.backbone = torch.nn.Sequential(
+            *list(resnet.children())[:-1],
+            torch.nn.AdaptiveAvgPool2d(1),
+        )
+        # use a projection head instead
+        num_ftrs = 512
+        out_dim = 128
+        self.projection_head = \
+            SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
+
+        # define the criterion / loss function
+        self.criterion = lightly.loss.NTXentLoss()
+
+    def forward(self, x):
+        features = self.backbone(x).flatten(start_dim=1)
+        out = self.projection_head(features)
+        return out
+
+    def training_step(self, batch, batch_idx):
+        # We assume that x0 and x1 are different augmentations of the same
+        # image each
+        (x0, x1), _, _ = batch
+        # Run each augmentation separately through the model
+        out0 = self.forward(x0)
+        out1 = self.forward(x1)
+        # Compute the loss between the different representations of each
+        # augmentation
+        loss = self.criterion(out0, out1)
+        self.log('train_loss_ssl', loss)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.resnet_simclr.parameters(), lr=6e-2,
+                                momentum=0.9, weight_decay=5e-4)
+        max_epochs = 200
+        scheduler = \
+            torch.optim.lr_scheduler.CosineAnnealingLR(optim, max_epochs)
+        return [optim], [scheduler]

--- a/lightly/models/modules/momentum_encoder.py
+++ b/lightly/models/modules/momentum_encoder.py
@@ -1,0 +1,103 @@
+""" Momentum Encoder """
+
+# Copyright (c) 2020. Lightly AG and its affiliates.
+# All Rights Reserved
+
+import copy
+
+import torch
+import torch.nn as nn
+
+
+def _deactivate_requires_grad(params):
+    """Deactivates the requires_grad flag for all parameters.
+
+    """
+    for param in params:
+        param.requires_grad = False
+
+
+def _do_momentum_update(prev_params, params, m):
+    """Updates the weights of the previous parameters.
+
+    """
+    for prev_param, param in zip(prev_params, params):
+        prev_param.data = prev_param.data * m + param.data * (1. - m)
+
+
+class MomentumEncoder(nn.Module):
+    """Mixin to provide momentum encoder functionalities.
+
+    Provides the following functionalities:
+        - Momentum encoder initialization.
+        - Momentum updates.
+        - Batch shuffling and unshuffling.
+
+    """
+
+    def __init__(self, backbone, projection_head, momentum: float = 0.999,
+                 batch_shuffle: bool = True):
+        """Initializes momentum backbone and a momentum projection head.
+
+        """
+        super().__init__()
+        self.backbone = backbone
+        self.projection_head = projection_head
+        self.momentum = momentum
+        self.batch_shuffle = batch_shuffle
+
+        self.momentum_backbone = copy.deepcopy(backbone)
+        self.momentum_projection_head = copy.deepcopy(projection_head)
+        _deactivate_requires_grad(self.momentum_backbone.parameters())
+        _deactivate_requires_grad(self.momentum_projection_head.parameters())
+
+    def forward(self, x):
+        self._momentum_update(self.momentum)
+        
+        # shuffle for batchnorm
+        if self.batch_shuffle:
+            x, shuffle = self._batch_shuffle(x)
+
+        # run x through momentum encoder
+        features = self.momentum_backbone(x).flatten(start_dim=1)
+        out = self.momentum_projection_head(features)
+
+        # unshuffle for batchnorm
+        if self.batch_shuffle:
+            features = self._batch_unshuffle(features, shuffle)
+            out = self._batch_unshuffle(out, shuffle)
+
+        return out
+
+    @torch.no_grad()
+    def _momentum_update(self, m: float = 0.999):
+        """Performs the momentum update for the backbone and projection head.
+
+        """
+        _do_momentum_update(
+            self.momentum_backbone.parameters(),
+            self.backbone.parameters(),
+            m=m,
+        )
+        _do_momentum_update(
+            self.momentum_projection_head.parameters(),
+            self.projection_head.parameters(),
+            m=m,
+        )
+
+    @torch.no_grad()
+    def _batch_shuffle(self, batch: torch.Tensor):
+        """Returns the shuffled batch and the indices to undo.
+
+        """
+        batch_size = batch.shape[0]
+        shuffle = torch.randperm(batch_size, device=batch.device)
+        return batch[shuffle], shuffle
+
+    @torch.no_grad()
+    def _batch_unshuffle(self, batch: torch.Tensor, shuffle: torch.Tensor):
+        """Returns the unshuffled batch.
+
+        """
+        unshuffle = torch.argsort(shuffle)
+        return batch[unshuffle]


### PR DESCRIPTION
closes #483

## Description:
- implemented high-level examples for MoCo and SimCLR as pytorch lightning modules
- put the MomentumEncoder is an independent class (no Mixin anymore)

## Open to-dos:

- [ ] write new momentum encoder (make it more flexible)
- [ ] make cli work 
- [ ] deprecation warning old momentum encoder
- [ ] implement high-level example for one new model (e.g. SwAV) https://github.com/lightly-ai/lightly/issues/492
- [ ] deprecation warnings for old models


- [ ] 3. delete mid-level models in lightly/lightly/models
- [ ] 4. ensure compatibility with old pretrained models
- [ ] 5. update documentation
- [ ] 6. implement high-level examples for all implemented papers based on base building blocks
