### PR TITLE
Bump deprecation warning to 1.3.0 for high-level models

### DIFF
--- a/lightly/models/barlowtwins.py
+++ b/lightly/models/barlowtwins.py
@@ -55,7 +55,7 @@ class BarlowTwins(nn.Module):
         )
 
         warnings.warn(Warning(
-            'The high-level building block BarlowTwins will be deprecated in version 1.2.0. '
+            'The high-level building block BarlowTwins will be deprecated in version 1.3.0. '
             + 'Use low-level building blocks instead. '
             + 'See https://docs.lightly.ai/lightly.models.html for more information'),
             PendingDeprecationWarning)

--- a/lightly/models/byol.py
+++ b/lightly/models/byol.py
@@ -64,7 +64,7 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
         self.m = m
 
         warnings.warn(Warning(
-            'The high-level building block BYOL will be deprecated in version 1.2.0. '
+            'The high-level building block BYOL will be deprecated in version 1.3.0. '
             + 'Use low-level building blocks instead. '
             + 'See https://docs.lightly.ai/lightly.models.html for more information'),
             PendingDeprecationWarning)

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -53,7 +53,7 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
         self._init_momentum_encoder()
 
         warnings.warn(Warning(
-            'The high-level building block MoCo will be deprecated in version 1.2.0. '
+            'The high-level building block MoCo will be deprecated in version 1.3.0. '
             + 'Use low-level building blocks instead. '
             + 'See https://docs.lightly.ai/lightly.models.html for more information'),
             PendingDeprecationWarning)

--- a/lightly/models/nnclr.py
+++ b/lightly/models/nnclr.py
@@ -154,7 +154,7 @@ class NNCLR(nn.Module):
         )
 
         warnings.warn(Warning(
-            'The high-level building block NNCLR will be deprecated in version 1.2.0. '
+            'The high-level building block NNCLR will be deprecated in version 1.3.0. '
             + 'Use low-level building blocks instead. '
             + 'See https://docs.lightly.ai/lightly.models.html for more information'),
             PendingDeprecationWarning)

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -39,7 +39,7 @@ class SimCLR(nn.Module):
         self.projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
 
         warnings.warn(Warning(
-            'The high-level building block SimCLR will be deprecated in version 1.2.0. '
+            'The high-level building block SimCLR will be deprecated in version 1.3.0. '
             + 'Use low-level building blocks instead. '
             + 'See https://docs.lightly.ai/lightly.models.html for more information'),
             PendingDeprecationWarning)

--- a/lightly/models/simsiam.py
+++ b/lightly/models/simsiam.py
@@ -63,7 +63,7 @@ class SimSiam(nn.Module):
         )
 
         warnings.warn(Warning(
-            'The high-level building block SimSiam will be deprecated in version 1.2.0. '
+            'The high-level building block SimSiam will be deprecated in version 1.3.0. '
             + 'Use low-level building blocks instead. '
             + 'See https://docs.lightly.ai/lightly.models.html for more information'),
             PendingDeprecationWarning)


### PR DESCRIPTION
Closes #591 