### PR TITLE
inline cropping image to reduce memory footprint

### DIFF
--- a/lightly/utils/cropping/crop_image_by_bounding_boxes.py
+++ b/lightly/utils/cropping/crop_image_by_bounding_boxes.py
@@ -9,9 +9,7 @@ from tqdm import tqdm
 from lightly.active_learning.utils import BoundingBox
 from lightly.data import LightlyDataset
 
-from memory_profiler import profile
 
-@profile
 def crop_dataset_by_bounding_boxes_and_save(dataset: LightlyDataset,
                                             output_dir: str,
                                             bounding_boxes_list_list: List[List[BoundingBox]],

--- a/lightly/utils/cropping/crop_image_by_bounding_boxes.py
+++ b/lightly/utils/cropping/crop_image_by_bounding_boxes.py
@@ -66,8 +66,12 @@ def crop_dataset_by_bounding_boxes_and_save(dataset: LightlyDataset,
         image = Image.open(filepath_image)
         
         cropped_images_filepaths = []
+        # For every image, crop out multiple cropped images, one for each
+        # bounding box
         for index, (class_index, bbox) in \
                 enumerate((zip(class_indices, bounding_boxes))):
+
+            # determine the filename and filepath of the cropped image
             if class_names:
                 class_name = class_names[class_index]
             else:
@@ -75,13 +79,14 @@ def crop_dataset_by_bounding_boxes_and_save(dataset: LightlyDataset,
             cropped_image_last_filename = f'{index}_{class_name}{image_extension}'
             cropped_image_filepath = os.path.join(filepath_out_dir, cropped_image_last_filename)
 
+            # crop out the image and save it
             w, h = image.size
             crop_box = (w * bbox.x0, h * bbox.y0, w * bbox.x1, h * bbox.y1)
             crop_box = tuple(int(i) for i in crop_box)
             cropped_image = image.crop(crop_box)
             cropped_image.save(cropped_image_filepath)
-            del cropped_image
 
+            # add the filename of the cropped image to the corresponding list
             cropped_image_filename = os.path.join(filename_image.replace(image_extension, ''), cropped_image_last_filename)
             cropped_images_filepaths.append(cropped_image_filename)
 

--- a/lightly/utils/cropping/crop_image_by_bounding_boxes.py
+++ b/lightly/utils/cropping/crop_image_by_bounding_boxes.py
@@ -43,7 +43,7 @@ def crop_dataset_by_bounding_boxes_and_save(dataset: LightlyDataset,
         raise ValueError("There must be one bounding box and class index list for each image in the datasets,"
                          "but the lengths dont align.")
 
-    cropped_image_filepath_list_list: List[List[Image]] = []
+    cropped_image_filepath_list_list: List[List[str]] = []
 
 
     print(f"Cropping objects out of {len(filenames_images)} images...")
@@ -87,7 +87,10 @@ def crop_dataset_by_bounding_boxes_and_save(dataset: LightlyDataset,
             cropped_image.save(cropped_image_filepath)
 
             # add the filename of the cropped image to the corresponding list
-            cropped_image_filename = os.path.join(filename_image.replace(image_extension, ''), cropped_image_last_filename)
+            cropped_image_filename: str = os.path.join(
+                filename_image.replace(image_extension, ''),
+                cropped_image_last_filename
+            )
             cropped_images_filepaths.append(cropped_image_filename)
 
         cropped_image_filepath_list_list.append(cropped_images_filepaths)


### PR DESCRIPTION
closes #485 

## Description
- do the cropping out of the image inline to prevent saving all images
- benchmarked it with a memory profiler: the memory footprint is much smaller