### PR TITLE
Datasource docs azure

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -54,6 +54,10 @@ download:
 	wget -N https://storage.googleapis.com/datasets_boris/resources_s3_integration.zip -P $(DATADIR)
 	unzip $(ZIPOPTS) $(DATADIR)/resources_s3_integration.zip  -d $(GETTING_STARTED_IMAGES)
 
+	# download resources for azure integration
+	wget -N https://storage.googleapis.com/datasets_boris/resources_azure_integration.zip -P $(DATADIR)
+	unzip ${ZIPOPTS} $(DATADIR)/resources_azure_integration.zip -d $(GETTING_STARTED_IMAGES)
+
 	# download images and report for docker
 	wget -N https://storage.googleapis.com/datasets_boris/resources.zip -P $(DATADIR)
 	unzip $(ZIPOPTS) $(DATADIR)/resources.zip  -d $(DOCKERSOURCE)

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -113,9 +113,8 @@ Create and configure a dataset
 
     .. figure:: ../resources/LightlyEdit1.png
         :align: center
-        :alt: Get security credentials (access key id, secret access key) from AWS
+        :alt: Edit your dataset.
 
-        Get security credentials (access key id, secret access key) from AWS
 
 3. As the resource path, enter the full S3 URI to your resource eg. `s3://datalake/projects/farm-animals/`
 4. Enter the `access key` and the `secret access key` we obtained from creating a new user in the previous step and select the AWS region in which you created your bucket in

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -16,8 +16,6 @@ You have the following three options:
 
 - You want to use thumbnails, but don't have them yet. Then you need to give
   Lightly write access to your bucket to create the thumbnails there for you.
-  The write access can be configured not to allow overwriting and
-  deleting, thus existing data cannot get lost.
 - You already have thumbnails in your bucket with a consistent name scheme, e.g.
   an image called `img.jpg` has a corresponding thumbnail called `img_thumb.jpg`.
   In this case, a read access to your bucket is sufficient.
@@ -33,18 +31,6 @@ Setting up Azure
 For the purpose of this guide we assume you have a storage account called `lightlydatalake`.
 We further assume the container you want to use with lightly is called `farm-animals` and already contains images.
 If you don't have a storage account or container yet follow the instructions `here <https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal>`_.
-
-1. In the `Azure Portal <https://portal.azure.com/#home>`_ navigate to `Storage Accounts`.
-2. Select your storage account and go to `Settings > Resource sharing (CORS)`. Allow at least `LIST` and `GET`. For write access also allow `PUT` and `DELETE`.
-   
-    .. figure:: ../resources/AzureResourceSharing.jpg
-        :align: center
-        :alt: Azure Resource Sharing (CORS)
-
-        Allow resource sharing by enabling CORS (in this example all methods are allowed).
-
-3. Go to `Security + networking > Access keys`. Copy the `Key` and store it in a secure location.
-
 Head to the next section to see how you can configure the Lightly dataset.
 
 
@@ -85,19 +71,24 @@ Uploading your data
 ^^^^^^^^^^^^^^^^^^^^
 
 
-For creating the dataset and uploading embeddings and metadata to it, you need
-the :ref:`lightly-command-line-tool`. Furthermore, you need to have your data locally on your machine.
-This can easily be done by using `AzCopy <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10>`_:
+For creating the dataset and uploading embeddings and metadata to it you need
+the Lightly :ref:`lightly-command-line-tool`.
+
+Furthermore, you need to have your data locally on your machine.
+This can easily be done by using `AzCopy <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10>`_.
+To copy your data from the container to your local machine, go to "Security + networking > Shared access signature" on the storage account
+page in the Azure portal. Generate a shared access signature (SAS) which allows access to the container and objects. Copy the SAS token and use
+the following command:
+
 
 .. code-block::
-    :caption: Sync your data with AzCopy. Example from `Microsoft's documentation <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-blobs-synchronize?toc=/azure/storage/blobs/toc.json>`_
 
-    azcopy sync './farm-animals' 'https://lightlydatalake.blob.core.windows.net/farm-animals' --recursive
+    azcopy copy 'https://lightlydatalake.blob.core.windows.net/{YOUR_SAS_TOKEN}' '/local/lightlydatalake/farm-animals' --recursive
 
 
 To add the images to the dataset use `lightly-magic` or `lightly-upload` with the following parameters:
 
-- Use `input_dir=/local/projects/wild-animals`
+- Use `input_dir=/local/lightlydatalake/farm-animals`
 - If you chose the option to generate thumbnails in your bucket,
   use the argument `upload=thumbnails`
 - Otherwise, use `upload=metadata` instead.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -11,19 +11,8 @@ One decision you need to make first is whether you want to use thumbnails.
 Using thumbnails makes the Lightly Platform more responsive, as it's enough to
 load the thumbnails instead of the full images in many cases.
 As a drawback, the thumbnails will be stored in your bucket and thus need storage.
-You have the following three options:
-
-
-- You want to use thumbnails, but don't have them yet. Then you need to give
-  Lightly write access to your bucket to create the thumbnails there for you.
-- You already have thumbnails in your bucket with a consistent name scheme, e.g.
-  an image called `img.jpg` has a corresponding thumbnail called `img_thumb.jpg`.
-  In this case, a read access to your bucket is sufficient.
-- You don't want to use thumbnails. Then a read access to your bucket
-  is sufficient. The Lightly Platform will load the full image
-  even when requesting the thumbnail.
-
 Depending on this decision, the following steps will differ slightly.
+
 
 Setting up Azure
 ^^^^^^^^^^^^^^^^^
@@ -31,7 +20,6 @@ Setting up Azure
 For the purpose of this guide we assume you have a storage account called `lightlydatalake`.
 We further assume the container you want to use with lightly is called `farm-animals` and already contains images.
 If you don't have a storage account or container yet follow the instructions `here <https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal>`_.
-
 
 Go to "Security + networking > Access keys". Copy the Key and store it in a secure location. Head to the next section to see how you can configure the Lightly dataset.
 
@@ -55,7 +43,7 @@ Configuring a Lightly dataset to access the Azure storage
     - You want Lightly to create the thumbnail for you.
       Then choose the naming scheme to your liking.
     - You have already generated thumbnails in your bucket.
-      Then choose the thumbnail suffix such that it reflects you naming scheme.
+      Then choose the thumbnail suffix such that it reflects your naming scheme.
     - You don't want to use thumbnails.
       Then leave the thumbnail suffix undefined/empty.
 
@@ -66,7 +54,7 @@ Configuring a Lightly dataset to access the Azure storage
 
         Lightly Azure Blob Storage config.
 
-6. Press save and ensure that at least the lights for List and Read turn green.
+6. Press save and ensure that all lights turn green.
 
 
 Uploading your data

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -31,7 +31,9 @@ Setting up Azure
 For the purpose of this guide we assume you have a storage account called `lightlydatalake`.
 We further assume the container you want to use with lightly is called `farm-animals` and already contains images.
 If you don't have a storage account or container yet follow the instructions `here <https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal>`_.
-Head to the next section to see how you can configure the Lightly dataset.
+
+
+Go to "Security + networking > Access keys". Copy the Key and store it in a secure location. Head to the next section to see how you can configure the Lightly dataset.
 
 
 Configuring a Lightly dataset to access the Azure storage

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -1,6 +1,103 @@
 .. _dataset-creation-azure-storage:
 
-Create a dataset from azure blob storage
-----------------------------------------
 
-TODO: Add the tutorial how to create a Lightly dataset from a azure bucket here.
+Create a dataset from Azure blob storage
+-----------------------------------------
+
+Lightly allows you to configure a remote datasource like Microsoft's Azure blob storage.
+In this guide, we will show you how to setup your Azure blob storage container and configure your dataset to use said container.
+
+One decision you need to make first is whether you want to use thumbnails.
+Using thumbnails makes the Lightly Platform more responsive, as it's enough to
+load the thumbnails instead of the full images in many cases.
+As a drawback, the thumbnails will be stored in your bucket and thus need storage.
+You have the following three options:
+
+
+- You want to use thumbnails, but don't have them yet. Then you need to give
+  Lightly write access to your bucket to create the thumbnails there for you.
+  The write access can be configured not to allow overwriting and
+  deleting, thus existing data cannot get lost.
+- You already have thumbnails in your bucket with a consistent name scheme, e.g.
+  an image called `img.jpg` has a corresponding thumbnail called `img_thumb.jpg`.
+  In this case, a read access to your bucket is sufficient.
+- You don't want to use thumbnails. Then a read access to your bucket
+  is sufficient. The Lightly Platform will load the full image
+  even when requesting the thumbnail.
+
+Depending on this decision, the following steps will differ slightly.
+
+Setting up Azure
+^^^^^^^^^^^^^^^^^
+
+For the purpose of this guide we assume you have a storage account called `lightlydatalake`.
+We further assume the container you want to use with lightly is called `farm-animals` and already contains images.
+If you don't have a storage account or container yet follow the instructions `here <https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal>`_.
+
+1. In the `Azure Portal <https://portal.azure.com/#home>`_ navigate to `Storage Accounts`.
+2. Select your storage account and go to `Settings > Resource sharing (CORS)`. Allow at least `LIST` and `GET`. For write access also allow `PUT` and `DELETE`.
+   
+    .. figure:: ../resources/AzureResourceSharing.jpg
+        :align: center
+        :alt: Azure Resource Sharing (CORS)
+
+        Allow resource sharing by enabling CORS (in this example all methods are allowed).
+
+3. Go to `Security + networking > Access keys`. Copy the `Key` and store it in a secure location.
+
+Head to the next section to see how you can configure the Lightly dataset.
+
+
+Configuring a Lightly dataset to access the Azure storage
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. `Create a new dataset <https://app.lightly.ai/dataset/create>`_ in Lightly
+2. Edit your dataset and select `Azure Blob Storage` as your datasource
+
+    .. figure:: ../resources/LightlyEdit1.png
+        :align: center
+        :alt: Edit your dataset.
+
+        To edit your dataset click the `Edit` button on the top.
+
+3. As your container name enter `farm-animals`.
+4. Enter the storage account name and storage account key from the previous step.
+5. The thumbnail suffix depends on the option you chose in the first step
+   
+    - You want Lightly to create the thumbnail for you.
+      Then choose the naming scheme to your liking.
+    - You have already generated thumbnails in your bucket.
+      Then choose the thumbnail suffix such that it reflects you naming scheme.
+    - You don't want to use thumbnails.
+      Then leave the thumbnail suffix undefined/empty.
+
+    .. figure:: ../resources/LightlyEditAzure.jpg
+        :align: center
+        :alt: Lightly Azure Blob Storage config.
+        :width: 60%
+
+        Lightly Azure Blob Storage config.
+
+6. Press save and ensure that at least the lights for List and Read turn green.
+
+
+Uploading your data
+^^^^^^^^^^^^^^^^^^^^
+
+
+For creating the dataset and uploading embeddings and metadata to it, you need
+the :ref:`lightly-command-line-tool`. Furthermore, you need to have your data locally on your machine.
+This can easily be done by using `AzCopy <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10>`_:
+
+.. code-block::
+    :caption: Sync your data with AzCopy. Example from `Microsoft's documentation <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-blobs-synchronize?toc=/azure/storage/blobs/toc.json>`_
+
+    azcopy sync './farm-animals' 'https://lightlydatalake.blob.core.windows.net/farm-animals' --recursive
+
+
+To add the images to the dataset use `lightly-magic` or `lightly-upload` with the following parameters:
+
+- Use `input_dir=/local/projects/wild-animals`
+- If you chose the option to generate thumbnails in your bucket,
+  use the argument `upload=thumbnails`
+- Otherwise, use `upload=metadata` instead.

--- a/docs/source/getting_started/platform.rst
+++ b/docs/source/getting_started/platform.rst
@@ -61,7 +61,7 @@ The baseline way is to upload your local dataset including all images or
 videos to the Lightly platform.
 
 If you don't have your data locally, but rather stored at a cloud provider like
-in an AWS S3 bucket, GCloud bucket or at Azure,
+AWS S3, Google Cloud Storage or Azure,
 you can create a dataset directly referencing the images in your bucket.
 It will keep all images and videos in your own bucket and only stream them from there if they are needed.
 This has the advantage that you don't need to upload your data to Lightly and can preserve its privacy.
@@ -72,6 +72,7 @@ This has the advantage that you don't need to upload your data to Lightly and ca
 
     dataset_creation/dataset_creation_local_upload.rst
     dataset_creation/dataset_creation_aws_bucket.rst
+    dataset_creation/dataset_creation_azure_storage.rst
     dataset_creation/dataset_creation_local_server.rst
     dataset_creation/dataset_creation_gcloud_bucket.rst
 


### PR DESCRIPTION
# Datasource docs azure

Adds documentation on how to use Azure blob storage with Ligthly:
[Create a dataset from Azure blob storage — lightly 1.2.1 documentation.pdf](https://github.com/lightly-ai/lightly/files/7792449/Create.a.dataset.from.Azure.blob.storage.lightly.1.2.1.documentation.pdf)

I added the images to our gcloud bucket so they're not part of the repo.

