### PR TITLE
embedding upload bugfix new dataset name

### DIFF
--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -194,10 +194,12 @@ class _UploadEmbeddingsMixin:
             index_filenames = header_row.index('filenames')
             filenames = [row[index_filenames] for row in rows_without_header]
 
-            if len(filenames) != len(self.filenames_on_server):
+            filenames_on_server = self.filenames_on_server
+
+            if len(filenames) != len(filenames_on_server):
                 raise ValueError(f'There are {len(filenames)} rows in the embedding file, but '
-                                 f'{len(self.filenames_on_server)} filenames/samples on the server.')
-            if set(filenames) != set(self.filenames_on_server):
+                                 f'{len(filenames_on_server)} filenames/samples on the server.')
+            if set(filenames) != set(filenames_on_server):
                 raise ValueError(f'The filenames in the embedding file and '
                                  f'the filenames on the server do not align')
             check_filenames(filenames)

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -14,19 +14,20 @@ from lightly.openapi_generated.swagger_client.models.write_csv_url_data \
 from lightly.utils.io import check_filenames
 
 
-def _get_csv_reader_from_read_url(read_url: str):
-    """Makes a get request to the signed read url and returns the .csv file.
-
-    """
-    request = Request(read_url, method='GET')
-    with urlopen(request) as response:
-        buffer = io.StringIO(response.read().decode('utf-8'))
-        reader = csv.reader(buffer)
-
-    return reader
 
 
 class _UploadEmbeddingsMixin:
+
+    def _get_csv_reader_from_read_url(self, read_url: str):
+        """Makes a get request to the signed read url and returns the .csv file.
+
+        """
+        request = Request(read_url, method='GET')
+        with urlopen(request) as response:
+            buffer = io.StringIO(response.read().decode('utf-8'))
+            reader = csv.reader(buffer)
+
+        return reader
 
 
     def set_embedding_id_by_name(self, embedding_name: str = None):
@@ -141,7 +142,7 @@ class _UploadEmbeddingsMixin:
         # read embedding from API
         embedding_read_url = self.embeddings_api \
             .get_embeddings_csv_read_url_by_id(self.dataset_id, embedding_id)
-        embedding_reader = _get_csv_reader_from_read_url(embedding_read_url)
+        embedding_reader = self._get_csv_reader_from_read_url(embedding_read_url)
         rows = list(embedding_reader)
         header, online_rows = rows[0], rows[1:]
 
@@ -152,8 +153,8 @@ class _UploadEmbeddingsMixin:
             if len(local_rows[0]) != len(header):
                 raise RuntimeError(
                     'Column mismatch! Number of columns in local and remote'
-                    f'embeddings files must match but are {len(local_rows[0])}'
-                    f'and {len(header[0])} respectively.'
+                    f' embeddings files must match but are {len(local_rows[0])}'
+                    f' and {len(header)} respectively.'
                 )
 
             local_rows = local_rows[1:]

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -40,8 +40,12 @@ def _upload_cli(cfg, is_cli_call=True):
         print_as_warning('Please specify your access token.')
         cli_api_args_wrong = True
 
-    dataset_id_ok = dataset_id and len(dataset_id) > 0
-    new_dataset_name_ok = new_dataset_name and len(new_dataset_name) > 0
+    if dataset_id and len(dataset_id) > 0:
+        dataset_id_ok = True
+    else:
+        dataset_id_ok = False
+        del dataset_id
+    new_dataset_name_ok = bool(new_dataset_name and len(new_dataset_name) > 0)
     if new_dataset_name_ok and not dataset_id_ok:
         api_workflow_client = ApiWorkflowClient(token=token)
         api_workflow_client.create_dataset(dataset_name=new_dataset_name)
@@ -99,7 +103,7 @@ def _upload_cli(cfg, is_cli_call=True):
         print('Starting upload of embeddings.')
         try:
             embeddings = api_workflow_client.embeddings_api \
-                .get_embeddings_by_dataset_id(dataset_id=dataset_id)
+                .get_embeddings_by_dataset_id(dataset_id=api_workflow_client.dataset_id)
             # use latest embedding first
             embeddings = sorted(
                 embeddings,

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -59,6 +59,7 @@ def _upload_cli(cfg, is_cli_call=True):
                 'Please specify either the dataset_id of an existing dataset '
                 'or a new_dataset_name.')
             cli_api_args_wrong = True
+    del dataset_id
 
     if cli_api_args_wrong:
         print_as_warning('For help, try: lightly-upload --help')

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -121,24 +121,14 @@ def _upload_cli(cfg, is_cli_call=True):
 
         if embedding is not None:
 
-            filenames_on_server = api_workflow_client.filenames_on_server
-            with open(path_to_embeddings, 'r') as f:
-                # count number of new embedding rows
-                n_rows = -1 + sum(
-                    1 for row in csv.reader(f)
-                    if list(row)[0] not in set(filenames_on_server)
-                )
-
-            if n_rows < len(filenames_on_server): 
-                # more filenames than rows in the embedding file
-                # -> append rows from server
-                print('Appending embeddings from server.')
-                api_workflow_client.append_embeddings(
-                    path_to_embeddings,
-                    embedding.id,
-                )
-                now = datetime.now().strftime('%Y%m%d_%Hh%Mm%Ss')
-                name = f'{name}_{now}'
+            # -> append rows from server
+            print('Appending embeddings from server.')
+            api_workflow_client.append_embeddings(
+                path_to_embeddings,
+                embedding.id,
+            )
+            now = datetime.now().strftime('%Y%m%d_%Hh%Mm%Ss')
+            name = f'{name}_{now}'
 
         api_workflow_client.upload_embeddings(
             path_to_embeddings_csv=path_to_embeddings, name=name

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -142,7 +142,7 @@ def _upload_cli(cfg, is_cli_call=True):
             verbose=True
         )
 
-    if new_dataset_name_ok:
+    if new_dataset_name:
         print(f'The dataset_id of the newly created dataset is '
               f'{bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')
 

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -59,6 +59,8 @@ def _upload_cli(cfg, is_cli_call=True):
                 'Please specify either the dataset_id of an existing dataset '
                 'or a new_dataset_name.')
             cli_api_args_wrong = True
+    # delete the dataset_id as it might be an empty string
+    # Use api_workflow_client.dataset_id instead
     del dataset_id
 
     if cli_api_args_wrong:

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -40,26 +40,25 @@ def _upload_cli(cfg, is_cli_call=True):
         print_as_warning('Please specify your access token.')
         cli_api_args_wrong = True
 
-    if dataset_id and len(dataset_id) > 0:
-        dataset_id_ok = True
+    if dataset_id:
+        if new_dataset_name:
+            print_as_warning(
+                'Please specify either the dataset_id of an existing dataset '
+                'or a new_dataset_name, but not both.'
+            )
+            cli_api_args_wrong = True
+        else:
+            api_workflow_client = \
+                ApiWorkflowClient(token=token,dataset_id=dataset_id)
     else:
-        dataset_id_ok = False
-        del dataset_id
-    new_dataset_name_ok = bool(new_dataset_name and len(new_dataset_name) > 0)
-    if new_dataset_name_ok and not dataset_id_ok:
-        api_workflow_client = ApiWorkflowClient(token=token)
-        api_workflow_client.create_dataset(dataset_name=new_dataset_name)
-    elif dataset_id_ok and not new_dataset_name_ok:
-        api_workflow_client = ApiWorkflowClient(
-            token=token,
-            dataset_id=dataset_id
-        )
-    else:
-        print_as_warning(
-            'Please specify either the dataset_id of an existing dataset or a '
-            'new_dataset_name.'
-        )
-        cli_api_args_wrong = True
+        if new_dataset_name:
+            api_workflow_client = ApiWorkflowClient(token=token)
+            api_workflow_client.create_dataset(dataset_name=new_dataset_name)
+        else:
+            print_as_warning(
+                'Please specify either the dataset_id of an existing dataset '
+                'or a new_dataset_name.')
+            cli_api_args_wrong = True
 
     if cli_api_args_wrong:
         print_as_warning('For help, try: lightly-upload --help')

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -49,7 +49,7 @@ def _upload_cli(cfg, is_cli_call=True):
             cli_api_args_wrong = True
         else:
             api_workflow_client = \
-                ApiWorkflowClient(token=token,dataset_id=dataset_id)
+                ApiWorkflowClient(token=token, dataset_id=dataset_id)
     else:
         if new_dataset_name:
             api_workflow_client = ApiWorkflowClient(token=token)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -38,6 +38,11 @@ from lightly.openapi_generated.swagger_client.models.tag_data import TagData
 from lightly.openapi_generated.swagger_client.models.write_csv_url_data import WriteCSVUrlData
 
 
+def _check_dataset_id(dataset_id: str):
+    assert isinstance(dataset_id, str)
+    assert len(dataset_id) > 0
+
+
 class MockedEmbeddingsApi(EmbeddingsApi):
     def __init__(self, api_client):
         EmbeddingsApi.__init__(self, api_client=api_client)
@@ -58,23 +63,28 @@ class MockedEmbeddingsApi(EmbeddingsApi):
         ]
 
     def get_embeddings_csv_write_url_by_id(self, dataset_id: str, **kwargs):
+        _check_dataset_id(dataset_id)
         assert isinstance(dataset_id, str)
         response_ = WriteCSVUrlData(signed_write_url="signed_write_url_valid", embedding_id="embedding_id_xyz")
         return response_
 
     def get_embeddings_by_dataset_id(self, dataset_id, **kwargs) -> List[DatasetEmbeddingData]:
+        _check_dataset_id(dataset_id)
         assert isinstance(dataset_id, str)
         return self.embeddings
 
     def trigger2d_embeddings_job(self, body, dataset_id, embedding_id, **kwargs):
+        _check_dataset_id(dataset_id)
         assert isinstance(body, EmbeddingIdTrigger2dEmbeddingsJobBody)
 
     def get_embeddings_csv_read_url_by_id(self, dataset_id, embedding_id, **kwargs):
+        _check_dataset_id(dataset_id)
         return 'https://my-embedding-read-url.com'
 
 
 class MockedSamplingsApi(SamplingsApi):
     def trigger_sampling_by_id(self, body: SamplingCreateRequest, dataset_id, embedding_id, **kwargs):
+        _check_dataset_id(dataset_id)
         assert isinstance(body, SamplingCreateRequest)
         assert isinstance(dataset_id, str)
         assert isinstance(embedding_id, str)
@@ -103,12 +113,14 @@ class MockedJobsApi(JobsApi):
 
 class MockedTagsApi(TagsApi):
     def create_initial_tag_by_dataset_id(self, body, dataset_id, **kwargs):
+        _check_dataset_id(dataset_id)
         assert isinstance(body, InitialTagCreateRequest)
         assert isinstance(dataset_id, str)
         response_ = CreateEntityResponse(id="xyz")
         return response_
 
     def get_tag_by_tag_id(self, dataset_id, tag_id, **kwargs):
+        _check_dataset_id(dataset_id)
         assert isinstance(dataset_id, str)
         assert isinstance(tag_id, str)
         response_ = TagData(id=tag_id, dataset_id=dataset_id, prev_tag_id="initial-tag", bit_mask_data="0x80bda23e9",
@@ -116,6 +128,7 @@ class MockedTagsApi(TagsApi):
         return response_
 
     def get_tags_by_dataset_id(self, dataset_id, **kwargs):
+        _check_dataset_id(dataset_id)
         if dataset_id == 'xyz-no-tags':
             return []
         tag_1 = TagData(id='inital_tag_id', dataset_id=dataset_id, prev_tag_id=None,
@@ -136,15 +149,18 @@ class MockedTagsApi(TagsApi):
         return tags
 
     def perform_tag_arithmetics(self, body: TagArithmeticsRequest, dataset_id, **kwargs):
+        _check_dataset_id(dataset_id)
         return TagBitMaskResponse(bit_mask_data="0x2")
 
     def upsize_tags_by_dataset_id(self, body, dataset_id, **kwargs):
+        _check_dataset_id(dataset_id)
         assert body.upsize_tag_creator == TagCreator.USER_PIP
 
 
 class MockedScoresApi(ScoresApi):
     def create_or_update_active_learning_score_by_tag_id(self, body, dataset_id, tag_id, **kwargs) -> \
             CreateEntityResponse:
+        _check_dataset_id(dataset_id)
         if len(body.scores) > 0 and not isinstance(body.scores[0], float):
             raise AttributeError
         response_ = CreateEntityResponse(id="sampled_tag_id_xyz")
@@ -179,20 +195,24 @@ class MockedSamplesApi(SamplesApi):
         return samples
 
     def create_sample_by_dataset_id(self, body, dataset_id, **kwargs):
+        _check_dataset_id(dataset_id)
         assert isinstance(body, SampleCreateRequest)
         response_ = CreateEntityResponse(id="xyz")
         self.sample_create_requests.append(body)
         return response_
 
     def get_sample_image_write_url_by_id(self, dataset_id, sample_id, is_thumbnail, **kwargs):
+        _check_dataset_id(dataset_id)
         url = f"{sample_id}_write_url"
         return url
 
     def get_sample_image_read_url_by_id(self, dataset_id, sample_id, type, **kwargs):
+        _check_dataset_id(dataset_id)
         url = f"{sample_id}_write_url"
         return url
 
     def get_sample_image_write_urls_by_id(self, dataset_id, sample_id, **kwargs) -> SampleWriteUrls:
+        _check_dataset_id(dataset_id)
         thumb_url = f"{sample_id}_thumb_write_url"
         full_url = f"{sample_id}_full_write_url"
         ret = SampleWriteUrls(full=full_url, thumb=thumb_url)
@@ -225,12 +245,15 @@ class MockedDatasetsApi(DatasetsApi):
         return response_
 
     def get_dataset_by_id(self, dataset_id):
+        _check_dataset_id(dataset_id)
         return next(dataset for dataset in self.default_datasets if dataset_id == dataset.id)
 
     def register_dataset_upload_by_id(self, body, dataset_id):
+        _check_dataset_id(dataset_id)
         return True
 
     def delete_dataset_by_id(self, dataset_id, **kwargs):
+        _check_dataset_id(dataset_id)
         datasets_without_that_id = [dataset for dataset in self.datasets if dataset.id != dataset_id]
         assert len(datasets_without_that_id) == len(self.datasets) - 1
         self.datasets = datasets_without_that_id

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -306,7 +306,8 @@ class MockedApiClient(ApiClient):
 
 class MockedApiWorkflowClient(ApiWorkflowClient):
 
-    embeddings_filename_base = 'sample'
+    embeddings_filename_base = 'img'
+    n_embedding_rows_on_server = N_FILES_ON_SERVER
 
     def __init__(self, *args, **kwargs):
         lightly.api.api_workflow_client.ApiClient = MockedApiClient

--- a/tests/api_workflow/test_api_workflow_upload_dataset.py
+++ b/tests/api_workflow/test_api_workflow_upload_dataset.py
@@ -144,7 +144,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
 
     def test_upload_dataset_twice_with_overlap(self):
 
-        all_sample_names = [f'sample_{i}.jpg' for i in range(10)]
+        all_sample_names = [f'img_{i}.jpg' for i in range(10)]
 
         # upload first part of the dataset (sample_0 - sample_6)
         self.create_fake_dataset(sample_names=all_sample_names[:7])

--- a/tests/api_workflow/test_api_workflow_upload_dataset.py
+++ b/tests/api_workflow/test_api_workflow_upload_dataset.py
@@ -144,7 +144,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
 
     def test_upload_dataset_twice_with_overlap(self):
 
-        all_sample_names = [f'img_{i}.jpg' for i in range(10)]
+        all_sample_names = [f'img_upload_twice_{i}.jpg' for i in range(10)]
 
         # upload first part of the dataset (sample_0 - sample_6)
         self.create_fake_dataset(sample_names=all_sample_names[:7])

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -96,8 +96,10 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
             self.api_workflow_client.set_embedding_id_by_name(embedding_name)
 
     def test_upload_existing_embedding(self):
-        embedding_name = self.api_workflow_client.embeddings_api.\
+        embeddings = self.api_workflow_client.embeddings_api.\
             get_embeddings_by_dataset_id(self.api_workflow_client.dataset_id)
+
+        embedding_name = embeddings[0].name
 
         n_data = len(self.api_workflow_client.mappings_api.sample_names)
         self.t_ester_upload_embedding(n_data=n_data, name=embedding_name)

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -46,7 +46,9 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
                                  n_data,
                                  n_dims: int = 32,
                                  special_name_first_sample: bool = False,
-                                 special_char_in_first_filename: str = None):
+                                 special_char_in_first_filename: str = None,
+                                 name: str = "embedding_xyz"
+                                 ):
 
         self.create_fake_embeddings(
             n_data,
@@ -56,7 +58,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         )
 
         # perform the workflow to upload the embeddings
-        self.api_workflow_client.upload_embeddings(path_to_embeddings_csv=self.path_to_embeddings, name="embedding_xyz")
+        self.api_workflow_client.upload_embeddings(path_to_embeddings_csv=self.path_to_embeddings, name=name)
         self.api_workflow_client.n_dims_embeddings_on_server = n_dims
 
     def test_upload_success(self):
@@ -92,6 +94,13 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         embedding_name = "blibblabblub"
         with self.assertRaises(ValueError):
             self.api_workflow_client.set_embedding_id_by_name(embedding_name)
+
+    def test_upload_existing_embedding(self):
+        embedding_name = self.api_workflow_client.embeddings_api.\
+            get_embeddings_by_dataset_id(self.api_workflow_client.dataset_id)
+
+        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        self.t_ester_upload_embedding(n_data=n_data, name=embedding_name)
 
     def test_set_embedding_id_default(self):
         self.api_workflow_client.set_embedding_id_by_name()

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -9,34 +9,11 @@ import numpy as np
 from lightly.utils.io import save_embeddings, load_embeddings, INVALID_FILENAME_CHARACTERS
 
 import lightly
-from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
+from tests.api_workflow.mocked_api_workflow_client import \
+    MockedApiWorkflowSetup, N_FILES_ON_SERVER
 
 
 class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
-
-    EMBEDDINGS_FILENAME_BASE: str = 'sample'
-
-    def mock_get_embeddings_from_api(self, read_url, n_rows: int = 10, n_dims: int = 32):
-
-        rows_csv = [['filenames'] + [f'embeddings_{i}' for i in range(n_dims)] + ['labels']]
-        for i in range(n_rows):
-            row = [f'{TestApiWorkflowUploadEmbeddings.EMBEDDINGS_FILENAME_BASE}_{i}.jpg']
-            for _ in range(n_dims):
-                row.append(random.uniform(0, 1))
-            row.append(i)
-            rows_csv.append(row)
-
-        # save the csv rows in a temporary in-memory string file
-        # using a csv writer and then read them as bytes
-        f = tempfile.SpooledTemporaryFile(mode="rw")
-        writer = csv.writer(f)
-        writer.writerows(rows_csv)
-        f.seek(0)
-        buffer = io.StringIO(f.read())
-        reader = csv.reader(buffer)
-
-        return reader
-
 
     def create_fake_embeddings(self,
                                n_data,
@@ -80,6 +57,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
 
         # perform the workflow to upload the embeddings
         self.api_workflow_client.upload_embeddings(path_to_embeddings_csv=self.path_to_embeddings, name="embedding_xyz")
+        self.api_workflow_client.n_dims_embeddings_on_server = n_dims
 
     def test_upload_success(self):
         n_data = len(self.api_workflow_client.mappings_api.sample_names)
@@ -127,7 +105,10 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         # create a new set of embeddings
         self.create_fake_embeddings(10)
 
-        lightly.api.api_workflow_upload_embeddings._get_csv_reader_from_read_url = self.mock_get_embeddings_from_api
+        # mock the embeddings on the server
+        self.api_workflow_client.n_embedding_rows_on_server = N_FILES_ON_SERVER
+        self.api_workflow_client.n_dims_embeddings_on_server = 32
+
         self.api_workflow_client.append_embeddings(
             self.path_to_embeddings,
             'embedding_id_xyz_2',
@@ -143,9 +124,12 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         # create a new set of embeddings overlapping with current embeddings
         self.create_fake_embeddings(100)
 
+        # mock the embeddings on the server
+        self.api_workflow_client.n_embedding_rows_on_server = N_FILES_ON_SERVER
+        self.api_workflow_client.n_dims_embeddings_on_server = 32
+        self.api_workflow_client.embeddings_filename_base = 'img'
+
         # the mock embeddings function returns embeddings which overlap with the ones generated above
-        TestApiWorkflowUploadEmbeddings.EMBEDDINGS_FILENAME_BASE: str = 'img'
-        lightly.api.api_workflow_upload_embeddings._get_csv_reader_from_read_url = self.mock_get_embeddings_from_api
         self.api_workflow_client.append_embeddings(
             self.path_to_embeddings,
             'embedding_id_xyz_2',
@@ -180,8 +164,10 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         # create a new set of embeddings
         self.create_fake_embeddings(10, n_dims=16) # default is 32
 
+        self.api_workflow_client.n_embedding_rows_on_server = N_FILES_ON_SERVER
+        self.api_workflow_client.n_dims_embeddings_on_server = 32
+
         with self.assertRaises(RuntimeError):
-            lightly.api.api_workflow_upload_embeddings._get_csv_reader_from_read_url = self.mock_get_embeddings_from_api
             self.api_workflow_client.append_embeddings(
                 self.path_to_embeddings,
                 'embedding_id_xyz_2',

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -106,7 +106,6 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         self.create_fake_embeddings(10)
 
         # mock the embeddings on the server
-        self.api_workflow_client.n_embedding_rows_on_server = N_FILES_ON_SERVER
         self.api_workflow_client.n_dims_embeddings_on_server = 32
 
         self.api_workflow_client.append_embeddings(
@@ -125,9 +124,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         self.create_fake_embeddings(100)
 
         # mock the embeddings on the server
-        self.api_workflow_client.n_embedding_rows_on_server = N_FILES_ON_SERVER
         self.api_workflow_client.n_dims_embeddings_on_server = 32
-        self.api_workflow_client.embeddings_filename_base = 'img'
 
         # the mock embeddings function returns embeddings which overlap with the ones generated above
         self.api_workflow_client.append_embeddings(
@@ -164,7 +161,6 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         # create a new set of embeddings
         self.create_fake_embeddings(10, n_dims=16) # default is 32
 
-        self.api_workflow_client.n_embedding_rows_on_server = N_FILES_ON_SERVER
         self.api_workflow_client.n_dims_embeddings_on_server = 32
 
         with self.assertRaises(RuntimeError):

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -7,12 +7,8 @@ import torchvision
 from hydra.experimental import compose, initialize
 
 import lightly
-from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
-
-
-# get the mock embeddings function
-from tests.api_workflow.test_api_workflow_upload_embeddings import TestApiWorkflowUploadEmbeddings
-mock_get_embeddings_from_api = TestApiWorkflowUploadEmbeddings().mock_get_embeddings_from_api
+from tests.api_workflow.mocked_api_workflow_client import \
+    MockedApiWorkflowSetup, MockedApiWorkflowClient, N_FILES_ON_SERVER
 
 
 class TestCLIMagic(MockedApiWorkflowSetup):
@@ -61,13 +57,15 @@ class TestCLIMagic(MockedApiWorkflowSetup):
         assert self.cfg["upload"] == 'thumbnails'
 
     def test_magic_new_dataset_name(self):
-        lightly.api.api_workflow_upload_embeddings._get_csv_reader_from_read_url = mock_get_embeddings_from_api
+        MockedApiWorkflowClient.n_rows = N_FILES_ON_SERVER
+        MockedApiWorkflowClient.n_dims_embeddings_on_server = 32
         cli_string = "lightly-magic new_dataset_name='xyz-no-tags'"
         self.parse_cli_string(cli_string)
         lightly.cli.lightly_cli(self.cfg)
 
     def test_magic_new_dataset_id(self):
-        lightly.api.api_workflow_upload_embeddings._get_csv_reader_from_read_url = mock_get_embeddings_from_api
+        MockedApiWorkflowClient.n_dims_embeddings_on_server = N_FILES_ON_SERVER
+        MockedApiWorkflowClient.n_dims_embeddings_on_server = 32
         cli_string = "lightly-magic dataset_id='xyz-no-tags'"
         self.parse_cli_string(cli_string)
         lightly.cli.lightly_cli(self.cfg)

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -57,16 +57,14 @@ class TestCLIMagic(MockedApiWorkflowSetup):
         assert self.cfg["upload"] == 'thumbnails'
 
     def test_magic_new_dataset_name(self):
-        MockedApiWorkflowClient.n_rows = N_FILES_ON_SERVER
         MockedApiWorkflowClient.n_dims_embeddings_on_server = 32
-        cli_string = "lightly-magic new_dataset_name='xyz-no-tags'"
+        cli_string = "lightly-magic new_dataset_name='dataset_name_xyz'"
         self.parse_cli_string(cli_string)
         lightly.cli.lightly_cli(self.cfg)
 
     def test_magic_new_dataset_id(self):
-        MockedApiWorkflowClient.n_dims_embeddings_on_server = N_FILES_ON_SERVER
         MockedApiWorkflowClient.n_dims_embeddings_on_server = 32
-        cli_string = "lightly-magic dataset_id='xyz-no-tags'"
+        cli_string = "lightly-magic dataset_id='dataset_id_xyz'"
         self.parse_cli_string(cli_string)
         lightly.cli.lightly_cli(self.cfg)
 

--- a/tests/cli/test_cli_upload.py
+++ b/tests/cli/test_cli_upload.py
@@ -93,23 +93,25 @@ class TestCLIUpload(MockedApiWorkflowSetup):
         dims_embeddings_options = [8, 32]
         n_embedding_rows_on_server = 80
         for n_dims_embeddings in dims_embeddings_options:
-            with self.subTest(
-                    f"test_{n_dims_embeddings}"
-            ):
+            for n_dims_embeddings_server in dims_embeddings_options:
+                with self.subTest(
+                        f"test_{n_dims_embeddings}_{n_dims_embeddings_server}"
+                ):
 
-                def upload_dataset(n_dims_embeddings):
                     self.create_fake_dataset(
                         n_data=N_FILES_ON_SERVER-n_embedding_rows_on_server,
                         n_rows_embeddings=N_FILES_ON_SERVER,
                         n_dims_embeddings=n_dims_embeddings
                     )
                     MockedApiWorkflowClient.n_embedding_rows_on_server = n_embedding_rows_on_server
-                    MockedApiWorkflowClient.n_dims_embeddings_on_server = n_dims_embeddings
+                    MockedApiWorkflowClient.n_dims_embeddings_on_server = n_dims_embeddings_server
                     cli_string = f"lightly-upload new_dataset_name='new_dataset_name_xyz' embeddings={self.path_to_embeddings}"
                     self.parse_cli_string(cli_string)
-                    lightly.cli.upload_cli(self.cfg)
-
-                upload_dataset(n_dims_embeddings)
+                    if n_dims_embeddings != n_dims_embeddings_server:
+                        with self.assertRaises(ValueError):
+                            lightly.cli.upload_cli(self.cfg)
+                    else:
+                        lightly.cli.upload_cli(self.cfg)
 
     def test_upload_new_dataset_id(self):
         cli_string = "lightly-upload dataset_id='xyz'"

--- a/tests/cli/test_cli_upload.py
+++ b/tests/cli/test_cli_upload.py
@@ -10,7 +10,8 @@ from hydra.experimental import compose, initialize
 
 import lightly
 from lightly.utils import save_embeddings
-from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
+from tests.api_workflow.mocked_api_workflow_client import \
+    MockedApiWorkflowSetup, MockedApiWorkflowClient, N_FILES_ON_SERVER
 
 
 class TestCLIUpload(MockedApiWorkflowSetup):
@@ -24,12 +25,13 @@ class TestCLIUpload(MockedApiWorkflowSetup):
         with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
             self.cfg = compose(config_name="config", overrides=["token='123'", f"input_dir={self.folder_path}"])
 
-    def create_fake_dataset(self, n_data: int=5):
+
+    def create_fake_dataset(self, n_data: int=5, n_rows_embeddings: int=5, n_dims_embeddings: int = 4):
         self.dataset = torchvision.datasets.FakeData(size=n_data,
                                                      image_size=(3, 32, 32))
 
         self.folder_path = tempfile.mkdtemp()
-        sample_names = [f'img_{i}.jpg' for i in range(n_data)]
+        sample_names = [f'sample_{i}.jpg' for i in range(n_data)]
         self.sample_names = sample_names
         for sample_idx in range(n_data):
             data = self.dataset[sample_idx]
@@ -49,14 +51,14 @@ class TestCLIUpload(MockedApiWorkflowSetup):
         self.tfile.flush()
 
         # create fake embeddings
-        n_dims = 4
         self.path_to_embeddings = os.path.join(self.folder_path, 'embeddings.csv')
-        labels = [0] * len(sample_names)
+        sample_names_embeddings = [f'sample_{i}.jpg' for i in range(n_rows_embeddings)]
+        labels = [0] * len(sample_names_embeddings)
         save_embeddings(
             self.path_to_embeddings,
-            np.random.randn(n_data, n_dims),
+            np.random.randn(n_rows_embeddings, n_dims_embeddings),
             labels,
-            sample_names
+            sample_names_embeddings
         )
 
 
@@ -88,9 +90,26 @@ class TestCLIUpload(MockedApiWorkflowSetup):
         lightly.cli.upload_cli(self.cfg)
 
     def test_upload_new_dataset_name_and_embeddings(self):
-        cli_string = f"lightly-upload new_dataset_name='new_dataset_name_xyz' embeddings={self.path_to_embeddings}"
-        self.parse_cli_string(cli_string)
-        lightly.cli.upload_cli(self.cfg)
+        dims_embeddings_options = [8, 32]
+        n_embedding_rows_on_server = 80
+        for n_dims_embeddings in dims_embeddings_options:
+            with self.subTest(
+                    f"test_{n_dims_embeddings}"
+            ):
+
+                def upload_dataset(n_dims_embeddings):
+                    self.create_fake_dataset(
+                        n_data=N_FILES_ON_SERVER-n_embedding_rows_on_server,
+                        n_rows_embeddings=N_FILES_ON_SERVER,
+                        n_dims_embeddings=n_dims_embeddings
+                    )
+                    MockedApiWorkflowClient.n_embedding_rows_on_server = n_embedding_rows_on_server
+                    MockedApiWorkflowClient.n_dims_embeddings_on_server = n_dims_embeddings
+                    cli_string = f"lightly-upload new_dataset_name='new_dataset_name_xyz' embeddings={self.path_to_embeddings}"
+                    self.parse_cli_string(cli_string)
+                    lightly.cli.upload_cli(self.cfg)
+
+                upload_dataset(n_dims_embeddings)
 
     def test_upload_new_dataset_id(self):
         cli_string = "lightly-upload dataset_id='xyz'"


### PR DESCRIPTION
closes #544 

## description
- fixes the bug in #544 
- fixes the bug in https://github.com/lightly-ai/lightly/issues/544#issuecomment-969390020

## Other changes
- changed the MockedApiWorkflowClient to ensure that all datasets ids passed are valid. 
- adds much more unittests, especially for the CLI upload
- reworks some of the unittests to reuse functionality. E.g. `MockedApiWorkflowClient._get_csv_reader_from_read_url()` now allows all unittests to mock the returned embeddings file on the server (upload_cli, magic_clie, test of direct upload).

## Follow-up:
- https://github.com/lightly-ai/lightly/issues/546