### PR TITLE
Fix: Extract timestamp from response

### DIFF
--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -2,7 +2,10 @@ import time
 from typing import List, Tuple
 
 from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_request import DatasourceProcessedUntilTimestampRequest
+from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_response import DatasourceProcessedUntilTimestampResponse
+
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data import DatasourceRawSamplesData
+
 
 
 class _DatasourcesMixin:
@@ -53,8 +56,7 @@ class _DatasourcesMixin:
             A list of (filename, url) tuples, where each tuple represents a sample
 
         """
-        response = self.get_processed_until_timestamp()
-        from_ = int(response)
+        from_ = self.get_processed_until_timestamp()
         
         if from_ != 0:
             # We already processed samples at some point.
@@ -73,9 +75,13 @@ class _DatasourcesMixin:
         Returns:
             Unix timestamp of last processed sample
         """
-        return self._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id(
-            dataset_id=self.dataset_id
+        response: DatasourceProcessedUntilTimestampResponse = (
+            self._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id(
+                dataset_id=self.dataset_id
+            )
         )
+        timestamp = int(response.processed_until_timestamp)
+        return timestamp
 
     def update_processed_until_timestamp(self, timestamp: int) -> None:
         """Sets the timestamp until which samples have been processed.

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -8,6 +8,7 @@ import json
 
 import numpy as np
 from requests import Response
+from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_response import DatasourceProcessedUntilTimestampResponse
 
 from lightly.openapi_generated.swagger_client.models.tag_creator import TagCreator
 from lightly.openapi_generated.swagger_client.models.dataset_create_request import DatasetCreateRequest
@@ -165,7 +166,7 @@ class MockedTagsApi(TagsApi):
 
     def perform_tag_arithmetics(self, body: TagArithmeticsRequest, dataset_id, **kwargs):
         _check_dataset_id(dataset_id)
-        if body.new_tag_name is None or body.new_tag_name is '':
+        if (body.new_tag_name is None) or (body.new_tag_name == ''):
             return TagBitMaskResponse(bit_mask_data="0x2")
         else:
             return CreateEntityResponse(id="tag-arithmetic-created")
@@ -310,17 +311,20 @@ class MockedDatasourcesApi(DatasourcesApi):
             for i in range(self._num_samples)
         ]
 
-    def get_datasource_by_dataset_id(self, dataset_id: str, **kwargs):
-        return self._datasources[dataset_id]
+    def get_datasource_by_dataset_id(
+        self, dataset_id: str, **kwargs
+    ) -> DatasourceConfig:
+        return self._datasources[dataset_id] # type: ignore
 
     def get_datasource_processed_until_timestamp_by_dataset_id(
         self, dataset_id: str, **kwargs
-    ):
-        return self._processed_until_timestamp[dataset_id]
+    ) -> DatasourceProcessedUntilTimestampResponse:
+        timestamp = self._processed_until_timestamp[dataset_id]
+        return DatasourceProcessedUntilTimestampResponse(timestamp)
 
     def get_list_of_raw_samples_from_datasource_by_dataset_id(
         self, dataset_id, cursor: str = None, _from: int = None, to: int = None, **kwargs
-    ):
+    ) -> DatasourceRawSamplesData:
         if cursor is None:
             # initial request
             assert _from is not None
@@ -347,16 +351,16 @@ class MockedDatasourcesApi(DatasourcesApi):
 
     def update_datasource_by_dataset_id(
         self, body: DatasourceConfig, dataset_id: str, **kwargs
-    ):
+    ) -> None:
         assert isinstance(body, DatasourceConfig)
-        self._datasources[dataset_id] = body
+        self._datasources[dataset_id] = body # type: ignore
 
     def update_datasource_processed_until_timestamp_by_dataset_id(
         self, body, dataset_id, **kwargs
-    ):
+    ) -> None:
         assert isinstance(body, DatasourceProcessedUntilTimestampRequest)
         to = body.processed_until_timestamp
-        self._processed_until_timestamp[dataset_id] = to
+        self._processed_until_timestamp[dataset_id] = to # type: ignore
 
 
 class MockedVersioningApi(VersioningApi):


### PR DESCRIPTION
This makes the `ApiWorkflowClient.get_processed_until_timestamp()` method actually return an `int`. Before it simply returned the api response object by accident.

I also updated tests (including adding types) and updated an unrelated line that caused a warning when running tests here:

https://github.com/lightly-ai/lightly/blob/f96b5de7054ec94d1d6d51981c8662600500e130/tests/api_workflow/mocked_api_workflow_client.py#L169 