### PR TITLE
Update MoCo tutorial to use low-level blocks

### DIFF
--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -341,12 +341,12 @@ class Classifier(pl.LightningModule):
     def validation_epoch_end(self, outputs):
         # calculate and log top1 accuracy
         if outputs:
-            total_num = torch.Tensor([0],).to(self.device)
-            total_correct = torch.Tensor([0.0],).to(self.device)
+            total_num = 0
+            total_correct = 0
             for num, correct in outputs:
                 total_num += num
                 total_correct += correct
-            acc = total_correct.item() / total_num.item()
+            acc = total_correct / total_num
             self.log("val_acc", acc, on_epoch=True, prog_bar=True)
 
     def configure_optimizers(self):


### PR DESCRIPTION
- Rewrite MocoModel
- Remove `MocoModel.forward` as unused
- Switch to terminology from paper
- Rewrite Classifier
- Remove normalization in `Classifier.forward` as it is not in protocol
- Remove `pl.metrics.Accuracy` as it is deprecated
- Add code for accuracy calculation

I decided to use the non-symmetric version of MoCo due to #564 and because it is easier to understand.

[moco_tutorial.pdf](https://github.com/lightly-ai/lightly/files/7564322/moco_tutorial.pdf)
