### PR TITLE
Change input size to 32

### DIFF
--- a/examples/pytorch_lightning/barlowtwins.py
+++ b/examples/pytorch_lightning/barlowtwins.py
@@ -41,7 +41,7 @@ dataset = LightlyDataset.from_torch_dataset(cifar10)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = ImageCollateFunction(input_size=224)
+collate_fn = ImageCollateFunction(input_size=32)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,


### PR DESCRIPTION
### Changes

- change input size of barlow twins lightning example to 32 to match the other examples

fixes #465 