### PR TITLE
setting paths to CLI artifacts as environment variables

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -42,3 +42,5 @@ jobs:
         INPUT_DIR_1="clothing_dataset_small/test/dress"
         lightly-train input_dir=$INPUT_DIR_1 trainer.max_epochs=1 loader.num_workers=6
         lightly-embed input_dir=$INPUT_DIR_1
+        echo $LIGHTLY_LAST_CHECKPOINT_PATH
+        echo $LIGHTLY_LAST_EMBEDDING_PATH

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -42,5 +42,3 @@ jobs:
         INPUT_DIR_1="clothing_dataset_small/test/dress"
         lightly-train input_dir=$INPUT_DIR_1 trainer.max_epochs=1 loader.num_workers=6
         lightly-embed input_dir=$INPUT_DIR_1
-        echo $LIGHTLY_LAST_CHECKPOINT_PATH
-        echo $LIGHTLY_LAST_EMBEDDING_PATH

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -85,6 +85,12 @@ checkpoint_callback:
   dirpath:                    # Where to store the checkpoints (empty field resolves to None).
                               # If not set, checkpoints are stored in the hydra output dir.
 
+# environment variable namespace for saving artifacts
+environment_variable_names:
+  lightly_last_checkpoint_path: LIGHTLY_LAST_CHECKPOINT_PATH
+  lightly_last_embedding_path: LIGHTLY_LAST_EMBEDDING_PATH
+  lightly_last_dataset_id: LIGHTLY_LAST_DATASET_ID
+
 # seed
 seed: 1
 

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -116,6 +116,9 @@ def _embed_cli(cfg, is_cli_call=True):
         path = os.path.join(os.getcwd(), 'embeddings.csv')
         save_embeddings(path, embeddings, labels, filenames)
         print(f'Embeddings are stored at {bcolors.OKBLUE}{path}{bcolors.ENDC}')
+        os.environ[
+            cfg['environment_variable_names']['lightly_last_embedding_path']
+        ] = path
         return path
 
     return embeddings, labels, filenames

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -7,6 +7,7 @@ command-line interface.
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
+import os
 
 import hydra
 import torch
@@ -131,6 +132,9 @@ def _train_cli(cfg, is_cli_call=True):
     encoder.train_embedding(**cfg['trainer'])
 
     print(f'Best model is stored at: {bcolors.OKBLUE}{encoder.checkpoint}{bcolors.ENDC}')
+    os.environ[
+        cfg['environment_variable_names']['lightly_last_checkpoint_path']
+    ] = encoder.checkpoint
     return encoder.checkpoint
 
 

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -9,6 +9,7 @@ command-line interface.
 # All Rights Reserved
 import csv
 import json
+import os
 from datetime import datetime
 
 import hydra
@@ -118,6 +119,10 @@ def _upload_cli(cfg, is_cli_call=True):
     if new_dataset_name:
         print(f'The dataset_id of the newly created dataset is '
               f'{bcolors.OKBLUE}{api_workflow_client.dataset_id}{bcolors.ENDC}')
+
+    os.environ[
+        cfg['environment_variable_names']['lightly_last_dataset_id']
+    ] = api_workflow_client.dataset_id
 
 
 @hydra.main(config_path='config', config_name='config')

--- a/tests/cli/test_cli_embed.py
+++ b/tests/cli/test_cli_embed.py
@@ -41,6 +41,11 @@ class TestCLIEmbed(MockedApiWorkflowSetup):
 
     def test_embed(self):
         lightly.cli.embed_cli(self.cfg)
+        self.assertGreater(len(os.getenv(
+            self.cfg['environment_variable_names'][
+            'lightly_last_embedding_path']
+        )), 0)
+
 
     def tearDown(self) -> None:
         for filename in ["embeddings.csv", "embeddings_sorted.csv"]:

--- a/tests/cli/test_cli_train.py
+++ b/tests/cli/test_cli_train.py
@@ -67,6 +67,10 @@ class TestCLITrain(MockedApiWorkflowSetup):
                 self.parse_cli_string(cli_string)
                 lightly.cli.train_cli(self.cfg)
 
+                self.assertGreater(len(os.getenv(
+                    self.cfg['environment_variable_names'][
+                        'lightly_last_checkpoint_path'])), 0)
+
     def tearDown(self) -> None:
         for filename in ["embeddings.csv", "embeddings_sorted.csv"]:
             try:

--- a/tests/cli/test_cli_upload.py
+++ b/tests/cli/test_cli_upload.py
@@ -88,6 +88,10 @@ class TestCLIUpload(MockedApiWorkflowSetup):
         cli_string = "lightly-upload new_dataset_name='new_dataset_name_xyz'"
         self.parse_cli_string(cli_string)
         lightly.cli.upload_cli(self.cfg)
+        self.assertGreater(len(os.getenv(
+            self.cfg['environment_variable_names'][
+            'lightly_last_dataset_id']
+        )), 0)
 
     def test_upload_new_dataset_name_and_embeddings(self):
         """


### PR DESCRIPTION
## Descriptions
- Adds `environment_variable_names` to cfg to make it configurable where the paths are saved.
- When using the CLI for train, embed, upload, the paths to the artifacts are set at the corresponding locations.
- CLI unittests check that the paths are really set.

## Follow-Up Issue
- https://github.com/lightly-ai/lightly/issues/608