### PR TITLE
Fix docs

### DIFF
--- a/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
@@ -253,7 +253,7 @@ def convert_bbox_detectron2lightly(outputs):
 # in the `query_set`. Otherwise, we could upload a prediction to the wrong sample!
 
 obj_detection_outputs = []
-pbar = tqdm.tqdm(al_agent.query_set)
+pbar = tqdm.tqdm(al_agent.query_set, miniters=500, mininterval=60, maxinterval=120)
 for fname in pbar:
   fname_full = os.path.join(DATASET_ROOT, fname)
   im = cv2.imread(fname_full)

--- a/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
+++ b/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
@@ -31,7 +31,7 @@ Requirements
 You can use your own dataset or the one we provide for this tutorial. The dataset
 we will use is the training set of `Roboflow's Aquarium Dataset <https://public.roboflow.com/object-detection/aquarium>`_.
 It consists of 448 images from two aquariums in the United States and was made for object detection.
-You can download it here :download:`Aquarium.zip <../../../_data/aquarium.zip>`.
+You can download it here `aquarium.zip <https://storage.googleapis.com/datasets_boris/aquarium.zip>`_.
 
 For this tutorial the `lightly` pip package needs to be installed:
 


### PR DESCRIPTION
This pr addresses two issues:

1. Reduce the update interval of the progress bar in the detectron2 active learning tutorial. This is necessary because every update is printed to a new line (for some reason) which results in the terminal output getting spammed by these messages, making it impossible to find warnings/errors.

2. Replace aquarium.zip with external download link because the file is too large to be hosted on gcloud.