### PR TITLE
Guarin lig 429 speed up getting filenames from video dataset

### DIFF
--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -389,3 +389,25 @@ class VideoDataset(datasets.VisionDataset):
             n_frames = self.__len__() - self.offsets[i]
         
         return f'{video_name}-{frame_number:0{len(str(n_frames))}}-{video_format}.png'
+
+    def get_filenames(self) -> List[str]:
+        """Returns a list of all frames in the dataset.
+        
+        """
+        filenames = []
+        for i, filename in enumerate(self.videos):
+            filename = os.path.relpath(filename, self.root)
+            splits = filename.split('.')
+            video_format = splits[-1]
+            video_name = '.'.join(splits[:-1])
+
+            if i < len(self.offsets) - 1:
+                n_frames = self.offsets[i+1] - self.offsets[i]
+            else:
+                n_frames = len(self) - self.offsets[i]
+
+            for frame_number in range(n_frames):
+                filenames.append(
+                    f'{video_name}-{frame_number:0{len(str(n_frames))}}-{video_format}.png'
+                )
+        return filenames

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -4,7 +4,7 @@
 # All Rights Reserved
 
 import os
-from typing import List
+from typing import List, Tuple
 from fractions import Fraction
 
 from PIL import Image

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -391,7 +391,7 @@ class VideoDataset(datasets.VisionDataset):
         return f'{video_name}-{frame_number:0{len(str(n_frames))}}-{video_format}.png'
 
     def get_filenames(self) -> List[str]:
-        """Returns a list of all frames in the dataset.
+        """Returns a list filenames for all frames in the dataset.
         
         """
         filenames = []

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -260,6 +260,9 @@ class LightlyDataset:
         """Returns all filenames in the dataset.
 
         """
+        if hasattr(self.dataset, 'get_filenames'):
+            return self.dataset.get_filenames()
+            
         list_of_filenames = []
         for index in range(len(self)):
             fname = self.index_to_filename(self.dataset, index)

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -262,7 +262,7 @@ class LightlyDataset:
         """
         if hasattr(self.dataset, 'get_filenames'):
             return self.dataset.get_filenames()
-            
+
         list_of_filenames = []
         for index in range(len(self)):
             fname = self.index_to_filename(self.dataset, index)

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -17,7 +17,7 @@ from lightly.data._utils import check_images
 from lightly.utils.io import INVALID_FILENAME_CHARACTERS
 
 try:
-    from lightly.data._video import VideoDataset
+    from lightly.data._video import VideoDataset    
     import av
     import cv2
 
@@ -339,3 +339,19 @@ class TestLightlyDataset(unittest.TestCase):
     def test_no_dir_no_transform_fails(self):
         with self.assertRaises(ValueError):
             LightlyDataset(None, transform=torchvision.transforms.ToTensor())
+
+    @unittest.skipUnless(VIDEO_DATASET_AVAILABLE, "PyAV or CV2 is/are not installed")
+    def test_dataset_get_filenames(self):
+        self.create_video_dataset()
+        dataset = LightlyDataset(input_dir=self.input_dir)
+        
+        # get filenames using VideoDataset.get_filenames
+        video_dataset_filenames = dataset.dataset.get_filenames()
+        
+        # get filenames using calls to VideoDataset.get_filename(index)
+        get_filenames = VideoDataset.get_filenames
+        del VideoDataset.get_filenames
+        lightly_dataset_filenames = dataset.get_filenames()
+        VideoDataset.get_filenames = get_filenames
+
+        assert video_dataset_filenames == lightly_dataset_filenames

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -344,9 +344,10 @@ class TestLightlyDataset(unittest.TestCase):
     def test_dataset_get_filenames(self):
         self.create_video_dataset()
         dataset = LightlyDataset(input_dir=self.input_dir)
+        video_dataset = dataset.dataset
         
         # get filenames using VideoDataset.get_filenames
-        video_dataset_filenames = dataset.dataset.get_filenames()
+        video_dataset_filenames = video_dataset.get_filenames()
         
         # get filenames using calls to VideoDataset.get_filename(index)
         get_filenames = VideoDataset.get_filenames

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -346,10 +346,12 @@ class TestLightlyDataset(unittest.TestCase):
         dataset = LightlyDataset(input_dir=self.input_dir)
         video_dataset = dataset.dataset
         
-        # get filenames using VideoDataset.get_filenames
+        # Get filenames using VideoDataset.get_filenames.
         video_dataset_filenames = video_dataset.get_filenames()
         
-        # get filenames using calls to VideoDataset.get_filename(index)
+        # Get filenames using calls to VideoDataset.get_filename(index). 
+        # This removes the optimization introduced in VideoDatset.get_filenames. 
+        # Both methods should give the same result.
         get_filenames = VideoDataset.get_filenames
         del VideoDataset.get_filenames
         lightly_dataset_filenames = dataset.get_filenames()


### PR DESCRIPTION
This pr adds a `get_filenames` function directly to the the `VideoDataset` class. This avoids getting the filename for every frame by searching the corresponding video from the frame index.

I tested it with 20k videos and a total of 10M frames. For me this reduces the `get_filenames` operation from ~5 hours to 10 seconds. This also speeds up the time it takes to initialise `LightlyDataset` as it internally calls `get_filenames`. Using this pr it takes me 2min to initialise the dataset.

I added a test to make sure that the new method returns the same results as the old one.