### PR TITLE
536 Fix nnclr

### DIFF
--- a/lightly/models/nnclr.py
+++ b/lightly/models/nnclr.py
@@ -148,7 +148,7 @@ class NNCLR(nn.Module):
         )
         
         self.prediction_mlp = NNCLRPredictionHead(
-            num_ftrs,
+            out_dim,
             pred_hidden_dim,
             out_dim,
         )
@@ -202,7 +202,7 @@ class NNCLR(nn.Module):
         # forward pass of first input x0
         f0 = self.backbone(x0).flatten(start_dim=1)
         z0 = self.projection_mlp(f0)
-        p0 = self.prediction_mlp(f0)
+        p0 = self.prediction_mlp(z0)
 
         out0 = (z0, p0)
 
@@ -217,7 +217,7 @@ class NNCLR(nn.Module):
         # forward pass of second input x1
         f1 = self.backbone(x1).flatten(start_dim=1)
         z1 = self.projection_mlp(f1)
-        p1 = self.prediction_mlp(f1)
+        p1 = self.prediction_mlp(z1)
 
         out1 = (z1, p1)
 


### PR DESCRIPTION
# 536 Fix nnclr

Closes #536.

Result from the benchmark (improvement by 1.5%):
```
NNCLR_256: 0.847 +- 0.000, GPU used: 3.9 GByte
```
