### PR TITLE
precompute VideoDataset.length() to prevent squared complexity

### DIFF
--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -334,8 +334,18 @@ class VideoDataset(datasets.VisionDataset):
     def __len__(self):
         """Returns the number of samples (frames) in the dataset.
 
+        This can be precomputed, because self.video_timestamps is only
+        set in the __init__
         """
-        return sum((len(ts) for ts in self.video_timestamps))
+        try:
+            #raise AttributeError
+            return self._precomputed_length
+        except AttributeError:
+            self._precomputed_length = sum((
+                len(ts) for ts
+                 in self.video_timestamps
+            ))
+            return self._precomputed_length
 
     def get_filename(self, index):
         """Returns a filename for the frame at index.

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -271,9 +271,9 @@ class VideoDataset(datasets.VisionDataset):
 
         self.videos = videos
         self.video_timestamps = video_timestamps
-        self._precomputed_length = sum((
+        self._length = sum((
             len(ts) for ts in self.video_timestamps
-            ))
+        ))
         # offsets[i] indicates the index of the first frame of the i-th video.
         # e.g. for two videos of length 10 and 20, the offsets will be [0, 10].
         self.offsets = offsets
@@ -340,7 +340,7 @@ class VideoDataset(datasets.VisionDataset):
         This can be precomputed, because self.video_timestamps is only
         set in the __init__
         """
-        return self._precomputed_length
+        return self._length
 
     def get_filename(self, index):
         """Returns a filename for the frame at index.

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -271,6 +271,9 @@ class VideoDataset(datasets.VisionDataset):
 
         self.videos = videos
         self.video_timestamps = video_timestamps
+        self._precomputed_length = sum((
+            len(ts) for ts in self.video_timestamps
+            ))
         # offsets[i] indicates the index of the first frame of the i-th video.
         # e.g. for two videos of length 10 and 20, the offsets will be [0, 10].
         self.offsets = offsets
@@ -337,15 +340,7 @@ class VideoDataset(datasets.VisionDataset):
         This can be precomputed, because self.video_timestamps is only
         set in the __init__
         """
-        try:
-            #raise AttributeError
-            return self._precomputed_length
-        except AttributeError:
-            self._precomputed_length = sum((
-                len(ts) for ts
-                 in self.video_timestamps
-            ))
-            return self._precomputed_length
+        return self._precomputed_length
 
     def get_filename(self, index):
         """Returns a filename for the frame at index.


### PR DESCRIPTION
closes #562 

## Description
precomputes the VideoDataset.length() as it is used everytime a single frame is accessed.

## Profiling results
Measured the duration of creating a `LightlyDataset()` on an input directory with videos with 91 frames each.

| number of videos  | 100  | 300  | 1000  | 3000  |
|-----------------------------------|------|------|-------|-------|
| duration before fix               | 2.33 | 6.88 | 28.96 | 128.6 |
| duration after fix                | 2.3  | 6.63 | 23.04 | 76.87 |

## Profiling with 1000 images before bugfix
<img width="683" alt="image" src="https://user-images.githubusercontent.com/20324507/142462207-7c00a046-1f2c-4339-a361-c6be5e86dea7.png">
