### PR TITLE
Remove runtimeerror in download_all_frame_counts

### DIFF
--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -215,16 +215,16 @@ class TestDownload(unittest.TestCase):
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_all_video_frame_counts_broken(self):
         fps = 24
+        n_frames = 5
         with tempfile.NamedTemporaryFile(suffix='.mpeg') as file1, \
             tempfile.NamedTemporaryFile(suffix='.mpeg') as file2:
 
-            _generate_video(file1.name, fps=fps)
+            _generate_video(file1.name, fps=fps, n_frames=n_frames)
             _generate_video(file2.name, fps=fps, broken=True)
             
             urls = [file1.name, file2.name]
-            with self.assertRaises(RuntimeError):
-                result = download.all_video_frame_counts(urls)
-                print(result)
+            result = download.all_video_frame_counts(urls)
+            assert result == [n_frames, None]
 
 
 def _images_equal(image1, image2):


### PR DESCRIPTION
`download_all_frame_counts` currently raises a RuntimeError if the number of frames cannot be found for a video. To allow the docker to work with corrupt videos we have to remove this error.

This pr removes the error and returns None instead of the number of frames for all videos that failed to load. It also makes sure that all video streams use a context manager and are properly closed once they are no longer used.