### PR TITLE
remove embeddings_sorted.csv

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -129,13 +129,13 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             filenames_for_list.
 
         """
-        if not len(filenames_for_list) == len(list_to_order) or \
-                not len(filenames_for_list) == len(self.filenames_on_server):
+        if len(filenames_for_list) != len(list_to_order) or \
+                len(filenames_for_list) != len(self.filenames_on_server):
             raise ValueError(
                 f"All inputs (filenames_for_list,  list_to_order and "
                 f"self.filenames_on_server) must have the same length, "
-                f"but they have lengths of: ({len(filenames_for_list)},"
-                f"{len(list_to_order)} and {len(self.filenames_on_server)}."
+                f"but their lengths are: ({len(filenames_for_list)},"
+                f"{len(list_to_order)} and {len(self.filenames_on_server)})."
             )
         dict_by_filenames = dict(zip(filenames_for_list, list_to_order))
         list_ordered = [dict_by_filenames[filename] for filename in self.filenames_on_server]

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -129,8 +129,14 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             filenames_for_list.
 
         """
-        assert len(filenames_for_list) == len(list_to_order)
-        assert len(filenames_for_list) == len(self.filenames_on_server)
+        if not len(filenames_for_list) == len(list_to_order) or \
+                not len(filenames_for_list) == len(self.filenames_on_server):
+            raise ValueError(
+                f"All inputs (filenames_for_list,  list_to_order and "
+                f"self.filenames_on_server) must have the same length, "
+                f"but they have lengths of: ({len(filenames_for_list)},"
+                f"{len(list_to_order)} and {len(self.filenames_on_server)}."
+            )
         dict_by_filenames = dict(zip(filenames_for_list, list_to_order))
         list_ordered = [dict_by_filenames[filename] for filename in self.filenames_on_server]
         return list_ordered

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -109,7 +109,10 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
     def _get_all_tags(self) -> List[TagData]:
         return self.tags_api.get_tags_by_dataset_id(self.dataset_id)
 
-    def _order_list_by_filenames(self, filenames_for_list: List[str], list_to_order: List[object]) -> List[object]:
+    def _order_list_by_filenames(
+            self, filenames_for_list: List[str],
+            list_to_order: List[object]
+    ) -> List[object]:
         """Orders a list such that it is in the order of the filenames specified on the server.
 
         Args:
@@ -119,14 +122,17 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
                 Some values belonging to the samples
 
         Returns:
-            The list reordered. The same reorder applied on the filenames_for_list
-            would put them in the order of the filenames in self.filenames_on_server
+            The list reordered.
+            The same reorder applied on the filenames_for_list would put them
+            in the order of the filenames in self.filenames_on_server.
+            every filename in self.filenames_on_server must be in the
+            filenames_for_list.
 
         """
         assert len(filenames_for_list) == len(list_to_order)
+        assert len(filenames_for_list) == len(self.filenames_on_server)
         dict_by_filenames = dict(zip(filenames_for_list, list_to_order))
-        list_ordered = [dict_by_filenames[filename] for filename in self.filenames_on_server
-                        if filename in filenames_for_list]
+        list_ordered = [dict_by_filenames[filename] for filename in self.filenames_on_server]
         return list_ordered
 
     @property

--- a/tests/UNMOCKED_end2end_tests/test_api.py
+++ b/tests/UNMOCKED_end2end_tests/test_api.py
@@ -92,7 +92,9 @@ def create_new_dataset_with_embeddings(path_to_dataset: str,
         print("Finished save of embeddings")
 
     # upload the embeddings
+    print("Starting embedding upload")
     api_workflow_client.upload_embeddings(path_to_embeddings_csv=path_to_embeddings_csv, name="embedding_1")
+    print("Finished embedding upload")
 
     return api_workflow_client
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 from io import IOBase
 
@@ -214,7 +215,9 @@ class MockedQuotaApi(QuotaApi):
 
 def mocked_request_put(dst_url: str, data=IOBase) -> Response:
     assert isinstance(dst_url, str)
-    assert isinstance(data, IOBase)
+    content_bytes: bytes = data.read()
+    content_str: str = content_bytes.decode('utf-8')
+    assert content_str.startswith('filenames')
     response_ = Response()
     response_.status_code = 200
     return response_

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -258,6 +258,13 @@ class MockedApiWorkflowClient(ApiWorkflowClient):
 
         self.wait_time_till_next_poll = 0.001  # for api_workflow_sampling
 
+    def upload_file_with_signed_url(
+            self, file: IOBase, signed_write_url: str,
+            max_backoff: int = 32, max_retries: int = 5
+    ) -> Response:
+        res = Response()
+        return res
+
 
 class MockedApiWorkflowSetup(unittest.TestCase):
     def setUp(self, token="token_xyz",  dataset_id="dataset_id_xyz") -> None:

--- a/tests/api_workflow/test_api_workflow.py
+++ b/tests/api_workflow/test_api_workflow.py
@@ -47,7 +47,8 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
             api_workflow_client = MockedApiWorkflowClient(token="token_xyz", dataset_id="dataset_id_xyz")
             api_workflow_client.mappings_api.sample_names = filenames_on_server
 
-            numbers_in_tag = list(np.random.choice(numbers_to_choose_from, 50))
+            numbers_in_tag = np.copy(numbers_all)
+            np.random.shuffle(numbers_in_tag)
             filenames_for_list = [f"img_{i}" for i in numbers_in_tag]
 
             list_ordered = api_workflow_client._order_list_by_filenames(filenames_for_list,
@@ -59,10 +60,10 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
         filenames_on_server = ['a', 'b', 'c']
         api_workflow_client = MockedApiWorkflowClient(token="token_xyz", dataset_id="dataset_id_xyz")
         api_workflow_client.mappings_api.sample_names = filenames_on_server
-        filenames_for_list = ['c', 'a']
-        list_to_order = ['cccc', 'aaaa']
+        filenames_for_list = ['c', 'a', 'b']
+        list_to_order = ['cccc', 'aaaa', 'bbbb']
         list_ordered = api_workflow_client._order_list_by_filenames(filenames_for_list, list_to_order=list_to_order)
-        list_desired_order = ['aaaa', 'cccc']
+        list_desired_order = ['aaaa', 'bbbb', 'cccc']
         assert list_ordered == list_desired_order
 
 

--- a/tests/api_workflow/test_api_workflow.py
+++ b/tests/api_workflow/test_api_workflow.py
@@ -66,6 +66,32 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
         list_desired_order = ['aaaa', 'bbbb', 'cccc']
         assert list_ordered == list_desired_order
 
+    def test_reorder_wrong_lengths(self):
+        filenames_on_server = ['a', 'b', 'c']
+        api_workflow_client = MockedApiWorkflowClient(
+            token="token_xyz", dataset_id="dataset_id_xyz"
+        )
+        api_workflow_client.mappings_api.sample_names = filenames_on_server
+        filenames_for_list = ['c', 'a', 'b']
+        list_to_order = ['cccc', 'aaaa', 'bbbb']
+
+        with self.subTest("filenames_for_list wrong length"):
+            with self.assertRaises(ValueError):
+                api_workflow_client._order_list_by_filenames(
+                    filenames_for_list[:-1], list_to_order)
+
+        with self.subTest("list_to_order wrong length"):
+            with self.assertRaises(ValueError):
+                api_workflow_client._order_list_by_filenames(
+                    filenames_for_list, list_to_order[:-1])
+
+        with self.subTest("filenames_for_list and list_to_order wrong length"):
+            with self.assertRaises(ValueError):
+                api_workflow_client._order_list_by_filenames(
+                    filenames_for_list[:-1], list_to_order[:-1])
+
+
+
 
 
 

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -8,7 +8,7 @@ import lightly
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 
-class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
+class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
     def t_ester_upload_embedding(self,
                                  n_data,
                                  special_name_first_sample: bool = False,

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -14,9 +14,9 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
                                  special_name_first_sample: bool = False,
                                  special_char_in_first_filename: str = None):
         # create fake embeddings
-        folder_path = tempfile.mkdtemp()
+        self.folder_path = tempfile.mkdtemp()
         path_to_embeddings = os.path.join(
-            folder_path,
+            self.folder_path,
             'embeddings.csv'
         )
         sample_names = [f'img_{i}.jpg' for i in range(n_data)]
@@ -39,6 +39,8 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
     def test_upload_success(self):
         n_data = len(self.api_workflow_client.mappings_api.sample_names)
         self.t_ester_upload_embedding(n_data=n_data)
+        filepath_embeddings_sorted = os.path.join(self.folder_path, "embeddings_sorted.csv")
+        self.assertFalse(os.path.isfile(filepath_embeddings_sorted))
 
     def test_upload_wrong_lenght(self):
         n_data = 42 + len(self.api_workflow_client.mappings_api.sample_names)
@@ -70,3 +72,12 @@ class TestApiWorkflowUploadEmbeddigns(MockedApiWorkflowSetup):
 
     def test_set_embedding_id_default(self):
         self.api_workflow_client.set_embedding_id_by_name()
+
+    def tearDown(self) -> None:
+        for filename in ["embeddings.csv", "embeddings_sorted.csv"]:
+            try:
+                filepath = os.path.join(self.folder_path, filename)
+                os.remove(filepath)
+            except FileNotFoundError:
+                pass
+

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -75,9 +75,10 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
 
     def tearDown(self) -> None:
         for filename in ["embeddings.csv", "embeddings_sorted.csv"]:
-            try:
-                filepath = os.path.join(self.folder_path, filename)
-                os.remove(filepath)
-            except FileNotFoundError:
-                pass
+            if hasattr(self, 'folder_path'):
+                try:
+                    filepath = os.path.join(self.folder_path, filename)
+                    os.remove(filepath)
+                except FileNotFoundError:
+                    pass
 


### PR DESCRIPTION
closes #514 

## Description
- saves the sorted embeddings in a temporary in-memory file (first a string file, then a bytes file)
- uploads directly from the in-memory file

## Miscellaneous
- fixes a bug in ordering filenames by other filenames, that had a quadratic time complexity. Now it is required, that every filename on the server must also be in the list of filenames to be ordered.
- fixes a bug that the upload of a file to a signed url was not mocked to succeed always.

## Test of filename ordering:
```
  File "/Users/malteebnerlightly/Documents/GitHub/lightly/lightly/api/api_workflow_client.py", line 134, in _order_list_by_filenames
    raise ValueError(
ValueError: All inputs (filenames_for_list,  list_to_order and self.filenames_on_server) must have the same length, but their lengths are: (2,3 and 3).
```

## Performance
Preparing an `embeddings.csv` for upload with 1M samples now takes 40s.
![image](https://user-images.githubusercontent.com/20324507/135445401-200804e9-190f-433c-85f5-2943668d9a58.png)
