### PR TITLE
lightly download fails for integer tag

### DIFF
--- a/lightly/cli/download_cli.py
+++ b/lightly/cli/download_cli.py
@@ -27,9 +27,10 @@ from lightly.openapi_generated.swagger_client import TagData, TagArithmeticsRequ
 
 
 def _download_cli(cfg, is_cli_call=True):
-    tag_name = cfg['tag_name']
-    dataset_id = cfg['dataset_id']
-    token = cfg['token']
+
+    tag_name = str(cfg['tag_name'])
+    dataset_id = str(cfg['dataset_id'])
+    token = str(cfg['token'])
 
     if not tag_name or not token or not dataset_id:
         print_as_warning('Please specify all of the parameters tag_name, token and dataset_id')
@@ -69,7 +70,7 @@ def _download_cli(cfg, is_cli_call=True):
     samples = [api_workflow_client.filenames_on_server[i] for i in chosen_samples_ids]
 
     # store sample names in a .txt file
-    filename = cfg['tag_name'] + '.txt'
+    filename = tag_name + '.txt'
     with open(filename, 'w') as f:
         for item in samples:
             f.write("%s\n" % item)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -151,8 +151,11 @@ class MockedTagsApi(TagsApi):
         tag_4 = TagData(id='sampled_tag_xyz', dataset_id=dataset_id, prev_tag_id="preselected_tag_id_xyz",
                         bit_mask_data="0x3", name='sampled_tag_xyz', tot_size=4,
                         created_at=1577836800, changes=dict())
-        tags = [tag_1, tag_2, tag_3, tag_4]
-        no_tags_to_return = getattr(self, "no_tags", 4)
+        tag_5 = TagData(id='tag_with_integer_name', dataset_id=dataset_id, prev_tag_id=None,
+                        bit_mask_data='0x1', name='1000', tot_size=4,
+                        created_at=1577836800, changes=dict())
+        tags = [tag_1, tag_2, tag_3, tag_4, tag_5]
+        no_tags_to_return = getattr(self, "no_tags", 5)
         tags = tags[:no_tags_to_return]
         return tags
 

--- a/tests/cli/test_cli_download.py
+++ b/tests/cli/test_cli_download.py
@@ -104,7 +104,10 @@ class TestCLIDownload(MockedApiWorkflowSetup):
         self.parse_cli_string(cli_string)
         with pytest.warns(None) as record:
             lightly.cli.download_cli(self.cfg)
-        self.assertEqual(len(record), 0) # no warning was raised
+        # check if the warning "Tag with name 1000 does not exist" is raised
+        # if so, the cli string was not parsed correctly
+        # (i.e. as int instead of str)
+        self.assertEqual(len(record), 0)
 
     def tearDown(self) -> None:
         try:

--- a/tests/cli/test_cli_download.py
+++ b/tests/cli/test_cli_download.py
@@ -1,13 +1,14 @@
 import os
-import re
 import sys
 import tempfile
 
+import pytest
 import torchvision
 from hydra.experimental import compose, initialize
 
 import lightly
-from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
+from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
+from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowClient
 
 
 class TestCLIDownload(MockedApiWorkflowSetup):
@@ -36,15 +37,13 @@ class TestCLIDownload(MockedApiWorkflowSetup):
         self.output_dir = tempfile.mkdtemp()
 
     def parse_cli_string(self, cli_words: str):
-        cli_words = cli_words.replace("lightly-download ", "")
-        cli_words = re.split("=| ", cli_words)
-        assert len(cli_words) % 2 == 0
-        dict_keys = cli_words[0::2]
-        dict_values = cli_words[1::2]
-        for key, value in zip(dict_keys, dict_values):
-            value = value.strip('\"')
-            value = value.strip('\'')
-            self.cfg[key] = value
+        cli_words = cli_words.replace('lightly-download ', '')
+        overrides = cli_words.split(' ')
+        with initialize(config_path='../../lightly/cli/config/'):
+            self.cfg = compose(
+                config_name='config',
+                overrides=overrides,
+            )
 
     def test_parse_cli_string(self):
         cli_string = "lightly-download token='123' dataset_id='XYZ'"
@@ -97,6 +96,15 @@ class TestCLIDownload(MockedApiWorkflowSetup):
                      f"input_dir={self.input_dir} output_dir={self.output_dir}"
         self.parse_cli_string(cli_string)
         lightly.cli.download_cli(self.cfg)
+
+    def test_download_from_tag_with_integer_name(self):
+        """Test to reproduce issue #575."""
+        # use tag name "1000"
+        cli_string = "lightly-download token='123' dataset_id='dataset_1_id' tag_name=1000"
+        self.parse_cli_string(cli_string)
+        with pytest.warns(None) as record:
+            lightly.cli.download_cli(self.cfg)
+        self.assertEqual(len(record), 0) # no warning was raised
 
     def tearDown(self) -> None:
         try:


### PR DESCRIPTION
# lightly download fails for integer tag name

Closes #575. A better solution is proposed and up for discussion, see #586.

- Adds a unit test to reproduce #575.
- Fixes the problem by converting the `tag_name` to string