### PR TITLE
Malte lig 390 datasource docs reorganize

### DIFF
--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -1,5 +1,7 @@
-How to use S3 with Lightly
-------------------------------
+.. _dataset-creation-aws-bucket:
+
+Create dataset from AWS S3 bucket
+---------------------------------
 
 
 Lightly allows you to configure a remote datasource like Amazon S3 (Amazon Simple Storage Service).

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -19,7 +19,7 @@ Let us assume your bucket is called `datalake`. And let us assume the folder you
 1. Go to the `Identity and Access Management IAM page <https://console.aws.amazon.com/iamv2/home?#/users>`_ and create a new user for Lightly.
 2. Choose a unique name of your choice and select "Programmatic access" as "Access type". Click next
     
-    .. figure:: resources/AWSCreateUser2.png
+    .. figure:: ../resources/AWSCreateUser2.png
         :align: center
         :alt: Create AWS User
 
@@ -27,7 +27,7 @@ Let us assume your bucket is called `datalake`. And let us assume the folder you
 
 3. We will want to create very restrictive permissions for this new user so that it can't access other resources of your company. Click on "Attach existing policies directly" and then on "Create policy". This will bring you to a new page
     
-    .. figure:: resources/AWSCreateUser3.png
+    .. figure:: ../resources/AWSCreateUser3.png
         :align: center
         :alt: Setting user permission in AWS
 
@@ -59,28 +59,28 @@ Let us assume your bucket is called `datalake`. And let us assume the folder you
                 }
             ]
         }
-    .. figure:: resources/AWSCreateUser4.png
+    .. figure:: ../resources/AWSCreateUser4.png
         :align: center
         :alt: Permission policy in AWS
 
         Permission policy in AWS
 5. Go to the next page and create tags as you see fit (e.g `external` or `lightly`) and give a name to your new policy before creating it.
 
-    .. figure:: resources/AWSCreateUser5.png
+    .. figure:: ../resources/AWSCreateUser5.png
         :align: center
         :alt: Review and name permission policy in AWS
 
         Review and name permission policy in AWS
 6. Return to the previous page as shown in the screenshot below and reload. Now when filtering policies your newly created policy will show up. Select it and continue setting up your new user.
     
-    .. figure:: resources/AWSCreateUser6.png
+    .. figure:: ../resources/AWSCreateUser6.png
         :align: center
         :alt: Attach permission policy to user in AWS
 
         Attach permission policy to user in AWS
 7. Write down the `Access key ID` and the `Secret access key` in a secure location (such as a password manager) as you will not be able to access this information again (you can generate new keys and revoke old keys under `Security credentials` of a users detail page)
     
-    .. figure:: resources/AWSCreateUser7.png
+    .. figure:: ../resources/AWSCreateUser7.png
         :align: center
         :alt: Get security credentials (access key id, secret access key) from AWS
 
@@ -111,7 +111,7 @@ Create and configure a dataset
 1. `Create a new dataset <https://app.lightly.ai/dataset/create>`_ in Lightly
 2. Edit your dataset and select S3 as your datasource
 
-    .. figure:: resources/LightlyEdit1.png
+    .. figure:: ../resources/LightlyEdit1.png
         :align: center
         :alt: Get security credentials (access key id, secret access key) from AWS
 
@@ -125,7 +125,7 @@ Create and configure a dataset
     - where your thumbnails will be stored when you want Lightly to create thumbnails for you. For this to work, the user policy you have created must possess write permissions.
     - when the thumbnail suffix is not defined/empty, we will load the full image even when requesting the thumbnail.
     
-    .. figure:: resources/LightlyEdit2.png
+    .. figure:: ../resources/LightlyEdit2.png
         :align: center
         :alt: Lightly S3 connection config
         :width: 60%

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -1,0 +1,140 @@
+How to use S3 with Lightly
+------------------------------
+
+
+Lightly allows you to configure a remote datasource like Amazon S3 (Amazon Simple Storage Service).
+In this guide, we will show you how to setup your S3 bucket, configure your dataset to use said bucket, and only upload metadata to Lightly.
+
+
+Setting up Amazon S3
+^^^^^^^^^^^^^^^^^^^^^^
+For Lightly to be able to create so-called `presigned URLs/read URLs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html>`_ to be used for displaying your data in your browser, Lightly needs at minimum to be able to read and list permissions on your bucket. If you want Lightly to create optimal thumbnails for you while uploading the metadata of your images, write permissions are also needed.
+
+Let us assume your bucket is called `datalake`. And let us assume the folder you want to use with Lightly is located at projects/farm-animals/
+
+**Setting up IAM**
+
+1. Go to the `Identity and Access Management IAM page <https://console.aws.amazon.com/iamv2/home?#/users>`_ and create a new user for Lightly.
+2. Choose a unique name of your choice and select "Programmatic access" as "Access type". Click next
+    
+    .. figure:: resources/AWSCreateUser2.png
+        :align: center
+        :alt: Create AWS User
+
+        Create AWS User
+
+3. We will want to create very restrictive permissions for this new user so that it can't access other resources of your company. Click on "Attach existing policies directly" and then on "Create policy". This will bring you to a new page
+    
+    .. figure:: resources/AWSCreateUser3.png
+        :align: center
+        :alt: Setting user permission in AWS
+
+        Setting user permission in AWS
+
+4. As our policy is very simple, we will use the JSON option and enter the following while substituting `datalake` with your bucket and `projects/farm-animals/` with the folder you want to share.
+    
+    .. code-block:: json
+
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "VisualEditor0",
+                    "Effect": "Allow",
+                    "Action": "s3:ListBucket",
+                    "Resource": [
+                        "arn:aws:s3:::datalake",
+                        "arn:aws:s3:::datalake/projects/farm-animals/*"
+                    ]
+                },
+                {
+                    "Sid": "VisualEditor1",
+                    "Effect": "Allow",
+                    "Action": "s3:*",
+                    "Resource": [
+                        "arn:aws:s3:::datalake/projects/farm-animals/*"
+                    ]
+                }
+            ]
+        }
+    .. figure:: resources/AWSCreateUser4.png
+        :align: center
+        :alt: Permission policy in AWS
+
+        Permission policy in AWS
+5. Go to the next page and create tags as you see fit (e.g `external` or `lightly`) and give a name to your new policy before creating it.
+
+    .. figure:: resources/AWSCreateUser5.png
+        :align: center
+        :alt: Review and name permission policy in AWS
+
+        Review and name permission policy in AWS
+6. Return to the previous page as shown in the screenshot below and reload. Now when filtering policies your newly created policy will show up. Select it and continue setting up your new user.
+    
+    .. figure:: resources/AWSCreateUser6.png
+        :align: center
+        :alt: Attach permission policy to user in AWS
+
+        Attach permission policy to user in AWS
+7. Write down the `Access key ID` and the `Secret access key` in a secure location (such as a password manager) as you will not be able to access this information again (you can generate new keys and revoke old keys under `Security credentials` of a users detail page)
+    
+    .. figure:: resources/AWSCreateUser7.png
+        :align: center
+        :alt: Get security credentials (access key id, secret access key) from AWS
+
+        Get security credentials (access key id, secret access key) from AWS
+
+**Preparing your data**
+
+
+For Lightly to be able to create embeddings and extract metadata from your data, `lightly-magic` needs to be able to access your data. You can either download/sync your data from S3 or you can mount S3 as a drive. We recommend downloading your data from S3 as it makes the overall process faster.
+
+**Downloading from S3 (recommended)**
+
+1. Install AWS cli by following the `guide of Amazon <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`_
+2. Run `aws configure` and set the credentials
+3. Download/synchronize the folder located on S3 to your current directory `aws s3 sync s3://datalake/projects/farm-animals ./farm`
+
+**Mount S3 as a drive**
+
+For Linux and MacOS we recommend using `s3fs-fuse <https://github.com/s3fs-fuse/s3fs-fuse>`_ to mount S3 buckets to a local file storage. 
+You can have a look at our step-by-step guide: :ref:`ref-docker-integration-s3fs-fuse`. 
+
+
+Uploading your data
+^^^^^^^^^^^^^^^^^^^^^^
+
+Create and configure a dataset
+
+1. `Create a new dataset <https://app.lightly.ai/dataset/create>`_ in Lightly
+2. Edit your dataset and select S3 as your datasource
+
+    .. figure:: resources/LightlyEdit1.png
+        :align: center
+        :alt: Get security credentials (access key id, secret access key) from AWS
+
+        Get security credentials (access key id, secret access key) from AWS
+
+3. As the resource path, enter the full S3 URI to your resource eg. `s3://datalake/projects/farm-animals/`
+4. Enter the `access key` and the `secret access key` we obtained from creating a new user in the previous step and select the AWS region in which you created your bucket in
+5. The thumbnail suffix allows you to configure
+   
+    - where your thumbnails are stored when you already have generated thumbnails in your S3 bucket
+    - where your thumbnails will be stored when you want Lightly to create thumbnails for you. For this to work, the user policy you have created must possess write permissions.
+    - when the thumbnail suffix is not defined/empty, we will load the full image even when requesting the thumbnail.
+    
+    .. figure:: resources/LightlyEdit2.png
+        :align: center
+        :alt: Lightly S3 connection config
+        :width: 60%
+
+        Lightly S3 connection config
+
+6. Press save and ensure that at least the lights for List and Read turn green.
+
+
+Use Lightly
+Use `lightly-magic` and `lightly-upload` just as you always would with the following considerations;
+
+- If you already have generated thumbnails, don't want to see thumbnails or just want to use the full image for a thumbnail (by setting the thumbnail suffix to empty), add `upload=metadata` to the `lightly-magic` command.
+- If you want Lightly to create thumbnails for you, you can add `upload=thumbnails` to the `lightly-magic` command.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_bucket.rst
@@ -1,1 +1,6 @@
+.. _dataset-creation-azure-bucket:
+
+Create dataset from azure cloud bucket
+---------------------------------
+
 TODO: Add the tutorial how to create a Lightly dataset from a azure bucket here.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_bucket.rst
@@ -1,6 +1,6 @@
 .. _dataset-creation-azure-bucket:
 
-Create dataset from azure cloud bucket
----------------------------------
+Create dataset from azure blob storage
+--------------------------------------
 
 TODO: Add the tutorial how to create a Lightly dataset from a azure bucket here.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_bucket.rst
@@ -1,0 +1,1 @@
+TODO: Add the tutorial how to create a Lightly dataset from a azure bucket here.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -1,4 +1,4 @@
-.. _dataset-creation-azure-bucket:
+.. _dataset-creation-azure-storage:
 
 Create dataset from azure blob storage
 --------------------------------------

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -1,1 +1,6 @@
+.. _dataset-creation-gcloud-bucket:
+
+Create dataset from google cloud bucket
+---------------------------------
+
 TODO: Add the tutorial how to create a Lightly dataset from a gcloud bucket here.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -1,6 +1,6 @@
 .. _dataset-creation-gcloud-bucket:
 
 Create dataset from google cloud bucket
----------------------------------
+---------------------------------------
 
 TODO: Add the tutorial how to create a Lightly dataset from a gcloud bucket here.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -1,0 +1,1 @@
+TODO: Add the tutorial how to create a Lightly dataset from a gcloud bucket here.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_local_upload.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_local_upload.rst
@@ -1,0 +1,32 @@
+To create a new dataset of images with embeddings use the lightly :ref:`lightly-command-line-tool`:
+
+.. code-block:: bash
+
+    lightly-magic trainer.max_epochs=0 token='YOUR_API_TOKEN' new_dataset_name='my-dataset' input_dir='/path/to/my/dataset'
+
+
+Images and embeddings can also be uploaded from a Python script. For this, you need to
+have a numpy array of image embeddings, the filenames of the images, and categorical pseudo-labels.
+You can use the `save_embeddings` function to store them in a lightly-compatible CSV format and
+upload them from your Python code:
+
+.. code-block:: python
+
+    from lightly.utils import save_embeddings
+    from lightly.api.api_workflow_client import ApiWorkflowClient
+
+    client = ApiWorkflowClient(token='123', dataset_id='xyz')
+
+    # upload the images to the dataset
+    # change mode to 'thumbnails' or 'meta' if you're working with sensitive data
+    client.upload_dataset('path/to/your/images/', mode='full')
+
+    # store the embeddings in a lightly compatible CSV format
+    save_embeddings('embeddings.csv', embeddings, labels, filenames)
+
+    # upload the embeddings.csv file to the platform
+    client.upload_embeddings('embeddings.csv', name='my-embeddings')
+
+.. note::
+
+    Check out :ref:`ref-webapp-dataset-id` to see how to get the dataset identifier.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_local_upload.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_local_upload.rst
@@ -1,3 +1,8 @@
+.. _dataset-creation-local-upload:
+
+Create dataset with local upload
+--------------------------------
+
 To create a new dataset of images with embeddings use the lightly :ref:`lightly-command-line-tool`:
 
 .. code-block:: bash

--- a/docs/source/getting_started/dataset_creation/dataset_creation_local_upload.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_local_upload.rst
@@ -1,7 +1,7 @@
 .. _dataset-creation-local-upload:
 
-Create dataset with local upload
---------------------------------
+Create a dataset from a local dataset
+-------------------------------------
 
 To create a new dataset of images with embeddings use the lightly :ref:`lightly-command-line-tool`:
 

--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -67,27 +67,13 @@ It will keep all images and videos in your own bucket and only stream them from 
 This has the advantage that you don't need to upload your data to Lightly and can preserve its privacy.
 
 
-.. tabs::
+.. toctree::
+    :maxdepth: 1
 
-    .. tab:: Upload from local files
-
-        .. _platform-dataset-creation-local-upload:
-
-        .. include::  dataset_creation/dataset_creation_local_upload.rst
-
-    .. tab:: AWS S3
-
-        .. _platform-dataset-creation-aws-bucket:
-
-        .. include::  dataset_creation/dataset_creation_aws_bucket.rst
-
-    .. tab:: GCloud
-
-        .. include::  dataset_creation/dataset_creation_gcloud_bucket.rst
-
-    .. tab:: Azure
-
-        .. include::  dataset_creation/dataset_creation_azure_bucket.rst
+    dataset_creation/dataset_creation_local_upload.rst
+    dataset_creation/dataset_creation_aws_bucket.rst
+    dataset_creation/dataset_creation_gcloud_bucket.rst
+    dataset_creation/dataset_creation_azure_bucket.rst
 
 
 .. _platform-custom-metadata:

--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -72,8 +72,6 @@ This has the advantage that you don't need to upload your data to Lightly and ca
 
     dataset_creation/dataset_creation_local_upload.rst
     dataset_creation/dataset_creation_aws_bucket.rst
-    dataset_creation/dataset_creation_gcloud_bucket.rst
-    dataset_creation/dataset_creation_azure_bucket.rst
 
 
 .. _platform-custom-metadata:

--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -61,8 +61,8 @@ The baseline way is to upload your local dataset including all images or
 videos to the Lightly platform.
 
 If you don't have your data locally, but rather stored at a cloud provider like
-in an AWS S3 bucket, GCloud bucket or at Azure, you can create a dataset directly
-from your bucket.
+in an AWS S3 bucket, GCloud bucket or at Azure,
+you can create a dataset directly referencing the images in your bucket.
 It will keep all images and videos in your own bucket and only stream them from there if they are needed.
 This has the advantage that you don't need to upload your data to Lightly and can preserve its privacy.
 

--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -55,39 +55,39 @@ Learn more about the different concepts in our `Glossary <https://app.lightly.ai
 Create a Dataset
 ----------------
 
+There are several different ways to create a dataset on the lightly platform.
 
-To create a new dataset of images with embeddings use the lightly :ref:`lightly-command-line-tool`:
+The baseline way is to upload your local dataset including all images or
+videos to the Lightly platform.
 
-.. code-block:: bash
+If you don't have your data locally, but rather stored at a cloud provider like
+in an AWS S3 bucket, GCloud bucket or at Azure, you can create a dataset directly
+from your bucket.
+It will keep all images and videos in your own bucket and only stream them from there if they are needed.
+This has the advantage that you don't need to upload your data to Lightly and can preserve its privacy.
 
-    lightly-magic trainer.max_epochs=0 token='YOUR_API_TOKEN' new_dataset_name='my-dataset' input_dir='/path/to/my/dataset'
 
+.. tabs::
 
-Images and embeddings can also be uploaded from a Python script. For this, you need to 
-have a numpy array of image embeddings, the filenames of the images, and categorical pseudo-labels.
-You can use the `save_embeddings` function to store them in a lightly-compatible CSV format and
-upload them from your Python code:
+    .. tab:: Upload from local files
 
-.. code-block:: python
+        .. _platform-dataset-creation-local-upload:
 
-    from lightly.utils import save_embeddings
-    from lightly.api.api_workflow_client import ApiWorkflowClient
+        .. include::  dataset_creation/dataset_creation_local_upload.rst
 
-    client = ApiWorkflowClient(token='123', dataset_id='xyz')
+    .. tab:: AWS S3
 
-    # upload the images to the dataset
-    # change mode to 'thumbnails' or 'meta' if you're working with sensitive data
-    client.upload_dataset('path/to/your/images/', mode='full')
+        .. _platform-dataset-creation-aws-bucket:
 
-    # store the embeddings in a lightly compatible CSV format
-    save_embeddings('embeddings.csv', embeddings, labels, filenames)
+        .. include::  dataset_creation/dataset_creation_aws_bucket.rst
 
-    # upload the embeddings.csv file to the platform
-    client.upload_embeddings('embeddings.csv', name='my-embeddings')
+    .. tab:: GCloud
 
-.. note::
+        .. include::  dataset_creation/dataset_creation_gcloud_bucket.rst
 
-    Check out :ref:`ref-webapp-dataset-id` to see how to get the dataset identifier.
+    .. tab:: Azure
+
+        .. include::  dataset_creation/dataset_creation_azure_bucket.rst
 
 
 .. _platform-custom-metadata:
@@ -299,152 +299,6 @@ account (top right)-> preferences on the
 .. warning:: Keep the token for yourself and don't share it. Anyone with the
           token could access your datasets!
 
-
-How to use S3 with Lightly
-------------------------------
-
-
-Lightly allows you to configure a remote datasource like Amazon S3 (Amazon Simple Storage Service) so that you don't need to upload your data to Lightly and can preserve its privacy.
-
-
-**What you will learn**
-
-
-In this guide, we will show you how to setup your S3 bucket, configure your dataset to use said bucket, and only upload metadata to Lightly while preserving the privacy of your data
-
-
-Setting up Amazon S3
-^^^^^^^^^^^^^^^^^^^^^^
-For Lightly to be able to create so-called `presigned URLs/read URLs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html>`_ to be used for displaying your data in your browser, Lightly needs at minimum to be able to read and list permissions on your bucket. If you want Lightly to create optimal thumbnails for you while uploading the metadata of your images, write permissions are also needed.
-
-Let us assume your bucket is called `datalake`. And let us assume the folder you want to use with Lightly is located at projects/farm-animals/
-
-**Setting up IAM**
-
-1. Go to the `Identity and Access Management IAM page <https://console.aws.amazon.com/iamv2/home?#/users>`_ and create a new user for Lightly.
-2. Choose a unique name of your choice and select "Programmatic access" as "Access type". Click next
-    
-    .. figure:: resources/AWSCreateUser2.png
-        :align: center
-        :alt: Create AWS User
-
-        Create AWS User
-
-3. We will want to create very restrictive permissions for this new user so that it can't access other resources of your company. Click on "Attach existing policies directly" and then on "Create policy". This will bring you to a new page
-    
-    .. figure:: resources/AWSCreateUser3.png
-        :align: center
-        :alt: Setting user permission in AWS
-
-        Setting user permission in AWS
-
-4. As our policy is very simple, we will use the JSON option and enter the following while substituting `datalake` with your bucket and `projects/farm-animals/` with the folder you want to share.
-    
-    .. code-block:: json
-
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "VisualEditor0",
-                    "Effect": "Allow",
-                    "Action": "s3:ListBucket",
-                    "Resource": [
-                        "arn:aws:s3:::datalake",
-                        "arn:aws:s3:::datalake/projects/farm-animals/*"
-                    ]
-                },
-                {
-                    "Sid": "VisualEditor1",
-                    "Effect": "Allow",
-                    "Action": "s3:*",
-                    "Resource": [
-                        "arn:aws:s3:::datalake/projects/farm-animals/*"
-                    ]
-                }
-            ]
-        }
-    .. figure:: resources/AWSCreateUser4.png
-        :align: center
-        :alt: Permission policy in AWS
-
-        Permission policy in AWS
-5. Go to the next page and create tags as you see fit (e.g `external` or `lightly`) and give a name to your new policy before creating it.
-
-    .. figure:: resources/AWSCreateUser5.png
-        :align: center
-        :alt: Review and name permission policy in AWS
-
-        Review and name permission policy in AWS
-6. Return to the previous page as shown in the screenshot below and reload. Now when filtering policies your newly created policy will show up. Select it and continue setting up your new user.
-    
-    .. figure:: resources/AWSCreateUser6.png
-        :align: center
-        :alt: Attach permission policy to user in AWS
-
-        Attach permission policy to user in AWS
-7. Write down the `Access key ID` and the `Secret access key` in a secure location (such as a password manager) as you will not be able to access this information again (you can generate new keys and revoke old keys under `Security credentials` of a users detail page)
-    
-    .. figure:: resources/AWSCreateUser7.png
-        :align: center
-        :alt: Get security credentials (access key id, secret access key) from AWS
-
-        Get security credentials (access key id, secret access key) from AWS
-
-**Preparing your data**
-
-
-For Lightly to be able to create embeddings and extract metadata from your data, `lightly-magic` needs to be able to access your data. You can either download/sync your data from S3 or you can mount S3 as a drive. We recommend downloading your data from S3 as it makes the overall process faster.
-
-**Downloading from S3 (recommended)**
-
-1. Install AWS cli by following the `guide of Amazon <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`_
-2. Run `aws configure` and set the credentials
-3. Download/synchronize the folder located on S3 to your current directory `aws s3 sync s3://datalake/projects/farm-animals ./farm`
-
-**Mount S3 as a drive**
-
-For Linux and MacOS we recommend using `s3fs-fuse <https://github.com/s3fs-fuse/s3fs-fuse>`_ to mount S3 buckets to a local file storage. 
-You can have a look at our step-by-step guide: :ref:`ref-docker-integration-s3fs-fuse`. 
-
-
-Uploading your data
-^^^^^^^^^^^^^^^^^^^^^^
-
-Create and configure a dataset
-
-1. `Create a new dataset <https://app.lightly.ai/dataset/create>`_ in Lightly
-2. Edit your dataset and select S3 as your datasource
-
-    .. figure:: resources/LightlyEdit1.png
-        :align: center
-        :alt: Get security credentials (access key id, secret access key) from AWS
-
-        Get security credentials (access key id, secret access key) from AWS
-
-3. As the resource path, enter the full S3 URI to your resource eg. `s3://datalake/projects/farm-animals/`
-4. Enter the `access key` and the `secret access key` we obtained from creating a new user in the previous step and select the AWS region in which you created your bucket in
-5. The thumbnail suffix allows you to configure
-   
-    - where your thumbnails are stored when you already have generated thumbnails in your S3 bucket
-    - where your thumbnails will be stored when you want Lightly to create thumbnails for you. For this to work, the user policy you have created must possess write permissions.
-    - when the thumbnail suffix is not defined/empty, we will load the full image even when requesting the thumbnail.
-    
-    .. figure:: resources/LightlyEdit2.png
-        :align: center
-        :alt: Lightly S3 connection config
-        :width: 60%
-
-        Lightly S3 connection config
-
-6. Press save and ensure that at least the lights for List and Read turn green.
-
-
-Use Lightly
-Use `lightly-magic` and `lightly-upload` just as you always would with the following considerations;
-
-- If you already have generated thumbnails, don't want to see thumbnails or just want to use the full image for a thumbnail (by setting the thumbnail suffix to empty), add `upload=metadata` to the `lightly-magic` command.
-- If you want Lightly to create thumbnails for you, you can add `upload=thumbnails` to the `lightly-magic` command.
 
 
 


### PR DESCRIPTION

## Description
Puts the different options to create a dataset in the Lightly Platform into separate files. The files are included in form of a toctree.

## How it looks like

#### Create a Dataset

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/20324507/146181417-2a7e7145-2aba-40a3-9eef-e639a87a0650.png">

#### Create a Dataset with local upload

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/20324507/146181498-43a0c55f-cf5c-43f0-ad79-3fa3a23ea829.png">

#### Create a Dataset from S3

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/20324507/146181734-ea145db2-330a-4087-ac07-57a062c9f1f7.png">
