### PR TITLE
Malte lig 454 docker fails when files dont have read

### DIFF
--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -25,11 +25,6 @@ VIDEO_EXTENSIONS = ('.mp4', '.mov', '.avi', '.mpg',
                     '.hevc', '.m4v', '.webm', '.mpeg')
 
 
-def walk_dir_not_ignoring_erors(root):
-    def on_error(error):
-        raise error
-    return os.walk(root, onerror=on_error)
-
 def _dir_contains_videos(root: str, extensions: tuple):
     """Checks whether directory contains video files.
 
@@ -57,9 +52,7 @@ def _contains_videos(root: str, extensions: tuple):
         True if "root" or any subdir contains video files.
 
     """
-    def on_error(error):
-        raise error
-    for subdir, _, _ in walk_dir_not_ignoring_erors(root):
+    for subdir, _, _ in os.walk(root):
         if _dir_contains_videos(subdir, extensions):
             return True
     return False

--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -25,6 +25,11 @@ VIDEO_EXTENSIONS = ('.mp4', '.mov', '.avi', '.mpg',
                     '.hevc', '.m4v', '.webm', '.mpeg')
 
 
+def walk_dir_not_ignoring_erors(root):
+    def on_error(error):
+        raise error
+    return os.walk(root, onerror=on_error)
+
 def _dir_contains_videos(root: str, extensions: tuple):
     """Checks whether directory contains video files.
 
@@ -52,7 +57,9 @@ def _contains_videos(root: str, extensions: tuple):
         True if "root" or any subdir contains video files.
 
     """
-    for subdir, _, _ in os.walk(root):
+    def on_error(error):
+        raise error
+    for subdir, _, _ in walk_dir_not_ignoring_erors(root):
         if _dir_contains_videos(subdir, extensions):
             return True
     return False

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -13,8 +13,6 @@ import torchvision
 from torchvision import datasets
 from torchvision import io
 
-from lightly.data._helpers import walk_dir_not_ignoring_erors
-
 try:
     import av
     AV_AVAILABLE = True
@@ -176,7 +174,7 @@ def _make_dataset(directory,
 
     # find all video instances (no subdirectories)
     video_instances = []
-    for root, _, files in walk_dir_not_ignoring_erors(directory):
+    for root, _, files in os.walk(directory):
 
         for fname in files:
             # skip invalid files

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -174,7 +174,10 @@ def _make_dataset(directory,
 
     # find all video instances (no subdirectories)
     video_instances = []
-    for root, _, files in os.walk(directory):
+
+    def on_error(error):
+        raise error
+    for root, _, files in os.walk(directory, onerror=on_error):
 
         for fname in files:
             # skip invalid files

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -13,6 +13,8 @@ import torchvision
 from torchvision import datasets
 from torchvision import io
 
+from lightly.data._helpers import walk_dir_not_ignoring_erors
+
 try:
     import av
     AV_AVAILABLE = True
@@ -174,7 +176,7 @@ def _make_dataset(directory,
 
     # find all video instances (no subdirectories)
     video_instances = []
-    for root, _, files in os.walk(directory):
+    for root, _, files in walk_dir_not_ignoring_erors(directory):
 
         for fname in files:
             # skip invalid files

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -366,6 +366,7 @@ class TestLightlyDataset(unittest.TestCase):
                 filepath = os.path.join(subdir, filename)
                 os.chmod(filepath, 0o000)
         dataset = LightlyDataset(input_dir=tmp_dir)
+        self.assertGreater(len(dataset.get_filenames()), 0)
         with self.assertRaises(PermissionError):
             for _ in dataset:
                 pass

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -358,3 +358,14 @@ class TestLightlyDataset(unittest.TestCase):
         VideoDataset.get_filenames = get_filenames
 
         assert video_dataset_filenames == lightly_dataset_filenames
+
+    @unittest.skip("Fails currently with 'PermissionError: [Errno 13]' when iterating over the dataset.")
+    def test_dataset_no_read_rights(self):
+        tmp_dir, _, _ = self.create_dataset()
+        for subdir, dirs, files in os.walk(tmp_dir):
+            for filename in files:
+                filepath = os.path.join(subdir, filename)
+                os.chmod(filepath, 0o000)
+        dataset = LightlyDataset(input_dir=tmp_dir)
+        for _ in dataset:
+            pass

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -360,12 +360,21 @@ class TestLightlyDataset(unittest.TestCase):
         assert video_dataset_filenames == lightly_dataset_filenames
 
     @unittest.skip("Fails currently with 'PermissionError: [Errno 13]' when iterating over the dataset.")
-    def test_dataset_no_read_rights(self):
+    def test_dataset_no_read_rights_files(self):
         tmp_dir, _, _ = self.create_dataset()
         for subdir, dirs, files in os.walk(tmp_dir):
             for filename in files:
                 filepath = os.path.join(subdir, filename)
                 os.chmod(filepath, 0o000)
+        dataset = LightlyDataset(input_dir=tmp_dir)
+        for _ in dataset:
+            pass
+
+    #@unittest.skip("Fails currently with 'PermissionError: [Errno 13]' when iterating over the dataset.")
+    def test_dataset_no_read_rights_subdirs(self):
+        tmp_dir, _, _ = self.create_dataset()
+        for subdir, dirs, files in os.walk(tmp_dir):
+            os.chmod(subdir, 0o000)
         dataset = LightlyDataset(input_dir=tmp_dir)
         for _ in dataset:
             pass

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -359,7 +359,6 @@ class TestLightlyDataset(unittest.TestCase):
 
         assert video_dataset_filenames == lightly_dataset_filenames
 
-    @unittest.skip("Fails currently with 'PermissionError: [Errno 13]' when iterating over the dataset.")
     def test_dataset_no_read_rights_files(self):
         tmp_dir, _, _ = self.create_dataset()
         for subdir, dirs, files in os.walk(tmp_dir):
@@ -367,14 +366,13 @@ class TestLightlyDataset(unittest.TestCase):
                 filepath = os.path.join(subdir, filename)
                 os.chmod(filepath, 0o000)
         dataset = LightlyDataset(input_dir=tmp_dir)
-        for _ in dataset:
-            pass
+        with self.assertRaises(PermissionError):
+            for _ in dataset:
+                pass
 
-    #@unittest.skip("Fails currently with 'PermissionError: [Errno 13]' when iterating over the dataset.")
     def test_dataset_no_read_rights_subdirs(self):
         tmp_dir, _, _ = self.create_dataset()
         for subdir, dirs, files in os.walk(tmp_dir):
             os.chmod(subdir, 0o000)
-        dataset = LightlyDataset(input_dir=tmp_dir)
-        for _ in dataset:
-            pass
+        with self.assertRaises(PermissionError):
+            dataset = LightlyDataset(input_dir=tmp_dir)

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import random
 import shutil
+from typing import Tuple, List
 
 import torch
 import torchvision
@@ -30,6 +31,18 @@ class TestLightlyDataset(unittest.TestCase):
 
     def ensure_dir(self, path_to_folder: str):
         os.makedirs(path_to_folder, exist_ok=True)
+
+    def create_dataset_no_subdir(self, n_samples: int) -> Tuple[int, List[str]]:
+        dataset = torchvision.datasets.FakeData(size=n_samples,
+                                                image_size=(3, 32, 32))
+
+        tmp_dir = tempfile.mkdtemp()
+        sample_names = [f'img_{i}.jpg' for i in range(n_samples)]
+        for sample_idx in range(n_samples):
+            data = dataset[sample_idx]
+            path = os.path.join(tmp_dir, sample_names[sample_idx])
+            data[0].save(path)
+        return tmp_dir, sample_names
 
     def create_dataset(self, n_subfolders=5, n_samples_per_subfolder=20):
         n_tot = n_subfolders * n_samples_per_subfolder
@@ -110,15 +123,7 @@ class TestLightlyDataset(unittest.TestCase):
 
         # create a dataset
         n_tot = 100
-        dataset = torchvision.datasets.FakeData(size=n_tot,
-                                                image_size=(3, 32, 32))
-
-        tmp_dir = tempfile.mkdtemp()
-        sample_names = [f'img_{i}.jpg' for i in range(n_tot)]
-        for sample_idx in range(n_tot):
-            data = dataset[sample_idx]
-            path = os.path.join(tmp_dir, sample_names[sample_idx])
-            data[0].save(path)
+        tmp_dir, sample_names = self.create_dataset_no_subdir(n_tot)
 
         # create lightly dataset
         dataset = LightlyDataset(input_dir=tmp_dir)
@@ -359,7 +364,7 @@ class TestLightlyDataset(unittest.TestCase):
 
         assert video_dataset_filenames == lightly_dataset_filenames
 
-    def test_dataset_no_read_rights_files(self):
+    def test_dataset_no_read_rights_files_in_subdirs(self):
         tmp_dir, _, _ = self.create_dataset()
         for subdir, dirs, files in os.walk(tmp_dir):
             for filename in files:
@@ -377,3 +382,24 @@ class TestLightlyDataset(unittest.TestCase):
             os.chmod(subdir, 0o000)
         with self.assertRaises(PermissionError):
             dataset = LightlyDataset(input_dir=tmp_dir)
+
+    def test_dataset_no_read_rights_root(self):
+        tmp_dir, _, _ = self.create_dataset()
+        os.chmod(tmp_dir, 0o000)
+        with self.assertRaises(PermissionError):
+            dataset = LightlyDataset(input_dir=tmp_dir)
+
+    def test_dataset_no_read_rights_files_in_root(self):
+        tmp_dir, _ = self.create_dataset_no_subdir(100)
+        for subdir, dirs, files in os.walk(tmp_dir):
+            for filename in files:
+                filepath = os.path.join(tmp_dir, filename)
+                os.chmod(filepath, 0o000)
+        dataset = LightlyDataset(input_dir=tmp_dir)
+        self.assertGreater(len(dataset.get_filenames()), 0)
+        with self.assertRaises(PermissionError):
+            for _ in dataset:
+                pass
+
+
+

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -364,42 +364,50 @@ class TestLightlyDataset(unittest.TestCase):
 
         assert video_dataset_filenames == lightly_dataset_filenames
 
-    def test_dataset_no_read_rights_files_in_subdirs(self):
+    def test_dataset_with_subdirs(self):
         tmp_dir, _, _ = self.create_dataset()
-        for subdir, dirs, files in os.walk(tmp_dir):
-            for filename in files:
-                filepath = os.path.join(subdir, filename)
-                os.chmod(filepath, 0o000)
-        dataset = LightlyDataset(input_dir=tmp_dir)
-        self.assertGreater(len(dataset.get_filenames()), 0)
-        with self.assertRaises(PermissionError):
-            for _ in dataset:
-                pass
 
-    def test_dataset_no_read_rights_subdirs(self):
-        tmp_dir, _, _ = self.create_dataset()
-        for subdir, dirs, files in os.walk(tmp_dir):
-            os.chmod(subdir, 0o000)
-        with self.assertRaises(PermissionError):
+        with self.subTest("no read rights files"):
+            for subdir, dirs, files in os.walk(tmp_dir):
+                for filename in files:
+                    filepath = os.path.join(subdir, filename)
+                    os.chmod(filepath, 0o000)
             dataset = LightlyDataset(input_dir=tmp_dir)
+            self.assertGreater(len(dataset.get_filenames()), 0)
+            with self.assertRaises(PermissionError):
+                for _ in dataset:
+                    pass
 
-    def test_dataset_no_read_rights_root(self):
-        tmp_dir, _, _ = self.create_dataset()
-        os.chmod(tmp_dir, 0o000)
-        with self.assertRaises(PermissionError):
-            dataset = LightlyDataset(input_dir=tmp_dir)
+        with self.subTest("no read rights subfolders"):
+            for subdir, dirs, files in os.walk(tmp_dir):
+                os.chmod(subdir, 0o000)
+            with self.assertRaises(PermissionError):
+                dataset = LightlyDataset(input_dir=tmp_dir)
 
-    def test_dataset_no_read_rights_files_in_root(self):
+        with self.subTest("no read rights root"):
+            os.chmod(tmp_dir, 0o000)
+            with self.assertRaises(PermissionError):
+                dataset = LightlyDataset(input_dir=tmp_dir)
+
+
+    def test_dataset_plain(self):
         tmp_dir, _ = self.create_dataset_no_subdir(100)
-        for subdir, dirs, files in os.walk(tmp_dir):
-            for filename in files:
-                filepath = os.path.join(tmp_dir, filename)
-                os.chmod(filepath, 0o000)
-        dataset = LightlyDataset(input_dir=tmp_dir)
-        self.assertGreater(len(dataset.get_filenames()), 0)
-        with self.assertRaises(PermissionError):
-            for _ in dataset:
-                pass
+
+        with self.subTest("no read rights files"):
+            for subdir, dirs, files in os.walk(tmp_dir):
+                for filename in files:
+                    filepath = os.path.join(tmp_dir, filename)
+                    os.chmod(filepath, 0o000)
+            dataset = LightlyDataset(input_dir=tmp_dir)
+            self.assertGreater(len(dataset.get_filenames()), 0)
+            with self.assertRaises(PermissionError):
+                for _ in dataset:
+                    pass
+
+        with self.subTest("no read rights root"):
+            os.chmod(tmp_dir, 0o000)
+            with self.assertRaises(PermissionError):
+                dataset = LightlyDataset(input_dir=tmp_dir)
 
 
 

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -113,11 +113,8 @@ class TestVideoDataset(unittest.TestCase):
                 for filename in files:
                     filepath = os.path.join(self.input_dir, filename)
                     os.chmod(filepath, 0o000)
-            dataset = VideoDataset(self.input_dir, extensions=self.extensions)
-            self.assertGreater(len(dataset.get_filenames()), 0)
             with self.assertRaises(PermissionError):
-                for _ in dataset:
-                    pass
+                dataset = VideoDataset(self.input_dir, extensions=self.extensions)
 
         with self.subTest("no read rights subdirs"):
             for subdir, dirs, files in os.walk(self.input_dir):

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -39,6 +39,7 @@ class TestVideoDataset(unittest.TestCase):
 
         for i in range(n_videos):
             path = os.path.join(self.input_dir, f'output-{i}.avi')
+            print(path)
             out = cv2.VideoWriter(path, 0, 1, (w, h))
             for frame in self.frames:
                 out.write(frame)
@@ -116,7 +117,6 @@ class TestVideoDataset(unittest.TestCase):
                     os.chmod(filepath, 0o000)
             with self.assertRaises(PermissionError):
                 dataset = LightlyDataset(self.input_dir)
-
 
         with self.subTest("no read rights subdirs"):
             for subdir, dirs, files in os.walk(self.input_dir):

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -105,29 +105,31 @@ class TestVideoDataset(unittest.TestCase):
         
         shutil.rmtree(self.input_dir)
 
-    def test_video_dataset_no_read_rights_input_dir(self):
+    def test_video_dataset_no_read_rights(self):
         self.create_dataset()
-        os.chmod(self.input_dir, 0o000)
-        with self.assertRaises(PermissionError):
-            dataset = VideoDataset(self.input_dir, extensions=self.extensions)
 
-    def test_video_dataset_no_read_rights_subdir(self):
-        self.create_dataset()
-        for subdir, dirs, files in os.walk(self.input_dir):
-            os.chmod(subdir, 0o000)
-        with self.assertRaises(PermissionError):
+        with self.subTest("no read rights files"):
+            for subdir, dirs, files in os.walk(self.input_dir):
+                for filename in files:
+                    filepath = os.path.join(self.input_dir, filename)
+                    os.chmod(filepath, 0o000)
             dataset = VideoDataset(self.input_dir, extensions=self.extensions)
+            self.assertGreater(len(dataset.get_filenames()), 0)
+            with self.assertRaises(PermissionError):
+                for _ in dataset:
+                    pass
 
-    def test_video_dataset_no_read_rights_files(self):
-        self.create_dataset()
-        for subdir, dirs, files in os.walk(self.input_dir):
-            for filename in files:
-                filepath = os.path.join(self.input_dir, filename)
-                os.chmod(filepath, 0o000)
-        dataset = VideoDataset(self.input_dir, extensions=self.extensions)
-        self.assertGreater(len(dataset.get_filenames()), 0)
-        with self.assertRaises(PermissionError):
-            for _ in dataset:
-                pass
+        with self.subTest("no read rights subdirs"):
+            for subdir, dirs, files in os.walk(self.input_dir):
+                os.chmod(subdir, 0o000)
+            with self.assertRaises(PermissionError):
+                dataset = VideoDataset(self.input_dir,
+                                       extensions=self.extensions)
+        with self.subTest("no read rights root"):
+            os.chmod(self.input_dir, 0o000)
+            with self.assertRaises(PermissionError):
+                dataset = VideoDataset(self.input_dir,
+                                       extensions=self.extensions)
+
 
 

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -7,6 +7,7 @@ import warnings
 import PIL
 import torchvision
 
+from lightly.data import LightlyDataset
 from lightly.data._video import VideoDataset, _make_dataset
 import cv2
 
@@ -114,19 +115,19 @@ class TestVideoDataset(unittest.TestCase):
                     filepath = os.path.join(self.input_dir, filename)
                     os.chmod(filepath, 0o000)
             with self.assertRaises(PermissionError):
-                dataset = VideoDataset(self.input_dir, extensions=self.extensions)
+                dataset = LightlyDataset(self.input_dir)
+
 
         with self.subTest("no read rights subdirs"):
             for subdir, dirs, files in os.walk(self.input_dir):
                 os.chmod(subdir, 0o000)
             with self.assertRaises(PermissionError):
-                dataset = VideoDataset(self.input_dir,
-                                       extensions=self.extensions)
+                dataset = LightlyDataset(self.input_dir)
+
         with self.subTest("no read rights root"):
             os.chmod(self.input_dir, 0o000)
             with self.assertRaises(PermissionError):
-                dataset = VideoDataset(self.input_dir,
-                                       extensions=self.extensions)
+                dataset = LightlyDataset(self.input_dir)
 
 
 


### PR DESCRIPTION
## Description
- os.walk used for the video dataset now throws all errors it encounters including permission errors

## New tests
Added many tests for the following cases, all throwing permission errors.

#### Types of datasets for reference, there is one test for each of them.
- datasets.ImageFolder ( from torch for nested dirs)
- DatasetFolder (self-implemented, for plain dirs)
- VideoDataset (self.implemented, for plain and nested dirs)

#### With a nested image folder created:
- the images in the subdirs have no read rights (fails when iterating over the datasets.ImageFolder)
- subdirs have no read rights (fails in `_contains_subdirs()` containing `os.scandir(root)`)
- root has no read rights (fails in `_contains_subdirs()` containing `os.scandir(root)`)
#### With a plain image folder created:
- the images in root have no read rights (fails when iterating over the DatasetFolder)
- root has no read rights (fails in `_contains_subdirs()` containing `os.scandir(root)`)
#### With a video dataset created
- the videos in the subdirs have no read rights (fails when creating the VideoDataset, as it cannot read the video to know the number of frames)
- subdirs have no read rights (fails in `_contains_subdirs()` containing `os.scandir(root)`)
- root has no read rights (fails in `_contains_subdirs()` containing `os.scandir(root)`)

## NOT TESTED
- Image dataset with sub-sub-directories. I expect it to silently ignore all sub-sub-directories without read rights, as `os.walk` used but `datasets.ImageFolder` does that.
- Video dataset with videos in plain folder. I expect it to fail during creation just like for the other dataset, as it uses `os.walk` with error throwing internally.
- Video dataset with videos in sub-sub-directories. I expect it to fail during creation just like for the other video dataset, as it uses `os.walk` with error throwing internally.


