### PR TITLE
Malte lig 301 fix + refactor api_workflow_client

### DIFF
--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -70,7 +70,7 @@ class ActiveLearningAgent:
 
         # build lookup table for tag_name to tag_id
         tag_name_id_dict = {}
-        for tag in self.api_workflow_client._get_all_tags():
+        for tag in self.api_workflow_client.get_all_tags():
             tag_name_id_dict[tag.name] = tag.id
         # use lookup table to set ids
         self._query_tag_id = tag_name_id_dict[query_tag_name]

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -120,7 +120,7 @@ class ActiveLearningAgent:
 
         """
         return self._query_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.download_filenames_from_server()
+            self.api_workflow_client.get_filenames()
         )
 
     @property
@@ -129,7 +129,7 @@ class ActiveLearningAgent:
 
         """
         return self._preselected_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.download_filenames_from_server()
+            self.api_workflow_client.get_filenames()
         )
 
     @property
@@ -140,7 +140,7 @@ class ActiveLearningAgent:
         # unlabeled set is the query set minus the preselected set
         unlabeled_tag_bitmask = self._query_tag_bitmask - self._preselected_tag_bitmask
         return unlabeled_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.download_filenames_from_server()
+            self.api_workflow_client.get_filenames()
         )
 
     @property
@@ -157,7 +157,7 @@ class ActiveLearningAgent:
         # added set is new preselected set minus the old one
         added_tag_bitmask = self._preselected_tag_bitmask - self._old_preselected_tag_bitmask
         return added_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.download_filenames_from_server()
+            self.api_workflow_client.get_filenames()
         )
 
 

--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -89,7 +89,7 @@ class ActiveLearningAgent:
 
         """
         # get query tag from api and set bitmask accordingly
-        query_tag_data = self.api_workflow_client.tags_api.get_tag_by_tag_id(
+        query_tag_data = self.api_workflow_client._tags_api.get_tag_by_tag_id(
             self.api_workflow_client.dataset_id,
             tag_id=self._query_tag_id
         )
@@ -106,7 +106,7 @@ class ActiveLearningAgent:
             preselected_tag_bitmask = BitMask.from_hex('0x0')
         else:
             # get preselected tag from api and set bitmask accordingly
-            preselected_tag_data = self.api_workflow_client.tags_api.get_tag_by_tag_id(
+            preselected_tag_data = self.api_workflow_client._tags_api.get_tag_by_tag_id(
                 self.api_workflow_client.dataset_id,
                 tag_id=self._preselected_tag_id
             )
@@ -120,7 +120,7 @@ class ActiveLearningAgent:
 
         """
         return self._query_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.filenames_on_server
+            self.api_workflow_client.download_filenames_from_server()
         )
 
     @property
@@ -129,7 +129,7 @@ class ActiveLearningAgent:
 
         """
         return self._preselected_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.filenames_on_server
+            self.api_workflow_client.download_filenames_from_server()
         )
 
     @property
@@ -140,7 +140,7 @@ class ActiveLearningAgent:
         # unlabeled set is the query set minus the preselected set
         unlabeled_tag_bitmask = self._query_tag_bitmask - self._preselected_tag_bitmask
         return unlabeled_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.filenames_on_server
+            self.api_workflow_client.download_filenames_from_server()
         )
 
     @property
@@ -157,7 +157,7 @@ class ActiveLearningAgent:
         # added set is new preselected set minus the old one
         added_tag_bitmask = self._preselected_tag_bitmask - self._old_preselected_tag_bitmask
         return added_tag_bitmask.masked_select_from_list(
-            self.api_workflow_client.filenames_on_server
+            self.api_workflow_client.download_filenames_from_server()
         )
 
 

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -158,68 +158,6 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             get_sample_mappings_by_dataset_id(dataset_id=self.dataset_id, field="fileName")
         return filenames_on_server
 
-    def get_tag_and_filenames(
-            self,
-            tag_name: str = None,
-            tag_id: str = None,
-            filenames_on_server: List[str] = None,
-            exclude_parent_tag: bool = False
-    ) -> Tuple[TagData, List[str]]:
-        """Gets the TagData of a tag and the filenames in it
-
-        The tag_name or the tag_id must be passed.
-        The tag_name overwrites the tag_id.
-        Args:
-            tag_name:
-                The name of the tag.
-            tag_id:
-                The id of the tag.
-            filenames_on_server:
-                List of all filenames on the server. If they are not given,
-                they need to be download newly, which is quite expensive.
-            exclude_parent_tag:
-                Excludes the parent tag in the returned filenames.
-
-        Returns:
-            tag_data:
-                The tag_data, raw from the API
-            filenames_tag:
-                The filenames of all samples in the tag.
-
-        """
-        tag_name_id_dict = {tag.name: tag.id for tag in self._get_all_tags()}
-        if tag_name:
-            tag_name_id_dict = {
-                tag.name: tag.id for tag in self._get_all_tags()
-            }
-            tag_id = tag_name_id_dict.get(tag_name, None)
-            if tag_id is None:
-                raise ValueError(f'Your tag_name is invalid: {tag_name}.')
-        elif tag_id is None or tag_id not in tag_name_id_dict.values():
-            raise ValueError(f'Your tag_id is invalid: {tag_id}')
-        tag_data = self._tags_api.get_tag_by_tag_id(self.dataset_id, tag_id)
-
-        if exclude_parent_tag:
-            parent_tag_id = tag_data.prev_tag_id
-            tag_arithmetics_request = TagArithmeticsRequest(
-                tag_id1=tag_data.id, tag_id2=parent_tag_id,
-                operation=TagArithmeticsOperation.DIFFERENCE)
-            bit_mask_response: TagBitMaskResponse = \
-                self._tags_api.perform_tag_arithmetics(
-                    body=tag_arithmetics_request, dataset_id=self.dataset_id
-                )
-            bit_mask_data = bit_mask_response.bit_mask_data
-        else:
-            bit_mask_data = tag_data.bit_mask_data
-
-        if not filenames_on_server:
-            filenames_on_server = self.download_filenames_from_server()
-
-        chosen_samples_ids = BitMask.from_hex(bit_mask_data).to_indices()
-        filenames_tag = [filenames_on_server[i] for i in chosen_samples_ids]
-
-        return tag_data, filenames_tag
-
     def upload_file_with_signed_url(self,
                                     file: IOBase,
                                     signed_write_url: str) -> Response:

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -136,7 +136,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             filenames_for_list.
 
         """
-        filenames_on_server = self.download_filenames_from_server()
+        filenames_on_server = self.get_filenames()
         if len(filenames_for_list) != len(list_to_order) or \
                 len(filenames_for_list) != len(filenames_on_server):
             raise ValueError(
@@ -149,7 +149,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         list_ordered = [dict_by_filenames[filename] for filename in filenames_on_server]
         return list_ordered
 
-    def download_filenames_from_server(self) -> List[str]:
+    def get_filenames(self) -> List[str]:
         """Downloads the list of filenames from the server.
 
         This is an expensive operation, especially for large datasets.

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -71,15 +71,15 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         if embedding_id is not None:
             self.embedding_id = embedding_id
 
-        self.datasets_api = DatasetsApi(api_client=self.api_client)
-        self.samplings_api = SamplingsApi(api_client=self.api_client)
-        self.jobs_api = JobsApi(api_client=self.api_client)
-        self.tags_api = TagsApi(api_client=self.api_client)
-        self.embeddings_api = EmbeddingsApi(api_client=api_client)
-        self.mappings_api = MappingsApi(api_client=api_client)
-        self.scores_api = ScoresApi(api_client=api_client)
-        self.samples_api = SamplesApi(api_client=api_client)
-        self.quota_api = QuotaApi(api_client=api_client)
+        self._datasets_api = DatasetsApi(api_client=self.api_client)
+        self._samplings_api = SamplingsApi(api_client=self.api_client)
+        self._jobs_api = JobsApi(api_client=self.api_client)
+        self._tags_api = TagsApi(api_client=self.api_client)
+        self._embeddings_api = EmbeddingsApi(api_client=api_client)
+        self._mappings_api = MappingsApi(api_client=api_client)
+        self._scores_api = ScoresApi(api_client=api_client)
+        self._samples_api = SamplesApi(api_client=api_client)
+        self._quota_api = QuotaApi(api_client=api_client)
 
     def check_version_compatibility(self):
         minimum_version = get_minimum_compatible_version()
@@ -98,7 +98,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         try:
             return self._dataset_id
         except AttributeError:
-            all_datasets: List[DatasetData] = self.datasets_api.get_datasets()
+            all_datasets: List[DatasetData] = self._datasets_api.get_datasets()
             datasets_sorted = sorted(all_datasets, key=lambda dataset: dataset.last_modified_at)
             last_modified_dataset = datasets_sorted[-1]
             self._dataset_id = last_modified_dataset.id
@@ -107,7 +107,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             return self._dataset_id
 
     def _get_all_tags(self) -> List[TagData]:
-        return self.tags_api.get_tags_by_dataset_id(self.dataset_id)
+        return self._tags_api.get_tags_by_dataset_id(self.dataset_id)
 
     def _order_list_by_filenames(
             self, filenames_for_list: List[str],
@@ -146,7 +146,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         """The list of the filenames in the dataset.
         
         """
-        self._filenames_on_server = self.mappings_api. \
+        self._filenames_on_server = self._mappings_api. \
             get_sample_mappings_by_dataset_id(dataset_id=self.dataset_id, field="fileName")
         return self._filenames_on_server
 

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -19,7 +19,7 @@ class _DatasetsMixin:
 
         """
         current_datasets: List[DatasetData] \
-            = self.datasets_api.get_datasets()
+            = self._datasets_api.get_datasets()
 
         try:
             dataset_with_specified_name = next(dataset for dataset in current_datasets if dataset.name == dataset_name)
@@ -52,7 +52,7 @@ class _DatasetsMixin:
 
         """
         body = DatasetCreateRequest(name=dataset_name)
-        response: CreateEntityResponse = self.datasets_api.create_dataset(body=body)
+        response: CreateEntityResponse = self._datasets_api.create_dataset(body=body)
         self._dataset_id = response.id
 
     def create_new_dataset_with_unique_name(self, dataset_basename: str):
@@ -66,7 +66,7 @@ class _DatasetsMixin:
 
         """
         current_datasets: List[DatasetData] \
-            = self.datasets_api.get_datasets()
+            = self._datasets_api.get_datasets()
         current_datasets_names = [dataset.name for dataset in current_datasets]
 
         if dataset_basename not in current_datasets_names:
@@ -88,5 +88,5 @@ class _DatasetsMixin:
                 The id of the dataset to be deleted.
 
         """
-        self.datasets_api.delete_dataset_by_id(dataset_id=dataset_id)
+        self._datasets_api.delete_dataset_by_id(dataset_id=dataset_id)
         del self._dataset_id

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -88,7 +88,8 @@ class _DownloadDatasetMixin:
 
         indices = BitMask.from_hex(tag.bit_mask_data).to_indices()
         sample_ids = [sample_ids[i] for i in indices]
-        filenames = [self.filenames_on_server[i] for i in indices]
+        filenames_on_server = self.download_filenames_from_server()
+        filenames = [filenames_on_server[i] for i in indices]
 
         if verbose:
             print(f'Downloading {len(sample_ids)} images:', flush=True)

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -72,7 +72,7 @@ class _DownloadDatasetMixin:
             )
 
         # check if tag exists
-        available_tags = self._get_all_tags()
+        available_tags = self.get_all_tags()
         try:
             tag = next(tag for tag in available_tags if tag.name == tag_name)
         except StopIteration:

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -88,7 +88,7 @@ class _DownloadDatasetMixin:
 
         indices = BitMask.from_hex(tag.bit_mask_data).to_indices()
         sample_ids = [sample_ids[i] for i in indices]
-        filenames_on_server = self.download_filenames_from_server()
+        filenames_on_server = self.get_filenames()
         filenames = [filenames_on_server[i] for i in indices]
 
         if verbose:

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -64,7 +64,7 @@ class _DownloadDatasetMixin:
         """
 
         # check if images are available
-        dataset = self.datasets_api.get_dataset_by_id(self.dataset_id)
+        dataset = self._datasets_api.get_dataset_by_id(self.dataset_id)
         if dataset.img_type != ImageType.FULL:
             # only thumbnails or metadata available
             raise ValueError(
@@ -81,7 +81,7 @@ class _DownloadDatasetMixin:
             )
 
         # get sample ids
-        sample_ids = self.mappings_api.get_sample_mappings_by_dataset_id(
+        sample_ids = self._mappings_api.get_sample_mappings_by_dataset_id(
             self.dataset_id,
             field='_id'
         )
@@ -96,7 +96,7 @@ class _DownloadDatasetMixin:
 
         # download images
         for sample_id, filename in zip(sample_ids, filenames):
-            read_url = self.samples_api.get_sample_image_read_url_by_id(
+            read_url = self._samples_api.get_sample_image_read_url_by_id(
                 self.dataset_id, 
                 sample_id,
                 type="full",

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -85,7 +85,7 @@ class _SamplingMixin:
         try:
             self.embedding_id
         except AttributeError:
-            self.set_embedding_id_by_name()
+            self.set_embedding_id()
 
         # trigger the sampling
         payload = self._create_sampling_create_request(sampler_config, preselected_tag_id, query_tag_id)

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -85,7 +85,7 @@ class _SamplingMixin:
         try:
             self.embedding_id
         except AttributeError:
-            self.set_embedding_id()
+            self.set_latest_embedding_id()
 
         # trigger the sampling
         payload = self._create_sampling_create_request(sampler_config, preselected_tag_id, query_tag_id)

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -46,7 +46,7 @@ class _SamplingMixin:
                 score_type=score_type,
                 scores=_parse_active_learning_scores(score_values)
             )
-            self.scores_api.create_or_update_active_learning_score_by_tag_id(
+            self._scores_api.create_or_update_active_learning_score_by_tag_id(
                 body,
                 dataset_id=self.dataset_id,
                 tag_id=query_tag_id,

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -106,7 +106,7 @@ class _SamplingMixin:
             time.sleep(wait_time_till_next_poll)
             # try to read the sleep time until the next poll from the status data
             try:
-                job_status_data: JobStatusData = self.jobs_api.get_job_status_by_id(job_id=job_id)
+                job_status_data: JobStatusData = self._jobs_api.get_job_status_by_id(job_id=job_id)
                 wait_time_till_next_poll = job_status_data.wait_time_till_next_poll
             except Exception as err:
                 exception_counter += 1
@@ -121,7 +121,7 @@ class _SamplingMixin:
         new_tag_id = job_status_data.result.data
         if new_tag_id is None:
             raise RuntimeError(f"TagId returned by job with job_id {job_id} is None.")
-        new_tag_data = self.tags_api.get_tag_by_tag_id(self.dataset_id, tag_id=new_tag_id)
+        new_tag_data = self._tags_api.get_tag_by_tag_id(self.dataset_id, tag_id=new_tag_id)
 
         return new_tag_data
 

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -85,7 +85,7 @@ class _SamplingMixin:
         try:
             self.embedding_id
         except AttributeError:
-            self.set_latest_embedding_id()
+            self.set_embedding_id_to_latest()
 
         # trigger the sampling
         payload = self._create_sampling_create_request(sampler_config, preselected_tag_id, query_tag_id)

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -30,7 +30,7 @@ class _SamplingMixin:
 
     def upload_scores(self, al_scores: Dict[str, np.ndarray], query_tag_id: str = None):
 
-        tags = self._get_all_tags()
+        tags = self.get_all_tags()
 
         # upload the active learning scores to the api
         # change @20210422: we store the active learning scores with the query
@@ -75,7 +75,7 @@ class _SamplingMixin:
         """
 
         # make sure the tag name does not exist yet
-        tags = self._get_all_tags()
+        tags = self.get_all_tags()
         if sampler_config.name in [tag.name for tag in tags]:
             raise RuntimeError(f'There already exists a tag with tag_name {sampler_config.name}.')
         if len(tags) == 0:
@@ -89,7 +89,7 @@ class _SamplingMixin:
 
         # trigger the sampling
         payload = self._create_sampling_create_request(sampler_config, preselected_tag_id, query_tag_id)
-        payload.row_count = self._get_all_tags()[0].tot_size
+        payload.row_count = self.get_all_tags()[0].tot_size
         response = self._samplings_api.trigger_sampling_by_id(payload, self.dataset_id, self.embedding_id)
         job_id = response.job_id
 

--- a/lightly/api/api_workflow_sampling.py
+++ b/lightly/api/api_workflow_sampling.py
@@ -90,7 +90,7 @@ class _SamplingMixin:
         # trigger the sampling
         payload = self._create_sampling_create_request(sampler_config, preselected_tag_id, query_tag_id)
         payload.row_count = self._get_all_tags()[0].tot_size
-        response = self.samplings_api.trigger_sampling_by_id(payload, self.dataset_id, self.embedding_id)
+        response = self._samplings_api.trigger_sampling_by_id(payload, self.dataset_id, self.embedding_id)
         job_id = response.job_id
 
         # poll the job status till the job is not running anymore

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -44,15 +44,15 @@ class _TagsMixin:
                 The filenames of all samples in the tag.
 
         """
+        tag_name_id_dict = {tag.name: tag.id for tag in self._get_all_tags()}
         if tag_name:
-            tag_name_id_dict = {
-                tag.name: tag.id for tag in self._get_all_tags()
-            }
+
             tag_id = tag_name_id_dict.get(tag_name, None)
             if tag_id is None:
                 raise ValueError(f'Your tag_name is invalid: {tag_name}.')
-        elif tag_id is None:
+        elif tag_id is None or tag_id not in tag_name_id_dict.values():
             raise ValueError(f'Your tag_id is invalid: {tag_id}')
+
         tag_data = self._tags_api.get_tag_by_tag_id(self.dataset_id, tag_id)
 
         if exclude_parent_tag:

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -5,6 +5,9 @@ from lightly.openapi_generated.swagger_client import TagData, \
     TagArithmeticsRequest, TagArithmeticsOperation, TagBitMaskResponse
 
 
+class TagDoesNotExistError(ValueError):
+    pass
+
 class _TagsMixin:
 
     def get_all_tags(self) -> List[TagData]:
@@ -24,7 +27,7 @@ class _TagsMixin:
         tag_name_id_dict = {tag.name: tag.id for tag in self.get_all_tags()}
         tag_id = tag_name_id_dict.get(tag_name, None)
         if tag_id is None:
-            raise ValueError(f'Your tag_name is invalid: {tag_name}.')
+            raise TagDoesNotExistError(f'Your tag_name does not exist: {tag_name}.')
         return self.get_tag_by_id(tag_id)
 
     def get_filenames_in_tag(
@@ -40,7 +43,7 @@ class _TagsMixin:
                 The data of the tag.
             filenames_on_server:
                 List of all filenames on the server. If they are not given,
-                they need to be download newly, which is quite expensive.
+                they need to be downloaded, which is quite expensive.
             exclude_parent_tag:
                 Excludes the parent tag in the returned filenames.
 
@@ -66,7 +69,7 @@ class _TagsMixin:
         if not filenames_on_server:
             filenames_on_server = self.get_filenames()
 
-        chosen_samples_ids = BitMask.from_hex(bit_mask_data).to_indices()
-        filenames_tag = [filenames_on_server[i] for i in chosen_samples_ids]
+        filenames_tag = BitMask.from_hex(bit_mask_data).\
+            masked_select_from_list(filenames_on_server)
 
         return filenames_tag

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -7,30 +7,37 @@ from lightly.openapi_generated.swagger_client import TagData, \
 
 class _TagsMixin:
 
-    def _get_all_tags(self) -> List[TagData]:
+    def get_all_tags(self) -> List[TagData]:
         """ Gets all tags on the server
 
         Returns:
+            one TagData entry for each tag on the server
 
         """
         return self._tags_api.get_tags_by_dataset_id(self.dataset_id)
 
-    def get_tag_and_filenames(
-            self,
-            tag_name: str = None,
-            tag_id: str = None,
-            filenames_on_server: List[str] = None,
-            exclude_parent_tag: bool = False
-    ) -> Tuple[TagData, List[str]]:
-        """ Gets the TagData of a tag and the filenames in it
+    def get_tag_by_id(self, tag_id: str) -> TagData:
+        tag_data = self._tags_api.get_tag_by_tag_id(self.dataset_id, tag_id)
+        return tag_data
 
-        The tag_name or the tag_id must be passed.
-        The tag_name overwrites the tag_id.
+    def get_tag_by_name(self, tag_name: str) -> TagData:
+        tag_name_id_dict = {tag.name: tag.id for tag in self.get_all_tags()}
+        tag_id = tag_name_id_dict.get(tag_name, None)
+        if tag_id is None:
+            raise ValueError(f'Your tag_name is invalid: {tag_name}.')
+        return self.get_tag_by_id(tag_id)
+
+    def get_filenames_in_tag(
+            self,
+            tag_data: TagData,
+            filenames_on_server: List[str] = None,
+            exclude_parent_tag: bool = False,
+    ) -> List[str]:
+        """ Gets the filenames of a tag
+
         Args:
-            tag_name:
-                The name of the tag.
-            tag_id:
-                The id of the tag.
+            tag_data:
+                The data of the tag.
             filenames_on_server:
                 List of all filenames on the server. If they are not given,
                 they need to be download newly, which is quite expensive.
@@ -38,22 +45,10 @@ class _TagsMixin:
                 Excludes the parent tag in the returned filenames.
 
         Returns:
-            tag_data:
-                The tag_data, raw from the API
             filenames_tag:
                 The filenames of all samples in the tag.
 
         """
-        tag_name_id_dict = {tag.name: tag.id for tag in self._get_all_tags()}
-        if tag_name:
-
-            tag_id = tag_name_id_dict.get(tag_name, None)
-            if tag_id is None:
-                raise ValueError(f'Your tag_name is invalid: {tag_name}.')
-        elif tag_id is None or tag_id not in tag_name_id_dict.values():
-            raise ValueError(f'Your tag_id is invalid: {tag_id}')
-
-        tag_data = self._tags_api.get_tag_by_tag_id(self.dataset_id, tag_id)
 
         if exclude_parent_tag:
             parent_tag_id = tag_data.prev_tag_id
@@ -69,9 +64,9 @@ class _TagsMixin:
             bit_mask_data = tag_data.bit_mask_data
 
         if not filenames_on_server:
-            filenames_on_server = self.download_filenames_from_server()
+            filenames_on_server = self.get_filenames()
 
         chosen_samples_ids = BitMask.from_hex(bit_mask_data).to_indices()
         filenames_tag = [filenames_on_server[i] for i in chosen_samples_ids]
 
-        return tag_data, filenames_tag
+        return filenames_tag

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -1,0 +1,77 @@
+from typing import *
+
+from lightly.api.bitmask import BitMask
+from lightly.openapi_generated.swagger_client import TagData, \
+    TagArithmeticsRequest, TagArithmeticsOperation, TagBitMaskResponse
+
+
+class _TagsMixin:
+
+    def _get_all_tags(self) -> List[TagData]:
+        """ Gets all tags on the server
+
+        Returns:
+
+        """
+        return self._tags_api.get_tags_by_dataset_id(self.dataset_id)
+
+    def get_tag_and_filenames(
+            self,
+            tag_name: str = None,
+            tag_id: str = None,
+            filenames_on_server: List[str] = None,
+            exclude_parent_tag: bool = False
+    ) -> Tuple[TagData, List[str]]:
+        """ Gets the TagData of a tag and the filenames in it
+
+        The tag_name or the tag_id must be passed.
+        The tag_name overwrites the tag_id.
+        Args:
+            tag_name:
+                The name of the tag.
+            tag_id:
+                The id of the tag.
+            filenames_on_server:
+                List of all filenames on the server. If they are not given,
+                they need to be download newly, which is quite expensive.
+            exclude_parent_tag:
+                Excludes the parent tag in the returned filenames.
+
+        Returns:
+            tag_data:
+                The tag_data, raw from the API
+            filenames_tag:
+                The filenames of all samples in the tag.
+
+        """
+        if tag_name:
+            tag_name_id_dict = {
+                tag.name: tag.id for tag in self._get_all_tags()
+            }
+            tag_id = tag_name_id_dict.get(tag_name, None)
+            if tag_id is None:
+                raise ValueError(f'Your tag_name is invalid: {tag_name}.')
+        elif tag_id is None:
+            raise ValueError(f'Your tag_id is invalid: {tag_id}')
+        tag_data = self._tags_api.get_tag_by_tag_id(self.dataset_id, tag_id)
+
+        if exclude_parent_tag:
+            parent_tag_id = tag_data.prev_tag_id
+            tag_arithmetics_request = TagArithmeticsRequest(
+                tag_id1=tag_data.id, tag_id2=parent_tag_id,
+                operation=TagArithmeticsOperation.DIFFERENCE)
+            bit_mask_response: TagBitMaskResponse = \
+                self._tags_api.perform_tag_arithmetics(
+                    body=tag_arithmetics_request, dataset_id=self.dataset_id
+                )
+            bit_mask_data = bit_mask_response.bit_mask_data
+        else:
+            bit_mask_data = tag_data.bit_mask_data
+
+        if not filenames_on_server:
+            filenames_on_server = self.download_filenames_from_server()
+
+        chosen_samples_ids = BitMask.from_hex(bit_mask_data).to_indices()
+        filenames_tag = [filenames_on_server[i] for i in chosen_samples_ids]
+
+        return tag_data, filenames_tag

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -61,7 +61,7 @@ class _UploadDatasetMixin:
         """
 
         # get all tags of the dataset
-        tags = self._get_all_tags()
+        tags = self.get_all_tags()
         if len(tags) > 0:
             print(
                 f'Dataset with id {self.dataset_id} has {len(tags)} tags.',

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -95,7 +95,7 @@ class _UploadDatasetMixin:
             lambda img: 0 # pylint: disable=protected-access
 
         # get the filenames of the samples already on the server
-        samples = self.samples_api.get_samples_by_dataset_id(
+        samples = self._samples_api.get_samples_by_dataset_id(
             dataset_id=self.dataset_id
         )
         filenames_on_server = [sample.file_name for sample in samples]
@@ -111,7 +111,7 @@ class _UploadDatasetMixin:
             filenames_on_server_set
         )
         max_dataset_size = \
-            int(self.quota_api.get_quota_maximum_dataset_size())
+            int(self._quota_api.get_quota_maximum_dataset_size())
         if len(total_filenames) > max_dataset_size:
             msg = f'Your dataset has {len(dataset)} samples which'
             msg += f' is more than the allowed maximum of {max_dataset_size}'
@@ -133,7 +133,7 @@ class _UploadDatasetMixin:
             is_registered=True,
             upload_method=JobStatusUploadMethod.USER_PIP,
         )
-        self.datasets_api.register_dataset_upload_by_id(
+        self._datasets_api.register_dataset_upload_by_id(
             job_status_meta,
             self.dataset_id
         )
@@ -204,7 +204,7 @@ class _UploadDatasetMixin:
                 img_type=img_type,
                 creator=TagCreator.USER_PIP
             )
-            self.tags_api.create_initial_tag_by_dataset_id(
+            self._tags_api.create_initial_tag_by_dataset_id(
                 body=initial_tag_create_request,
                 dataset_id=self.dataset_id,
             )
@@ -214,7 +214,7 @@ class _UploadDatasetMixin:
                 upsize_tag_name=datetime.now().strftime('%Y%m%d_%Hh%Mm%Ss'),
                 upsize_tag_creator=TagCreator.USER_PIP,
             )
-            self.tags_api.upsize_tags_by_dataset_id(
+            self._tags_api.upsize_tags_by_dataset_id(
                 body=upsize_tags_request,
                 dataset_id=self.dataset_id,
             )
@@ -257,7 +257,7 @@ class _UploadDatasetMixin:
             custom_meta_data=custom_metadata,
         )
         sample_id = retry(
-            self.samples_api.create_sample_by_dataset_id,
+            self._samples_api.create_sample_by_dataset_id,
             body=body,
             dataset_id=self.dataset_id
         ).id
@@ -284,7 +284,7 @@ class _UploadDatasetMixin:
 
             if mode == 'thumbnails':
                 thumbnail_url = retry(
-                    self.samples_api.get_sample_image_write_url_by_id,
+                    self._samples_api.get_sample_image_write_url_by_id,
                     dataset_id=self.dataset_id,
                     sample_id=sample_id,
                     is_thumbnail=True
@@ -292,7 +292,7 @@ class _UploadDatasetMixin:
                 upload_thumbnail(image, thumbnail_url)
             elif mode == 'full':
                 sample_write_urls: SampleWriteUrls = retry(
-                    self.samples_api.get_sample_image_write_urls_by_id,
+                    self._samples_api.get_sample_image_write_urls_by_id,
                     dataset_id=self.dataset_id,
                     sample_id=sample_id
                 )

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -32,16 +32,37 @@ class _UploadEmbeddingsMixin:
 
         return reader
 
-    def set_embedding_id(self):
+    def set_latest_embedding_id(self):
+        """Sets the self.embedding_id to the one of the latest on the server.
+
+        """
         embeddings_on_server: List[DatasetEmbeddingData] = \
             self._embeddings_api.get_embeddings_by_dataset_id(
                 dataset_id=self.dataset_id
             )
-        self.embedding_id = embeddings_on_server[0].id
+        self.embedding_id = embeddings_on_server[-1].id
 
     def get_embedding_by_name(
             self, name: str, ignore_suffix: bool = True
     ) -> DatasetEmbeddingData:
+        """Gets an embedding form the server by name.
+
+        Args:
+            name:
+                The name of the embedding to get.
+            ignore_suffix:
+                If true, a suffix of the embedding name on the server
+                is ignored.
+
+        Returns:
+            The embedding data.
+
+        Raises:
+            EmbeddingDoesNotExistError:
+                If the name does not match the name of an embedding
+                on the server.
+
+        """
         embeddings_on_server: List[DatasetEmbeddingData] = \
             self._embeddings_api.get_embeddings_by_dataset_id(
                 dataset_id=self.dataset_id
@@ -82,7 +103,7 @@ class _UploadEmbeddingsMixin:
 
         # Try to append the embeddings on the server, if they exist
         try:
-            embedding = self.get_embedding_by_name(name)
+            embedding = self.get_embedding_by_name(name, ignore_suffix=True)
             # -> append rows from server
             print('Appending embeddings from server.')
             self.append_embeddings(path_to_embeddings_csv, embedding.id)

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -32,7 +32,7 @@ class _UploadEmbeddingsMixin:
 
         return reader
 
-    def set_latest_embedding_id(self):
+    def set_embedding_id_to_latest(self):
         """Sets the self.embedding_id to the one of the latest on the server.
 
         """

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -41,7 +41,7 @@ class _UploadEmbeddingsMixin:
             ValueError if the embedding does not exist.
         """
         embeddings: List[DatasetEmbeddingData] = \
-            self.embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
+            self._embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
 
         if embedding_name is None:
             self.embedding_id = embeddings[-1].id
@@ -70,7 +70,7 @@ class _UploadEmbeddingsMixin:
         """
         # get the names of the current embeddings on the server:
         embeddings_on_server: List[DatasetEmbeddingData] = \
-            self.embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
+            self._embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
         names_embeddings_on_server = [embedding.name for embedding in embeddings_on_server]
 
         if name in names_embeddings_on_server:
@@ -84,7 +84,7 @@ class _UploadEmbeddingsMixin:
 
         # get the URL to upload the csv to
         response: WriteCSVUrlData = \
-            self.embeddings_api.get_embeddings_csv_write_url_by_id(self.dataset_id, name=name)
+            self._embeddings_api.get_embeddings_csv_write_url_by_id(self.dataset_id, name=name)
         self.embedding_id = response.embedding_id
         signed_write_url = response.signed_write_url
 
@@ -111,7 +111,7 @@ class _UploadEmbeddingsMixin:
 
             body = EmbeddingIdTrigger2dEmbeddingsJobBody(
                 dimensionality_reduction_method=dimensionality_reduction_method)
-            self.embeddings_api.trigger2d_embeddings_job(
+            self._embeddings_api.trigger2d_embeddings_job(
                 body=body,
                 dataset_id=self.dataset_id,
                 embedding_id=self.embedding_id
@@ -140,7 +140,7 @@ class _UploadEmbeddingsMixin:
         """
 
         # read embedding from API
-        embedding_read_url = self.embeddings_api \
+        embedding_read_url = self._embeddings_api \
             .get_embeddings_csv_read_url_by_id(self.dataset_id, embedding_id)
         embedding_reader = self._get_csv_reader_from_read_url(embedding_read_url)
         rows = list(embedding_reader)

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -15,6 +15,8 @@ from lightly.openapi_generated.swagger_client.models.write_csv_url_data \
 from lightly.utils.io import check_filenames
 
 
+class EmbeddingDoesNotExistError(ValueError):
+    pass
 
 
 class _UploadEmbeddingsMixin:
@@ -30,29 +32,37 @@ class _UploadEmbeddingsMixin:
 
         return reader
 
+    def set_embedding_id(self):
+        embeddings_on_server: List[DatasetEmbeddingData] = \
+            self._embeddings_api.get_embeddings_by_dataset_id(
+                dataset_id=self.dataset_id
+            )
+        self.embedding_id = embeddings_on_server[0].id
 
-    def set_embedding_id_by_name(self, embedding_name: str = None):
-        """Sets the embedding id of the client by embedding name.
-
-        Args:
-            embedding_name:
-                Name under which the embedding was uploaded.
-    
-        Raises:
-            ValueError if the embedding does not exist.
-        """
-        embeddings: List[DatasetEmbeddingData] = \
-            self._embeddings_api.get_embeddings_by_dataset_id(dataset_id=self.dataset_id)
-
-        if embedding_name is None:
-            self.embedding_id = embeddings[-1].id
-            return
-
+    def get_embedding_by_name(
+            self, name: str, ignore_suffix: bool = True
+    ) -> DatasetEmbeddingData:
+        embeddings_on_server: List[DatasetEmbeddingData] = \
+            self._embeddings_api.get_embeddings_by_dataset_id(
+                dataset_id=self.dataset_id
+            )
         try:
-            self.embedding_id = next(embedding.id for embedding in embeddings if embedding.name == embedding_name)
+            if ignore_suffix:
+                embedding = next(
+                    embedding for embedding in embeddings_on_server if
+                    embedding.name.startswith(name)
+                )
+            else:
+                embedding = next(
+                    embedding for embedding in embeddings_on_server if
+                    embedding.name == name
+                )
         except StopIteration:
-            raise ValueError(f"No embedding with name {embedding_name} found on the server.")
-
+            raise EmbeddingDoesNotExistError(
+                f"Embedding with the specified name "
+                f"does not exist on the server: {name}"
+            )
+        return embedding
 
     def upload_embeddings(self, path_to_embeddings_csv: str, name: str):
         """Uploads embeddings to the server.
@@ -69,23 +79,17 @@ class _UploadEmbeddingsMixin:
                 the upload is aborted.
 
         """
-        # get the names of the current embeddings on the server:
-        embeddings_on_server: List[DatasetEmbeddingData] = \
-            self._embeddings_api.get_embeddings_by_dataset_id(
-                dataset_id=self.dataset_id
-            )
-        embeddings_on_server_dict = {
-            embedding.name: embedding
-            for embedding in embeddings_on_server
-        }
 
-        if name in embeddings_on_server_dict.keys():
+        # Try to append the embeddings on the server, if they exist
+        try:
+            embedding = self.get_embedding_by_name(name)
             # -> append rows from server
             print('Appending embeddings from server.')
-            embedding_id = embeddings_on_server_dict[name]
-            self.append_embeddings(path_to_embeddings_csv, embedding_id)
+            self.append_embeddings(path_to_embeddings_csv, embedding.id)
             now = datetime.now().strftime('%Y%m%d_%Hh%Mm%Ss')
             name = f'{name}_{now}'
+        except EmbeddingDoesNotExistError:
+            pass
 
         # create a new csv with the filenames in the desired order
         rows_csv = self._order_csv_by_filenames(
@@ -203,7 +207,7 @@ class _UploadEmbeddingsMixin:
             index_filenames = header_row.index('filenames')
             filenames = [row[index_filenames] for row in rows_without_header]
 
-            filenames_on_server = self.download_filenames_from_server()
+            filenames_on_server = self.get_filenames()
 
             if len(filenames) != len(filenames_on_server):
                 raise ValueError(f'There are {len(filenames)} rows in the embedding file, but '

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -194,7 +194,7 @@ class _UploadEmbeddingsMixin:
             index_filenames = header_row.index('filenames')
             filenames = [row[index_filenames] for row in rows_without_header]
 
-            filenames_on_server = self.filenames_on_server
+            filenames_on_server = self.download_filenames_from_server()
 
             if len(filenames) != len(filenames_on_server):
                 raise ValueError(f'There are {len(filenames)} rows in the embedding file, but '

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -162,7 +162,7 @@ class _UploadCustomMetadataMixin:
         self.verify_custom_metadata_format(custom_metadata)
 
         # create a mapping from sample filenames to custom metadata
-        samples = self.samples_api.get_samples_by_dataset_id(self.dataset_id)
+        samples = self._samples_api.get_samples_by_dataset_id(self.dataset_id)
         filename_to_metadata = self.index_custom_metadata_by_filename(
             [sample.file_name for sample in samples],
             custom_metadata,

--- a/lightly/cli/download_cli.py
+++ b/lightly/cli/download_cli.py
@@ -42,7 +42,7 @@ def _download_cli(cfg, is_cli_call=True):
     )
 
     # get tag id
-    tag_data = api_workflow_client.get_tag_by_name(cfg['tag_name'])
+    tag_data = api_workflow_client.get_tag_by_name(tag_name)
     filenames_tag = api_workflow_client.get_filenames_in_tag(
         tag_data,
         exclude_parent_tag=cfg['exclude_parent_tag'],

--- a/lightly/cli/download_cli.py
+++ b/lightly/cli/download_cli.py
@@ -42,9 +42,10 @@ def _download_cli(cfg, is_cli_call=True):
     )
 
     # get tag id
-    tag, filenames_tag = api_workflow_client.get_tag_and_filenames(
-        tag_name=cfg['tag_name'],
-        exclude_parent_tag=cfg['exclude_parent_tag']
+    tag_data = api_workflow_client.get_tag_by_name(cfg['tag_name'])
+    filenames_tag = api_workflow_client.get_filenames_in_tag(
+        tag_data,
+        exclude_parent_tag=cfg['exclude_parent_tag'],
     )
 
     # store sample names in a .txt file

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -103,35 +103,6 @@ def _upload_cli(cfg, is_cli_call=True):
     if path_to_embeddings:
         name = cfg['embedding_name']
         print('Starting upload of embeddings.')
-        try:
-            embeddings = api_workflow_client._embeddings_api \
-                .get_embeddings_by_dataset_id(dataset_id=api_workflow_client.dataset_id)
-            # use latest embedding first
-            embeddings = sorted(
-                embeddings,
-                key=lambda x: x.created_at,
-                reverse=True
-            )
-            # find the latest embedding that starts with the name
-            # e.g. default_20211018_12h00m00s
-            embedding = next(
-                embedding for embedding in embeddings
-                if embedding.name.startswith(name)
-            )
-        except StopIteration:
-            embedding = None
-
-        if embedding is not None:
-
-            # -> append rows from server
-            print('Appending embeddings from server.')
-            api_workflow_client.append_embeddings(
-                path_to_embeddings,
-                embedding.id,
-            )
-            now = datetime.now().strftime('%Y%m%d_%Hh%Mm%Ss')
-            name = f'{name}_{now}'
-
         api_workflow_client.upload_embeddings(
             path_to_embeddings_csv=path_to_embeddings, name=name
         )

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -104,7 +104,7 @@ def _upload_cli(cfg, is_cli_call=True):
         name = cfg['embedding_name']
         print('Starting upload of embeddings.')
         try:
-            embeddings = api_workflow_client.embeddings_api \
+            embeddings = api_workflow_client._embeddings_api \
                 .get_embeddings_by_dataset_id(dataset_id=api_workflow_client.dataset_id)
             # use latest embedding first
             embeddings = sorted(

--- a/tests/active_learning/test_active_learning_agent.py
+++ b/tests/active_learning/test_active_learning_agent.py
@@ -125,4 +125,21 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
 
         agent.upload_scores(al_scorer)
 
+    def test_agent_without_embedding_id(self):
+        agent = ActiveLearningAgent(
+            self.api_workflow_client,
+            preselected_tag_name="preselected_tag_name_xyz"
+        )
+        method = SamplingMethod.CORAL
+        n_samples = len(agent.labeled_set) + 2
+
+        n_predictions = len(agent.query_set)
+        predictions = np.random.rand(n_predictions, 10).astype(np.float32)
+        predictions_normalized = predictions / np.sum(predictions, axis=1)[:, np.newaxis]
+        al_scorer = ScorerClassification(predictions_normalized)
+
+        sampler_config = SamplerConfig(n_samples=n_samples, method=method)
+        agent.query(sampler_config=sampler_config, al_scorer=al_scorer)
+
+
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -131,10 +131,6 @@ class MockedTagsApi(TagsApi):
         _check_dataset_id(dataset_id)
         assert isinstance(dataset_id, str)
         assert isinstance(tag_id, str)
-        tags_on_server = self.get_tags_by_dataset_id(dataset_id)
-        tag_ids_on_server = set(tag.id for tag in tags_on_server)
-        if tag_id not in tag_ids_on_server:
-            raise ValueError("Unknown tag id")
         response_ = TagData(id=tag_id, dataset_id=dataset_id, prev_tag_id="initial-tag", bit_mask_data="0x80bda23e9",
                             name='second-tag', tot_size=15, created_at=1577836800, changes=dict())
         return response_

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -131,6 +131,10 @@ class MockedTagsApi(TagsApi):
         _check_dataset_id(dataset_id)
         assert isinstance(dataset_id, str)
         assert isinstance(tag_id, str)
+        tags_on_server = self.get_tags_by_dataset_id(dataset_id)
+        tag_ids_on_server = set(tag.id for tag in tags_on_server)
+        if tag_id not in tag_ids_on_server:
+            raise ValueError("Unknown tag id")
         response_ = TagData(id=tag_id, dataset_id=dataset_id, prev_tag_id="initial-tag", bit_mask_data="0x80bda23e9",
                             name='second-tag', tot_size=15, created_at=1577836800, changes=dict())
         return response_

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -317,16 +317,16 @@ class MockedApiWorkflowClient(ApiWorkflowClient):
         lightly.api.version_checking.VersioningApi = MockedVersioningApi
         ApiWorkflowClient.__init__(self, *args, **kwargs)
 
-        self.samplings_api = MockedSamplingsApi(api_client=self.api_client)
-        self.jobs_api = MockedJobsApi(api_client=self.api_client)
-        self.tags_api = MockedTagsApi(api_client=self.api_client)
-        self.embeddings_api = MockedEmbeddingsApi(api_client=self.api_client)
-        self.samples_api = MockedSamplesApi(api_client=self.api_client)
-        self.mappings_api = MockedMappingsApi(api_client=self.api_client,
-                                              samples_api=self.samples_api)
-        self.scores_api = MockedScoresApi(api_client=self.api_client)
-        self.datasets_api = MockedDatasetsApi(api_client=self.api_client)
-        self.quota_api = MockedQuotaApi(api_client=self.api_client)
+        self._samplings_api = MockedSamplingsApi(api_client=self.api_client)
+        self._jobs_api = MockedJobsApi(api_client=self.api_client)
+        self._tags_api = MockedTagsApi(api_client=self.api_client)
+        self._embeddings_api = MockedEmbeddingsApi(api_client=self.api_client)
+        self._samples_api = MockedSamplesApi(api_client=self.api_client)
+        self._mappings_api = MockedMappingsApi(api_client=self.api_client,
+                                              samples_api=self._samples_api)
+        self._scores_api = MockedScoresApi(api_client=self.api_client)
+        self._datasets_api = MockedDatasetsApi(api_client=self.api_client)
+        self._quota_api = MockedQuotaApi(api_client=self.api_client)
 
         lightly.api.api_workflow_client.requests.put = mocked_request_put
 

--- a/tests/api_workflow/test_api_workflow.py
+++ b/tests/api_workflow/test_api_workflow.py
@@ -26,11 +26,11 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
         lightly.api.api_workflow_client.__version__ = lightly.__version__
 
     def test_dataset_id_nonexisting(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         assert not hasattr(self.api_workflow_client, "_dataset_id")
         with self.assertWarns(UserWarning):
             dataset_id = self.api_workflow_client.dataset_id
-        assert dataset_id == self.api_workflow_client.datasets_api.datasets[-1].id
+        assert dataset_id == self.api_workflow_client._datasets_api.datasets[-1].id
 
     def test_dataset_id_existing(self):
         id = "random_dataset_id"
@@ -45,7 +45,7 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
             filenames_on_server = [f"img_{i}" for i in numbers_all]
 
             api_workflow_client = MockedApiWorkflowClient(token="token_xyz", dataset_id="dataset_id_xyz")
-            api_workflow_client.mappings_api.sample_names = filenames_on_server
+            api_workflow_client._mappings_api.sample_names = filenames_on_server
 
             numbers_in_tag = np.copy(numbers_all)
             np.random.shuffle(numbers_in_tag)
@@ -59,7 +59,7 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
     def test_reorder_manual(self):
         filenames_on_server = ['a', 'b', 'c']
         api_workflow_client = MockedApiWorkflowClient(token="token_xyz", dataset_id="dataset_id_xyz")
-        api_workflow_client.mappings_api.sample_names = filenames_on_server
+        api_workflow_client._mappings_api.sample_names = filenames_on_server
         filenames_for_list = ['c', 'a', 'b']
         list_to_order = ['cccc', 'aaaa', 'bbbb']
         list_ordered = api_workflow_client._order_list_by_filenames(filenames_for_list, list_to_order=list_to_order)
@@ -71,7 +71,7 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
         api_workflow_client = MockedApiWorkflowClient(
             token="token_xyz", dataset_id="dataset_id_xyz"
         )
-        api_workflow_client.mappings_api.sample_names = filenames_on_server
+        api_workflow_client._mappings_api.sample_names = filenames_on_server
         filenames_for_list = ['c', 'a', 'b']
         list_to_order = ['cccc', 'aaaa', 'bbbb']
 

--- a/tests/api_workflow/test_api_workflow_datasets.py
+++ b/tests/api_workflow/test_api_workflow_datasets.py
@@ -6,40 +6,40 @@ from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
 
     def test_create_dataset_new(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="dataset_new")
         test_var = self.api_workflow_client.dataset_id
 
     def test_create_dataset_existing(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="dataset_1")
 
     def test_create_dataset_with_counter(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="basename")
         n_tries = 3
         for i in range(n_tries):
             self.api_workflow_client.create_new_dataset_with_unique_name(dataset_basename="basename")
-        assert self.api_workflow_client.datasets_api.datasets[-1].name == f"basename_{n_tries}"
+        assert self.api_workflow_client._datasets_api.datasets[-1].name == f"basename_{n_tries}"
 
     def test_create_dataset_with_counter_nonexisting(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="basename")
         self.api_workflow_client.create_new_dataset_with_unique_name(dataset_basename="baseName")
-        assert self.api_workflow_client.datasets_api.datasets[-1].name == "baseName"
+        assert self.api_workflow_client._datasets_api.datasets[-1].name == "baseName"
 
     def test_set_dataset_id_success(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.set_dataset_id_by_name("dataset_1")
         assert self.api_workflow_client.dataset_id == "dataset_1_id"
 
     def test_set_dataset_id_error(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         with self.assertRaises(ValueError):
             self.api_workflow_client.set_dataset_id_by_name("nonexisting-dataset")
 
     def test_delete_dataset(self):
-        self.api_workflow_client.datasets_api.reset()
+        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="dataset_to_delete")
         self.api_workflow_client.delete_dataset_by_id(self.api_workflow_client.dataset_id)
         assert not hasattr(self, "_dataset_id")

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -19,7 +19,7 @@ from lightly.openapi_generated.swagger_client.models.dataset_data import Dataset
 class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
     def setUp(self) -> None:
         MockedApiWorkflowSetup.setUp(self, dataset_id='dataset_0_id')
-        self.api_workflow_client.tags_api.no_tags = 3
+        self.api_workflow_client._tags_api.no_tags = 3
 
     def test_download_non_existing_tag(self):
         with self.assertRaises(ValueError):
@@ -29,7 +29,7 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
         def get_thumbnail_dataset_by_id(*args):
             return DatasetData(name=f'dataset', id='dataset_id', last_modified_at=0,
                                type='thumbnails', size_in_bytes=-1, n_samples=-1, created_at=-1)
-        self.api_workflow_client.datasets_api.get_dataset_by_id = get_thumbnail_dataset_by_id
+        self.api_workflow_client._datasets_api.get_dataset_by_id = get_thumbnail_dataset_by_id
         with self.assertRaises(ValueError):
             self.api_workflow_client.download_dataset('path/to/dir')
 

--- a/tests/api_workflow/test_api_workflow_tags.py
+++ b/tests/api_workflow/test_api_workflow_tags.py
@@ -1,0 +1,64 @@
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import lightly
+from lightly.active_learning.agents.agent import ActiveLearningAgent
+from lightly.active_learning.config.sampler_config import SamplerConfig
+from lightly.active_learning.scorers.classification import ScorerClassification
+from lightly.openapi_generated.swagger_client import SamplingMethod
+from lightly.openapi_generated.swagger_client.models.tag_data import TagData
+from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowClient, MockedApiWorkflowSetup
+
+
+class TestApiWorkflow(MockedApiWorkflowSetup):
+
+    def setUp(self) -> None:
+        lightly.api.api_workflow_client.__version__ = lightly.__version__
+        self.api_workflow_client = MockedApiWorkflowClient(token="token_xyz")
+
+        self.valid_tag_name = self.api_workflow_client._get_all_tags()[0].name
+        self.invalid_tag_name = "invalid_tag_name_xyz"
+        self.valid_tag_id = self.api_workflow_client._get_all_tags()[0].id
+        self.invalid_tag_id = "invalid-tag_id_xyz"
+    
+    def test_get_tag_name(self):
+        self.api_workflow_client.get_tag_and_filenames(tag_name=self.valid_tag_name)
+        
+    def test_get_tag_name_nonexisting(self):
+        with self.assertRaises(ValueError):
+            self.api_workflow_client.get_tag_and_filenames(tag_name=self.invalid_tag_name)
+
+    def test_get_tag_id(self):
+        self.api_workflow_client.get_tag_and_filenames(tag_id=self.valid_tag_id)
+
+    def test_get_tag_id_nonexisting(self):
+        with self.assertRaises(ValueError):
+            self.api_workflow_client.get_tag_and_filenames(tag_id=self.invalid_tag_id)
+
+    def test_get_tag_name_id(self):
+        self.api_workflow_client.get_tag_and_filenames(tag_name=self.valid_tag_name, tag_id=self.valid_tag_id)
+
+    def test_get_tag_name_id(self):
+        self.api_workflow_client.get_tag_and_filenames(tag_name=self.valid_tag_name, tag_id=self.invalid_tag_id)
+
+    def test_get_tag(self):
+        with self.assertRaises(ValueError):
+            self.api_workflow_client.get_tag_and_filenames()
+
+    def test_get_tag_filenames(self):
+        filenames = self.api_workflow_client.download_filenames_from_server()
+        self.api_workflow_client.get_tag_and_filenames(tag_id="sfdsdf", filenames_on_server=filenames)
+
+    def test_get_tag_exclude_parent(self):
+        self.api_workflow_client.get_tag_and_filenames(tag_id="sfdsdf", exclude_parent_tag=True)
+
+
+
+
+
+
+
+

--- a/tests/api_workflow/test_api_workflow_tags.py
+++ b/tests/api_workflow/test_api_workflow_tags.py
@@ -19,41 +19,45 @@ class TestApiWorkflowTags(MockedApiWorkflowSetup):
         lightly.api.api_workflow_client.__version__ = lightly.__version__
         self.api_workflow_client = MockedApiWorkflowClient(token="token_xyz")
 
-        self.valid_tag_name = self.api_workflow_client._get_all_tags()[0].name
+        self.valid_tag_name = self.api_workflow_client.get_all_tags()[0].name
         self.invalid_tag_name = "invalid_tag_name_xyz"
-        self.valid_tag_id = self.api_workflow_client._get_all_tags()[0].id
+        self.valid_tag_id = self.api_workflow_client.get_all_tags()[0].id
         self.invalid_tag_id = "invalid-tag_id_xyz"
+
+    def test_get_all_tags(self):
+        self.api_workflow_client.get_all_tags()
     
     def test_get_tag_name(self):
-        self.api_workflow_client.get_tag_and_filenames(tag_name=self.valid_tag_name)
+        self.api_workflow_client.get_tag_by_name(tag_name=self.valid_tag_name)
         
     def test_get_tag_name_nonexisting(self):
         with self.assertRaises(ValueError):
-            self.api_workflow_client.get_tag_and_filenames(tag_name=self.invalid_tag_name)
+            self.api_workflow_client.get_tag_by_name(tag_name=self.invalid_tag_name)
 
     def test_get_tag_id(self):
-        self.api_workflow_client.get_tag_and_filenames(tag_id=self.valid_tag_id)
+        self.api_workflow_client.get_tag_by_id(tag_id=self.valid_tag_id)
 
     def test_get_tag_id_nonexisting(self):
         with self.assertRaises(ValueError):
-            self.api_workflow_client.get_tag_and_filenames(tag_id=self.invalid_tag_id)
+            self.api_workflow_client.get_tag_by_id(tag_id=self.invalid_tag_id)
 
-    def test_get_tag_name_id(self):
-        self.api_workflow_client.get_tag_and_filenames(tag_name=self.valid_tag_name, tag_id=self.valid_tag_id)
+    def test_get_filenames_in_tag(self):
+        tag_data = self.api_workflow_client.get_tag_by_name(tag_name=self.valid_tag_name)
+        self.api_workflow_client.get_filenames_in_tag(tag_data)
 
-    def test_get_tag_name_id(self):
-        self.api_workflow_client.get_tag_and_filenames(tag_name=self.valid_tag_name, tag_id=self.invalid_tag_id)
+    def test_get_filenames_in_tag_with_filenames(self):
+        tag_data = self.api_workflow_client.get_tag_by_name(tag_name=self.valid_tag_name)
+        filenames = self.api_workflow_client.get_filenames()
+        self.api_workflow_client.get_filenames_in_tag(tag_data, filenames)
 
-    def test_get_tag(self):
-        with self.assertRaises(ValueError):
-            self.api_workflow_client.get_tag_and_filenames()
+    def test_get_filenames_in_tag_exclude_parent(self):
+        tag_data = self.api_workflow_client.get_tag_by_name(tag_name=self.valid_tag_name)
+        self.api_workflow_client.get_filenames_in_tag(tag_data, exclude_parent_tag=True)
 
-    def test_get_tag_filenames(self):
-        filenames = self.api_workflow_client.download_filenames_from_server()
-        self.api_workflow_client.get_tag_and_filenames(tag_id=self.valid_tag_id, filenames_on_server=filenames)
-
-    def test_get_tag_exclude_parent(self):
-        self.api_workflow_client.get_tag_and_filenames(tag_id=self.valid_tag_id, exclude_parent_tag=True)
+    def test_get_filenames_in_tag_with_filenames_exclude_parent(self):
+        tag_data = self.api_workflow_client.get_tag_by_name(tag_name=self.valid_tag_name)
+        filenames = self.api_workflow_client.get_filenames()
+        self.api_workflow_client.get_filenames_in_tag(tag_data, filenames, exclude_parent_tag=True)
 
 
 

--- a/tests/api_workflow/test_api_workflow_tags.py
+++ b/tests/api_workflow/test_api_workflow_tags.py
@@ -37,10 +37,6 @@ class TestApiWorkflowTags(MockedApiWorkflowSetup):
     def test_get_tag_id(self):
         self.api_workflow_client.get_tag_by_id(tag_id=self.valid_tag_id)
 
-    def test_get_tag_id_nonexisting(self):
-        with self.assertRaises(ValueError):
-            self.api_workflow_client.get_tag_by_id(tag_id=self.invalid_tag_id)
-
     def test_get_filenames_in_tag(self):
         tag_data = self.api_workflow_client.get_tag_by_name(tag_name=self.valid_tag_name)
         self.api_workflow_client.get_filenames_in_tag(tag_data)

--- a/tests/api_workflow/test_api_workflow_tags.py
+++ b/tests/api_workflow/test_api_workflow_tags.py
@@ -13,7 +13,7 @@ from lightly.openapi_generated.swagger_client.models.tag_data import TagData
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowClient, MockedApiWorkflowSetup
 
 
-class TestApiWorkflow(MockedApiWorkflowSetup):
+class TestApiWorkflowTags(MockedApiWorkflowSetup):
 
     def setUp(self) -> None:
         lightly.api.api_workflow_client.__version__ = lightly.__version__
@@ -50,10 +50,10 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
 
     def test_get_tag_filenames(self):
         filenames = self.api_workflow_client.download_filenames_from_server()
-        self.api_workflow_client.get_tag_and_filenames(tag_id="sfdsdf", filenames_on_server=filenames)
+        self.api_workflow_client.get_tag_and_filenames(tag_id=self.valid_tag_id, filenames_on_server=filenames)
 
     def test_get_tag_exclude_parent(self):
-        self.api_workflow_client.get_tag_and_filenames(tag_id="sfdsdf", exclude_parent_tag=True)
+        self.api_workflow_client.get_tag_and_filenames(tag_id=self.valid_tag_id, exclude_parent_tag=True)
 
 
 

--- a/tests/api_workflow/test_api_workflow_upload_dataset.py
+++ b/tests/api_workflow/test_api_workflow_upload_dataset.py
@@ -20,7 +20,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
         MockedApiWorkflowSetup.setUp(self)
         self.n_data = 100
         self.create_fake_dataset()
-        self.api_workflow_client.tags_api.no_tags = 0
+        self.api_workflow_client._tags_api.no_tags = 0
 
     def create_fake_dataset(self, length_of_filepath: int = -1, sample_names=None):
         n_data = self.n_data if sample_names is None else len(sample_names)
@@ -58,7 +58,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
         def get_quota_reduced():
             return str(quota)
 
-        self.api_workflow_client.quota_api.get_quota_maximum_dataset_size = get_quota_reduced
+        self.api_workflow_client._quota_api.get_quota_maximum_dataset_size = get_quota_reduced
         with self.assertRaises(ValueError):
             self.api_workflow_client.upload_dataset(input=self.folder_path)
 
@@ -72,7 +72,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
         self.api_workflow_client.upload_dataset(input=self.folder_path, mode="metadata")
 
     def test_upsize_existing_dataset(self):
-        self.api_workflow_client.tags_api.no_tags = 1
+        self.api_workflow_client._tags_api.no_tags = 1
         self.api_workflow_client.upload_dataset(input=self.folder_path)
 
     def test_upload_dataset_from_dataset(self):
@@ -88,14 +88,14 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
         self.create_fake_dataset(length_of_filepath=MAXIMUM_FILENAME_LENGTH - 1)
         self.api_workflow_client.upload_dataset(input=self.folder_path)
 
-        samples = self.api_workflow_client.samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
+        samples = self.api_workflow_client._samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
         self.assertEqual(self.n_data, len(samples))
 
     def test_filename_length_upper(self):
         self.create_fake_dataset(length_of_filepath=MAXIMUM_FILENAME_LENGTH + 10)
         self.api_workflow_client.upload_dataset(input=self.folder_path)
 
-        samples = self.api_workflow_client.samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
+        samples = self.api_workflow_client._samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
         self.assertEqual(0, len(samples))
 
     def create_fake_video_dataset(self, n_videos=5, n_frames_per_video=10, w=32, h=32, c=3, extension='avi'):
@@ -130,7 +130,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
         self.api_workflow_client.upload_dataset(input=self.folder_path)
 
         # Ensure that not all samples were uploaded
-        samples = self.api_workflow_client.samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
+        samples = self.api_workflow_client._samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
         self.assertLess(len(samples), self.n_data)
 
         # Upload without failing uploads
@@ -138,7 +138,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
         self.api_workflow_client.upload_dataset(input=self.folder_path)
 
         # Ensure that now all samples were uploaded exactly once
-        samples = self.api_workflow_client.samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
+        samples = self.api_workflow_client._samples_api.get_samples_by_dataset_id(dataset_id="does not matter")
         self.assertEqual(self.n_data, len(samples))
 
 
@@ -155,7 +155,7 @@ class TestApiWorkflowUploadDataset(MockedApiWorkflowSetup):
         self.api_workflow_client.upload_dataset(input=self.folder_path)
 
         # always returns all samples so dataset_id doesn't matter
-        samples = self.api_workflow_client.samples_api.get_samples_by_dataset_id(dataset_id='')
+        samples = self.api_workflow_client._samples_api.get_samples_by_dataset_id(dataset_id='')
 
         # assert the filenames are the same
         self.assertListEqual(

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -63,23 +63,23 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         self.api_workflow_client.n_dims_embeddings_on_server = n_dims
 
     def test_upload_success(self):
-        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        n_data = len(self.api_workflow_client._mappings_api.sample_names)
         self.t_ester_upload_embedding(n_data=n_data)
         filepath_embeddings_sorted = os.path.join(self.folder_path, "embeddings_sorted.csv")
         self.assertFalse(os.path.isfile(filepath_embeddings_sorted))
 
     def test_upload_wrong_length(self):
-        n_data = 42 + len(self.api_workflow_client.mappings_api.sample_names)
+        n_data = 42 + len(self.api_workflow_client._mappings_api.sample_names)
         with self.assertRaises(ValueError):
             self.t_ester_upload_embedding(n_data=n_data)
 
     def test_upload_wrong_filenames(self):
-        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        n_data = len(self.api_workflow_client._mappings_api.sample_names)
         with self.assertRaises(ValueError):
             self.t_ester_upload_embedding(n_data=n_data, special_name_first_sample=True)
 
     def test_upload_comma_filenames(self):
-        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        n_data = len(self.api_workflow_client._mappings_api.sample_names)
         for invalid_char in INVALID_FILENAME_CHARACTERS:
             with self.subTest(msg=f"invalid_char: {invalid_char}"):
                 with self.assertRaises(ValueError):
@@ -88,7 +88,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
                         special_char_in_first_filename=invalid_char)
 
     def test_set_embedding_id_success(self):
-        embedding_name = self.api_workflow_client.embeddings_api.embeddings[0].name
+        embedding_name = self.api_workflow_client._embeddings_api.embeddings[0].name
         self.api_workflow_client.set_embedding_id_by_name(embedding_name)
 
     def test_set_embedding_id_failure(self):
@@ -97,12 +97,12 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
             self.api_workflow_client.set_embedding_id_by_name(embedding_name)
 
     def test_upload_existing_embedding(self):
-        embeddings = self.api_workflow_client.embeddings_api.\
+        embeddings = self.api_workflow_client._embeddings_api.\
             get_embeddings_by_dataset_id(self.api_workflow_client.dataset_id)
 
         embedding_name = embeddings[0].name
 
-        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        n_data = len(self.api_workflow_client._mappings_api.sample_names)
         self.t_ester_upload_embedding(n_data=n_data, name=embedding_name)
 
     def test_set_embedding_id_default(self):
@@ -111,7 +111,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
     def test_append_embeddings(self):
     
         # first upload embeddings
-        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        n_data = len(self.api_workflow_client._mappings_api.sample_names)
         self.t_ester_upload_embedding(n_data=n_data)
 
         # create a new set of embeddings
@@ -129,7 +129,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
     def test_append_embeddings_with_overlap(self):
 
         # mock the embeddings on the server
-        n_data_server = len(self.api_workflow_client.mappings_api.sample_names)
+        n_data_server = len(self.api_workflow_client._mappings_api.sample_names)
         self.api_workflow_client.n_dims_embeddings_on_server = 32
 
         # create new local embeddings overlapping with server embeddings
@@ -179,7 +179,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
     def test_append_embeddings_different_shape(self):
 
         # first upload embeddings
-        n_data = len(self.api_workflow_client.mappings_api.sample_names)
+        n_data = len(self.api_workflow_client._mappings_api.sample_names)
         self.t_ester_upload_embedding(n_data=n_data)
 
         # create a new set of embeddings

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -87,17 +87,8 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
                         n_data=n_data,
                         special_char_in_first_filename=invalid_char)
 
-    def test_set_embedding_id_success(self):
-        embedding_name = self.api_workflow_client._embeddings_api.embeddings[0].name
-        self.api_workflow_client.set_embedding_id_by_name(embedding_name)
-
-    def test_set_embedding_id_failure(self):
-        embedding_name = "blibblabblub"
-        with self.assertRaises(ValueError):
-            self.api_workflow_client.set_embedding_id_by_name(embedding_name)
-
     def test_set_embedding_id_default(self):
-        self.api_workflow_client.set_embedding_id_by_name()
+        self.api_workflow_client.set_embedding_id()
 
     def test_upload_existing_embedding(self):
     

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -88,7 +88,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
                         special_char_in_first_filename=invalid_char)
 
     def test_set_embedding_id_default(self):
-        self.api_workflow_client.set_latest_embedding_id()
+        self.api_workflow_client.set_embedding_id_to_latest()
 
     def test_upload_existing_embedding(self):
     

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -96,19 +96,10 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         with self.assertRaises(ValueError):
             self.api_workflow_client.set_embedding_id_by_name(embedding_name)
 
-    def test_upload_existing_embedding(self):
-        embeddings = self.api_workflow_client._embeddings_api.\
-            get_embeddings_by_dataset_id(self.api_workflow_client.dataset_id)
-
-        embedding_name = embeddings[0].name
-
-        n_data = len(self.api_workflow_client._mappings_api.sample_names)
-        self.t_ester_upload_embedding(n_data=n_data, name=embedding_name)
-
     def test_set_embedding_id_default(self):
         self.api_workflow_client.set_embedding_id_by_name()
 
-    def test_append_embeddings(self):
+    def test_upload_existing_embedding(self):
     
         # first upload embeddings
         n_data = len(self.api_workflow_client._mappings_api.sample_names)
@@ -124,7 +115,6 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
             self.path_to_embeddings,
             'embedding_id_xyz_2',
         )
-
 
     def test_append_embeddings_with_overlap(self):
 

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -88,7 +88,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
                         special_char_in_first_filename=invalid_char)
 
     def test_set_embedding_id_default(self):
-        self.api_workflow_client.set_embedding_id()
+        self.api_workflow_client.set_latest_embedding_id()
 
     def test_upload_existing_embedding(self):
     

--- a/tests/cli/test_cli_crop.py
+++ b/tests/cli/test_cli_crop.py
@@ -35,7 +35,7 @@ class TestCLICrop(MockedApiWorkflowSetup):
             ])
 
     def create_fake_dataset(self):
-        n_data = len(self.api_workflow_client.filenames_on_server)
+        n_data = len(self.api_workflow_client.download_filenames_from_server())
         self.dataset = torchvision.datasets.FakeData(size=n_data, image_size=(3, 32, 32))
 
         self.folder_path = tempfile.mkdtemp()
@@ -49,7 +49,7 @@ class TestCLICrop(MockedApiWorkflowSetup):
     def create_fake_yolo_labels(self, no_classes: int = 10, objects_per_image: int = 13):
         random.seed(42)
 
-        n_data = len(self.api_workflow_client.filenames_on_server)
+        n_data = len(self.api_workflow_client.download_filenames_from_server())
 
         self.folder_path_labels = tempfile.mkdtemp()
         label_names = [f'img_{i}.txt' for i in range(n_data)]

--- a/tests/cli/test_cli_crop.py
+++ b/tests/cli/test_cli_crop.py
@@ -35,7 +35,7 @@ class TestCLICrop(MockedApiWorkflowSetup):
             ])
 
     def create_fake_dataset(self):
-        n_data = len(self.api_workflow_client.download_filenames_from_server())
+        n_data = len(self.api_workflow_client.get_filenames())
         self.dataset = torchvision.datasets.FakeData(size=n_data, image_size=(3, 32, 32))
 
         self.folder_path = tempfile.mkdtemp()
@@ -49,7 +49,7 @@ class TestCLICrop(MockedApiWorkflowSetup):
     def create_fake_yolo_labels(self, no_classes: int = 10, objects_per_image: int = 13):
         random.seed(42)
 
-        n_data = len(self.api_workflow_client.download_filenames_from_server())
+        n_data = len(self.api_workflow_client.get_filenames())
 
         self.folder_path_labels = tempfile.mkdtemp()
         label_names = [f'img_{i}.txt' for i in range(n_data)]

--- a/tests/cli/test_cli_download.py
+++ b/tests/cli/test_cli_download.py
@@ -64,7 +64,7 @@ class TestCLIDownload(MockedApiWorkflowSetup):
     def test_download_tag_name_nonexisting(self):
         cli_string = "lightly-download token='123' dataset_id='XYZ' tag_name='nonexisting_xyz'"
         self.parse_cli_string(cli_string)
-        with self.assertWarns(Warning):
+        with self.assertRaises(ValueError):
             lightly.cli.download_cli(self.cfg)
 
     def test_download_tag_name_exclude_parent(self):

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -28,7 +28,7 @@ class TestCLIMagic(MockedApiWorkflowSetup):
             ])
 
     def create_fake_dataset(self, filename_appendix: str = ''):
-        n_data = len(self.api_workflow_client.filenames_on_server)
+        n_data = len(self.api_workflow_client.download_filenames_from_server())
         self.dataset = torchvision.datasets.FakeData(size=n_data, image_size=(3, 32, 32))
 
         self.folder_path = tempfile.mkdtemp()

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -28,7 +28,7 @@ class TestCLIMagic(MockedApiWorkflowSetup):
             ])
 
     def create_fake_dataset(self, filename_appendix: str = ''):
-        n_data = len(self.api_workflow_client.download_filenames_from_server())
+        n_data = len(self.api_workflow_client.get_filenames())
         self.dataset = torchvision.datasets.FakeData(size=n_data, image_size=(3, 32, 32))
 
         self.folder_path = tempfile.mkdtemp()


### PR DESCRIPTION
close #568 
closes #576 

## Description
- Made all `api_workflow_client` apis private (e.g. rename `tags_api` to `_tags_api`).
- Renamed `filenames_on_server` to `download_filenames_from_server()` to make clear that this is not a cheap property, but an expensive download. This had also caused some squared complexities.
- Created a `_TagsMixin` with a method `get_tag_and_filenames`. It raises an error if the `tag_name` or `tag_id` is invalid.
- Put the bitmask when downloading a tag out of the `download_cli` inside the` api_workflow_client. get_tag_and_filenames`.
- Put the upload embeddings when appending stuff out of the `upload_cli` inside the` api_workflow_client.upload_embeddings`.
- Wrote a test class for the `ApiWorkflowTags`

## Tests
- unmocked tests run through: https://github.com/lightly-ai/lightly/actions/runs/1517025903

Open questions:
- How to handle invalid CLI arguments in general? Warning and return or ValueError? Currently, this is inconsistent.
- How to cache the `get_filenames()` better? E.g. in the `active_learning_agent`, each call of the properties (e.g. `query_set`) makes a new download.