### PR TITLE
Add deprecation warning

### DIFF
--- a/lightly/models/__init__.py
+++ b/lightly/models/__init__.py
@@ -1,5 +1,8 @@
 """The lightly.models package provides model implementations.
 
+Note that the high-level building blocks will be deprecated with lightly version
+1.2.0.
+
 The package contains an implementation of the commonly used ResNet and
 adaptations of the architecture which make self-supervised learning simpler.
 

--- a/lightly/models/barlowtwins.py
+++ b/lightly/models/barlowtwins.py
@@ -5,6 +5,8 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import warnings
+
 import torch
 import torch.nn as nn
 
@@ -51,6 +53,12 @@ class BarlowTwins(nn.Module):
             proj_hidden_dim,
             out_dim
         )
+
+        warnings.warn(Warning(
+            'The high-level building block BarlowTwins will be deprecated in version 1.2.0. '
+            + 'Use low-level building blocks instead. '
+            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
+            PendingDeprecationWarning)
 
     def forward(self,
                 x0: torch.Tensor,

--- a/lightly/models/byol.py
+++ b/lightly/models/byol.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import warnings
+
 import torch
 import torch.nn as nn
 
@@ -60,6 +62,12 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
 
         self._init_momentum_encoder()
         self.m = m
+
+        warnings.warn(Warning(
+            'The high-level building block BYOL will be deprecated in version 1.2.0. '
+            + 'Use low-level building blocks instead. '
+            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
+            PendingDeprecationWarning)
 
     def _forward(self,
                  x0: torch.Tensor,

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import warnings
+
 import torch
 import torch.nn as nn
 
@@ -49,6 +51,12 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
 
         # initialize momentum features and momentum projection head
         self._init_momentum_encoder()
+
+        warnings.warn(Warning(
+            'The high-level building block MoCo will be deprecated in version 1.2.0. '
+            + 'Use low-level building blocks instead. '
+            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
+            PendingDeprecationWarning)
 
     def forward(self,
                 x0: torch.Tensor,

--- a/lightly/models/nnclr.py
+++ b/lightly/models/nnclr.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import warnings
+
 import torch
 import torch.nn as nn
 
@@ -150,6 +152,12 @@ class NNCLR(nn.Module):
             pred_hidden_dim,
             out_dim,
         )
+
+        warnings.warn(Warning(
+            'The high-level building block NNCLR will be deprecated in version 1.2.0. '
+            + 'Use low-level building blocks instead. '
+            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
+            PendingDeprecationWarning)
 
     def forward(self,
                 x0: torch.Tensor,

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import warnings
+
 import torch
 import torch.nn as nn
 
@@ -35,6 +37,12 @@ class SimCLR(nn.Module):
 
         self.backbone = backbone
         self.projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
+
+        warnings.warn(Warning(
+            'The high-level building block SimCLR will be deprecated in version 1.2.0. '
+            + 'Use low-level building blocks instead. '
+            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
+            PendingDeprecationWarning)
 
     def forward(self,
                 x0: torch.Tensor,

--- a/lightly/models/simsiam.py
+++ b/lightly/models/simsiam.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import warnings
+
 import torch
 import torch.nn as nn
 
@@ -59,6 +61,12 @@ class SimSiam(nn.Module):
             pred_hidden_dim,
             out_dim,
         )
+
+        warnings.warn(
+            'The high-level building block SimSiam will be deprecated in version 1.2.0. '
+            + 'Use low-level building blocks instead. '
+            + 'See https://docs.lightly.ai/lightly.models.htmlfor more information',
+            PendingDeprecationWarning)
 
         
     def forward(self, 

--- a/lightly/models/simsiam.py
+++ b/lightly/models/simsiam.py
@@ -62,12 +62,11 @@ class SimSiam(nn.Module):
             out_dim,
         )
 
-        warnings.warn(
+        warnings.warn(Warning(
             'The high-level building block SimSiam will be deprecated in version 1.2.0. '
             + 'Use low-level building blocks instead. '
-            + 'See https://docs.lightly.ai/lightly.models.htmlfor more information',
+            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
             PendingDeprecationWarning)
-
         
     def forward(self, 
                 x0: torch.Tensor, 


### PR DESCRIPTION
### Changes

closes #498 

- Add deprecation warning for SimSiam model


Example of how it looks like in practice:

```
(lightly) igor_lightly_ai@igor-compute:~/lightly$ ipython
Python 3.7.8 | packaged by conda-forge | (default, Jul 31 2020, 02:25:08) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.18.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from lightly.models import SimSiam
/home/igor_lightly_ai/lightly/lightly/api/version_checking.py:57: Warning: You are using lightly version 1.1.18. There is a newer version of the package available. For compatability reasons, please upgrade your current version: pip install lightly==1.1.19
  warnings.warn(Warning(warning))

In [2]: from torchvision.models import resnet18

In [3]: backbone = resnet18()

In [4]: simsiam = SimSiam(backbone)
/home/igor_lightly_ai/lightly/lightly/models/simsiam.py:68: Warning: The high-level building block SimSiam will be deprecated in version 1.2.0. Use low-level building blocks instead. See https://docs.lightly.ai/lightly.models.html for more information
  PendingDeprecationWarning)
```