### PR TITLE
Better check for invalid chars in filenames

### DIFF
--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -1,20 +1,11 @@
 import csv
 from typing import List
 
-from lightly.openapi_generated.swagger_client.models.dataset_embedding_data import DatasetEmbeddingData
-from lightly.openapi_generated.swagger_client.models.write_csv_url_data import WriteCSVUrlData
-
-
-
-def _is_valid_filename(filename: str):
-    """Returns False if the filename is misformatted.
-
-    """
-    invalid_characters = [',']
-    for character in invalid_characters:
-        if character in filename:
-            return False
-    return True
+from lightly.openapi_generated.swagger_client.models.dataset_embedding_data \
+    import DatasetEmbeddingData
+from lightly.openapi_generated.swagger_client.models.write_csv_url_data \
+    import WriteCSVUrlData
+from lightly.utils.io import check_filenames
 
 
 class _UploadEmbeddingsMixin:
@@ -104,12 +95,12 @@ class _UploadEmbeddingsMixin:
                 raise ValueError(f'There are {len(filenames)} rows in the embedding file, but '
                                  f'{len(self.filenames_on_server)} filenames/samples on the server.')
             if set(filenames) != set(self.filenames_on_server):
-                raise ValueError(f'The filenames in the embedding file and the filenames on the server do not align')
-            invalid_filenames = [f for f in filenames if not _is_valid_filename(f)]
-            if len(invalid_filenames) > 0:
-                raise ValueError(f'Invalid filename(s) in embedding file: {invalid_filenames}')
+                raise ValueError(f'The filenames in the embedding file and '
+                                 f'the filenames on the server do not align')
+            check_filenames(filenames)
 
-            rows_without_header_ordered = self._order_list_by_filenames(filenames, rows_without_header)
+            rows_without_header_ordered = \
+                self._order_list_by_filenames(filenames, rows_without_header)
 
             rows_to_write = [header_row]
             rows_to_write += rows_without_header_ordered

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -3,7 +3,9 @@ from bisect import bisect_left
 
 import tqdm
 
-from lightly.openapi_generated.swagger_client.models.sample_update_request import SampleUpdateRequest
+from lightly.openapi_generated.swagger_client.models.sample_update_request import \
+    SampleUpdateRequest
+from lightly.utils.io import COCO_ANNOTATION_KEYS
 
 
 def _assert_key_exists_in_custom_metadata(key: str, dictionary: Dict):
@@ -35,12 +37,11 @@ class _UploadCustomMetadataMixin:
 
         """
         _assert_key_exists_in_custom_metadata(
-            _COCO_ANNOTATION_KEYS.images, custom_metadata
+            COCO_ANNOTATION_KEYS.images, custom_metadata
         )
         _assert_key_exists_in_custom_metadata(
-            _COCO_ANNOTATION_KEYS.custom_metadata, custom_metadata
+            COCO_ANNOTATION_KEYS.custom_metadata, custom_metadata
         )
-
 
     def index_custom_metadata_by_filename(self,
                                           filenames: List[str],
@@ -59,29 +60,28 @@ class _UploadCustomMetadataMixin:
 
         """
 
-
         # sort images by filename
-        custom_metadata[_COCO_ANNOTATION_KEYS.images] = sorted(
-            custom_metadata[_COCO_ANNOTATION_KEYS.images],
-            key=lambda x: x[_COCO_ANNOTATION_KEYS.images_filename]
+        custom_metadata[COCO_ANNOTATION_KEYS.images] = sorted(
+            custom_metadata[COCO_ANNOTATION_KEYS.images],
+            key=lambda x: x[COCO_ANNOTATION_KEYS.images_filename]
         )
 
         # sort metadata by image id
-        custom_metadata[_COCO_ANNOTATION_KEYS.custom_metadata] = sorted(
-            custom_metadata[_COCO_ANNOTATION_KEYS.custom_metadata],
-            key=lambda x: x[_COCO_ANNOTATION_KEYS.custom_metadata_image_id]
+        custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata] = sorted(
+            custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata],
+            key=lambda x: x[COCO_ANNOTATION_KEYS.custom_metadata_image_id]
         )
 
         # get a list of filenames for binary search
         image_filenames = [
-            image[_COCO_ANNOTATION_KEYS.images_filename] for image in 
-            custom_metadata[_COCO_ANNOTATION_KEYS.images]        
+            image[COCO_ANNOTATION_KEYS.images_filename] for image in
+            custom_metadata[COCO_ANNOTATION_KEYS.images]
         ]
 
         # get a list of image ids for binary search
         metadata_image_ids = [
-            data[_COCO_ANNOTATION_KEYS.custom_metadata_image_id] for data in 
-            custom_metadata[_COCO_ANNOTATION_KEYS.custom_metadata]        
+            data[COCO_ANNOTATION_KEYS.custom_metadata_image_id] for data in
+            custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata]
         ]
 
         # map filename to metadata in O(n * logn)
@@ -94,8 +94,8 @@ class _UploadCustomMetadataMixin:
                     f'Image with filename {filename} does not exist in custom metadata!'
                 )
 
-            image = custom_metadata[_COCO_ANNOTATION_KEYS.images][image_index]
-            image_id = image[_COCO_ANNOTATION_KEYS.images_id]
+            image = custom_metadata[COCO_ANNOTATION_KEYS.images][image_index]
+            image_id = image[COCO_ANNOTATION_KEYS.images_id]
 
             metadata_index = bisect_left(metadata_image_ids, image_id)
             if metadata_index == len(metadata_image_ids):
@@ -103,11 +103,11 @@ class _UploadCustomMetadataMixin:
                     f'Image with id {image_id} has no custom metadata!'
                 )
 
-            metadata = custom_metadata[_COCO_ANNOTATION_KEYS.custom_metadata][metadata_index]
+            metadata = custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata][
+                metadata_index]
             filename_to_metadata[filename] = metadata
 
         return filename_to_metadata
-
 
     def upload_custom_metadata(self,
                                custom_metadata: Dict,

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -6,20 +6,6 @@ import tqdm
 from lightly.openapi_generated.swagger_client.models.sample_update_request import SampleUpdateRequest
 
 
-class _COCO_ANNOTATION_KEYS:
-    """Enum of coco annotation keys complemented with a key for custom metadata.
-    
-    """
-    # image keys
-    images: str = 'images'
-    images_id: str = 'id'
-    images_filename: str = 'file_name'
-
-    # metadata keys
-    custom_metadata: str = 'metadata'
-    custom_metadata_image_id: str = 'image_id'
-
-
 def _assert_key_exists_in_custom_metadata(key: str, dictionary: Dict):
     """Raises a formatted KeyError if key is not a key of the dictionary.
     
@@ -72,6 +58,7 @@ class _UploadCustomMetadataMixin:
             A dictionary containing custom metdata indexed by filename.
 
         """
+
 
         # sort images by filename
         custom_metadata[_COCO_ANNOTATION_KEYS.images] = sorted(

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -160,7 +160,10 @@ class LightlyDataset:
         if index_to_filename is not None:
             self.index_to_filename = index_to_filename
 
-        check_filenames(self.get_filenames())
+        # if created from an input directory with filenames, check if they
+        # are valid
+        if input_dir:
+            check_filenames(self.get_filenames())
 
     @classmethod
     def from_torch_dataset(cls,

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -18,6 +18,7 @@ from torchvision import transforms
 from lightly.data._helpers import _load_dataset
 from lightly.data._helpers import DatasetFolder
 from lightly.data._video import VideoDataset
+from lightly.utils.io import check_filenames
 
 
 def _get_filename_by_index(dataset, index):
@@ -158,6 +159,8 @@ class LightlyDataset:
         self.index_to_filename = _get_filename_by_index
         if index_to_filename is not None:
             self.index_to_filename = index_to_filename
+
+        check_filenames(self.get_filenames())
 
     @classmethod
     def from_torch_dataset(cls,

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -99,7 +99,6 @@ def load_embeddings(path: str):
 
     """
     filenames, labels = [], []
-    check_filenames(filenames)
     embeddings = []
     with open(path, 'r', newline='') as csv_file:
         reader = csv.reader(csv_file, delimiter=',')
@@ -112,6 +111,8 @@ def load_embeddings(path: str):
             labels.append(int(row[-1]))
             # read embeddings
             embeddings.append(row[1:-1])
+
+    check_filenames(filenames)
 
     embeddings = np.array(embeddings).astype(np.float32)
     return embeddings, labels, filenames

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -176,7 +176,7 @@ def load_embeddings_as_dict(path: str,
         return data
 
 
-class _COCO_ANNOTATION_KEYS:
+class COCO_ANNOTATION_KEYS:
     """Enum of coco annotation keys complemented with a key for custom metadata.
 
     """
@@ -214,17 +214,17 @@ def format_custom_metadata(custom_metadata: List[Tuple[str, Dict]]):
     
     """
     formatted = {
-        _COCO_ANNOTATION_KEYS.images: [],
-        _COCO_ANNOTATION_KEYS.custom_metadata: [],
+        COCO_ANNOTATION_KEYS.images: [],
+        COCO_ANNOTATION_KEYS.custom_metadata: [],
     }
 
     for i, (filename, metadata) in enumerate(custom_metadata):
-        formatted[_COCO_ANNOTATION_KEYS.images].append({
-            _COCO_ANNOTATION_KEYS.images_id: i,
-            _COCO_ANNOTATION_KEYS.images_filename: filename,
+        formatted[COCO_ANNOTATION_KEYS.images].append({
+            COCO_ANNOTATION_KEYS.images_id: i,
+            COCO_ANNOTATION_KEYS.images_filename: filename,
         })
-        formatted[_COCO_ANNOTATION_KEYS.custom_metadata].append({
-            _COCO_ANNOTATION_KEYS.custom_metadata_image_id: i,
+        formatted[COCO_ANNOTATION_KEYS.custom_metadata].append({
+            COCO_ANNOTATION_KEYS.custom_metadata_image_id: i,
             **metadata,
         })
 

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -23,6 +23,13 @@ def _is_valid_filename(filename: str) -> bool:
 
 
 def check_filenames(filenames: List[str]):
+    """Raises an error if one of the filenames is misformatted
+
+    Args:
+        filenames:
+            A list of string being filenames
+
+    """
     invalid_filenames = [f for f in filenames if not _is_valid_filename(f)]
     if len(invalid_filenames) > 0:
         raise ValueError(f'Invalid filename(s): {invalid_filenames}')

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 
 import numpy as np
-from lightly.utils.io import save_embeddings
+from lightly.utils.io import save_embeddings, INVALID_FILENAME_CHARACTERS
 
 import lightly
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
@@ -12,7 +12,7 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
     def t_ester_upload_embedding(self,
                                  n_data,
                                  special_name_first_sample: bool = False,
-                                 comma_in_first_sample: bool = False):
+                                 special_char_in_first_filename: str = None):
         # create fake embeddings
         folder_path = tempfile.mkdtemp()
         path_to_embeddings = os.path.join(
@@ -22,8 +22,9 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
         sample_names = [f'img_{i}.jpg' for i in range(n_data)]
         if special_name_first_sample:
             sample_names[0] = "bliblablub"
-        if comma_in_first_sample:
-            sample_names[0] = "bli,blablu"
+        if special_char_in_first_filename:
+            sample_names[0] = f'_{special_char_in_first_filename}' \
+                              f'{sample_names[0]}'
         labels = [0] * len(sample_names)
         save_embeddings(
             path_to_embeddings,
@@ -51,8 +52,12 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
 
     def test_upload_comma_filenames(self):
         n_data = len(self.api_workflow_client.mappings_api.sample_names)
-        with self.assertRaises(ValueError):
-            self.t_ester_upload_embedding(n_data=n_data, comma_in_first_sample=True)
+        for invalid_char in INVALID_FILENAME_CHARACTERS:
+            with self.subTest(msg=f"invalid_char: {invalid_char}"):
+                with self.assertRaises(ValueError):
+                    self.t_ester_upload_embedding(
+                        n_data=n_data,
+                        special_char_in_first_filename=invalid_char)
 
     def test_set_embedding_id_success(self):
         embedding_name = self.api_workflow_client.embeddings_api.embeddings[0].name

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -70,11 +70,3 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
 
     def test_set_embedding_id_default(self):
         self.api_workflow_client.set_embedding_id_by_name()
-
-    def test_is_valid_filename(self):
-        filenames = [',a', ',', 'a,', 'a']
-        is_valid = [False, False, False, True]
-        result = [
-            lightly.api.api_workflow_upload_embeddings._is_valid_filename(f) for f in filenames
-        ]
-        self.assertListEqual(is_valid, result)

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -7,9 +7,9 @@ import tempfile
 import warnings
 import numpy as np
 from lightly.data import LightlyDataset
-import pytest
 
 from lightly.data._utils import check_images
+from lightly.utils.io import INVALID_FILENAME_CHARACTERS
 
 try:
     from lightly.data._video import VideoDataset
@@ -135,6 +135,26 @@ class TestLightlyDataset(unittest.TestCase):
 
         for i in range(n_tot):
             sample, target, fname = dataset[i]
+
+    def test_create_lightly_dataset_with_invalid_char_in_filename(self):
+
+        # create a dataset
+        n_tot = 100
+        dataset = torchvision.datasets.FakeData(size=n_tot,
+                                                image_size=(3, 32, 32))
+
+        for invalid_char in INVALID_FILENAME_CHARACTERS:
+            with self.subTest(msg=f"invalid_char: {invalid_char}"):
+                tmp_dir = tempfile.mkdtemp()
+                sample_names = [f'img_,_{i}.jpg' for i in range(n_tot)]
+                for sample_idx in range(n_tot):
+                    data = dataset[sample_idx]
+                    path = os.path.join(tmp_dir, sample_names[sample_idx])
+                    data[0].save(path)
+
+                # create lightly dataset
+                    with self.assertRaises(ValueError):
+                        dataset = LightlyDataset(input_dir=tmp_dir)
 
     def test_check_images(self):
 

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -2,6 +2,7 @@ import sys
 import tempfile
 
 from lightly.utils import save_custom_metadata
+from lightly.utils.io import check_filenames
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
 
 
@@ -15,3 +16,20 @@ class TestCLICrop(MockedApiWorkflowSetup):
         metadata = [("filename.jpg", {"random_metadata": 42})]
         metadata_filepath = tempfile.mktemp('.json', 'metadata')
         save_custom_metadata(metadata_filepath, metadata)
+
+    def test_valid_filenames(self):
+        valid = 'img.png'
+        non_valid = 'img,1.png'
+        filenames_list = [
+            ([valid], True),
+            ([valid, valid], True),
+            ([non_valid], False),
+            ([valid, non_valid], False),
+        ]
+        for filenames, valid in filenames_list:
+            with self.subTest(msg=f"filenames:{filenames}"):
+                if valid:
+                    check_filenames(filenames)
+                else:
+                    with self.assertRaises(ValueError):
+                        check_filenames(filenames)


### PR DESCRIPTION
closes https://github.com/lightly-ai/lightly-core/issues/1038
## Description:
- Puts the function to check if the filenames are valid into the utils. https://github.com/lightly-ai/lightly/blob/f73b4e05f2205cf2b17a75fc425c1f7dd26f3960/lightly/utils/io.py#L25
- Uses it when creating a `LightlyDataset`. https://github.com/lightly-ai/lightly/blob/41b0f943a5f66163ddc28e4e18fa0b306a5958af/lightly/data/dataset.py#L163
- Uses it when saving embeddings. https://github.com/lightly-ai/lightly/blob/f73b4e05f2205cf2b17a75fc425c1f7dd26f3960/lightly/utils/io.py#L61
- Uses it when reading embeddings to upload them. https://github.com/lightly-ai/lightly/blob/41b0f943a5f66163ddc28e4e18fa0b306a5958af/lightly/utils/io.py#L115
- some formatting improvements to be flake8 compliant

## Unittests:
- Create LightlyDataset with invalid characters in the filenames and assert that an error is thrown.
- Save embeddings with invalid characters in the filenames and assert that an error is thrown.
- Load embeddings with invalid characters in the filenames and assert that an error is thrown.
