### PR TITLE
Malte lig 529 m01 doesnt work with multiple workers

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -39,6 +39,8 @@ from lightly.openapi_generated.swagger_client.configuration import \
     Configuration
 from lightly.openapi_generated.swagger_client.models.dataset_data import \
     DatasetData
+from lightly.utils.reordering import sort_items_by_keys
+
 
 class ApiWorkflowClient(_UploadEmbeddingsMixin,
                         _SamplingMixin,
@@ -141,16 +143,9 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
 
         """
         filenames_on_server = self.get_filenames()
-        if len(filenames_for_list) != len(list_to_order) or \
-                len(filenames_for_list) != len(filenames_on_server):
-            raise ValueError(
-                f"All inputs (filenames_for_list,  list_to_order and "
-                f"self.filenames_on_server) must have the same length, "
-                f"but their lengths are: ({len(filenames_for_list)},"
-                f"{len(list_to_order)} and {len(filenames_on_server)})."
-            )
-        dict_by_filenames = dict(zip(filenames_for_list, list_to_order))
-        list_ordered = [dict_by_filenames[filename] for filename in filenames_on_server]
+        list_ordered = sort_items_by_keys(
+            filenames_for_list, list_to_order, filenames_on_server
+        )
         return list_ordered
 
     def get_filenames(self) -> List[str]:

--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -8,9 +8,14 @@ import warnings
 
 import torch
 from hydra import utils
+from torch import nn as nn
 from torch.utils.hipify.hipify_python import bcolors
 
-from lightly.models import ZOO as model_zoo
+from lightly.cli._cli_simclr import _SimCLR
+from lightly.embedding import SelfSupervisedEmbedding
+
+from lightly.models import ZOO as model_zoo, ResNetGenerator
+from lightly.models.batchnorm import get_norm_layer
 
 
 def _custom_formatwarning(msg, *args, **kwargs):
@@ -198,3 +203,44 @@ def load_from_state_dict(model,
 
     # step 3: load from checkpoint
     model.load_state_dict(state_dict, strict=strict)
+
+
+def get_model_from_config(cfg, is_cli_call: bool = False) -> SelfSupervisedEmbedding:
+    checkpoint = cfg['checkpoint']
+    if torch.cuda.is_available():
+        device = torch.device('cuda')
+    else:
+        device = torch.device('cpu')
+
+    if not checkpoint:
+        checkpoint, key = get_ptmodel_from_config(cfg['model'])
+        if not checkpoint:
+            msg = 'Cannot download checkpoint for key {} '.format(key)
+            msg += 'because it does not exist!'
+            raise RuntimeError(msg)
+        state_dict = load_state_dict_from_url(checkpoint, map_location=device)[
+            'state_dict'
+        ]
+    else:
+        checkpoint = fix_input_path(checkpoint) if is_cli_call else checkpoint
+        state_dict = torch.load(checkpoint, map_location=device)['state_dict']
+
+    # load model
+    resnet = ResNetGenerator(cfg['model']['name'], cfg['model']['width'])
+    last_conv_channels = list(resnet.children())[-1].in_features
+    features = nn.Sequential(
+        get_norm_layer(3, 0),
+        *list(resnet.children())[:-1],
+        nn.Conv2d(last_conv_channels, cfg['model']['num_ftrs'], 1),
+        nn.AdaptiveAvgPool2d(1),
+    )
+
+    model = _SimCLR(
+        features, num_ftrs=cfg['model']['num_ftrs'], out_dim=cfg['model']['out_dim']
+    ).to(device)
+
+    if state_dict is not None:
+        load_from_state_dict(model, state_dict)
+
+    encoder = SelfSupervisedEmbedding(model, None, None, None)
+    return encoder

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -12,65 +12,16 @@ import os
 
 import hydra
 import torch
-import torch.nn as nn
 import torchvision
 from torch.utils.hipify.hipify_python import bcolors
 
-from lightly.cli._cli_simclr import _SimCLR
 from lightly.data import LightlyDataset
-from lightly.embedding import SelfSupervisedEmbedding
-
-from lightly.models import ResNetGenerator
-from lightly.models.batchnorm import get_norm_layer
 
 from lightly.utils import save_embeddings
 
-from lightly.cli._helpers import get_ptmodel_from_config
+from lightly.cli._helpers import get_model_from_config
 from lightly.cli._helpers import fix_input_path
-from lightly.cli._helpers import load_state_dict_from_url
-from lightly.cli._helpers import load_from_state_dict
 from lightly.cli._helpers import cpu_count
-
-
-def get_model_from_config(cfg, is_cli_call: bool = False) -> SelfSupervisedEmbedding:
-    checkpoint = cfg['checkpoint']
-    if torch.cuda.is_available():
-        device = torch.device('cuda')
-    else:
-        device = torch.device('cpu')
-
-    if not checkpoint:
-        checkpoint, key = get_ptmodel_from_config(cfg['model'])
-        if not checkpoint:
-            msg = 'Cannot download checkpoint for key {} '.format(key)
-            msg += 'because it does not exist!'
-            raise RuntimeError(msg)
-        state_dict = load_state_dict_from_url(checkpoint, map_location=device)[
-            'state_dict'
-        ]
-    else:
-        checkpoint = fix_input_path(checkpoint) if is_cli_call else checkpoint
-        state_dict = torch.load(checkpoint, map_location=device)['state_dict']
-
-    # load model
-    resnet = ResNetGenerator(cfg['model']['name'], cfg['model']['width'])
-    last_conv_channels = list(resnet.children())[-1].in_features
-    features = nn.Sequential(
-        get_norm_layer(3, 0),
-        *list(resnet.children())[:-1],
-        nn.Conv2d(last_conv_channels, cfg['model']['num_ftrs'], 1),
-        nn.AdaptiveAvgPool2d(1),
-    )
-
-    model = _SimCLR(
-        features, num_ftrs=cfg['model']['num_ftrs'], out_dim=cfg['model']['out_dim']
-    ).to(device)
-
-    if state_dict is not None:
-        load_from_state_dict(model, state_dict)
-
-    encoder = SelfSupervisedEmbedding(model, None, None, None)
-    return encoder
 
 
 def _embed_cli(cfg, is_cli_call=True):

--- a/lightly/embedding/embedding.py
+++ b/lightly/embedding/embedding.py
@@ -71,7 +71,7 @@ class SelfSupervisedEmbedding(BaseEmbedding):
     def embed(self,
               dataloader: torch.utils.data.DataLoader,
               device: torch.device = None
-              ) -> Tuple[List[np.ndarray], List[int], List[str]]:
+              ) -> Tuple[np.ndarray, np.ndarray, List[str]]:
         """Embeds images in a vector space.
 
         Args:
@@ -81,14 +81,13 @@ class SelfSupervisedEmbedding(BaseEmbedding):
                 Selected device (`cpu`, `cuda`, see PyTorch documentation)
 
         Returns:
-            A tuple of thre lists: embeddings, labels, filenames.
-            Each list element belongs to one sample.
-            The order is equal to the one in the dataset of the dataloader.
+            The order of the return values is determined by the order of
+            samples in the dataset of the dataloader.
                 embeddings:
-                    One embedding (shape: (embedding_feature_size, )) for
-                    each sample.
+                    Embedding of shape (n_samples, embedding_feature_size).
+                    One embedding for each sample.
                 labels:
-                    The label of each sample.
+                    Labels of shape (n_samples, ).
                 filenames:
                     The filenames from dataloader.dataset.get_filenames().
 
@@ -150,7 +149,7 @@ class SelfSupervisedEmbedding(BaseEmbedding):
         list_ordered = [dict_by_filenames[filename] for filename in filenames_correct_order]
 
         embeddings_ordered, labels_ordered = zip(*list_ordered)
-        embeddings = list(embeddings_ordered)
-        labels = [int(label) for label in labels_ordered]
+        embeddings = np.stack(embeddings_ordered)
+        labels = np.stack(labels_ordered)
 
         return embeddings, labels, filenames_correct_order

--- a/lightly/embedding/embedding.py
+++ b/lightly/embedding/embedding.py
@@ -58,20 +58,22 @@ class SelfSupervisedEmbedding(BaseEmbedding):
 
     """
 
-    def __init__(self,
-                 model: torch.nn.Module,
-                 criterion: torch.nn.Module,
-                 optimizer: torch.optim.Optimizer,
-                 dataloader: torch.utils.data.DataLoader,
-                 scheduler=None):
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        criterion: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        dataloader: torch.utils.data.DataLoader,
+        scheduler=None,
+    ):
 
         super(SelfSupervisedEmbedding, self).__init__(
-            model, criterion, optimizer, dataloader, scheduler)
+            model, criterion, optimizer, dataloader, scheduler
+        )
 
-    def embed(self,
-              dataloader: torch.utils.data.DataLoader,
-              device: torch.device = None
-              ) -> Tuple[np.ndarray, np.ndarray, List[str]]:
+    def embed(
+        self, dataloader: torch.utils.data.DataLoader, device: torch.device = None
+    ) -> Tuple[np.ndarray, np.ndarray, List[str]]:
         """Embeds images in a vector space.
 
         Args:
@@ -102,12 +104,13 @@ class SelfSupervisedEmbedding(BaseEmbedding):
         embeddings, labels, fnames = None, None, []
 
         if lightly._is_prefetch_generator_available():
-            pbar = tqdm(BackgroundGenerator(dataloader, max_prefetch=3),
-                        total=len(dataloader))
+            pbar = tqdm(
+                BackgroundGenerator(dataloader, max_prefetch=3), total=len(dataloader)
+            )
         else:
             pbar = tqdm(dataloader, total=len(dataloader))
 
-        efficiency = 0.
+        efficiency = 0.0
         embeddings = []
         labels = []
         with torch.no_grad():
@@ -130,10 +133,8 @@ class SelfSupervisedEmbedding(BaseEmbedding):
 
                 process_time = time.time()
 
-                efficiency = \
-                    (process_time - prepare_time) / (process_time - start_time)
-                pbar.set_description(
-                    "Compute efficiency: {:.2f}".format(efficiency))
+                efficiency = (process_time - prepare_time) / (process_time - start_time)
+                pbar.set_description("Compute efficiency: {:.2f}".format(efficiency))
                 start_time = time.time()
 
             embeddings = torch.cat(embeddings, 0)
@@ -146,7 +147,9 @@ class SelfSupervisedEmbedding(BaseEmbedding):
         dict_by_filenames = dict(zip(fnames, list_to_order))
 
         filenames_correct_order = dataloader.dataset.get_filenames()
-        list_ordered = [dict_by_filenames[filename] for filename in filenames_correct_order]
+        list_ordered = [
+            dict_by_filenames[filename] for filename in filenames_correct_order
+        ]
 
         embeddings_ordered, labels_ordered = zip(*list_ordered)
         embeddings = np.stack(embeddings_ordered)

--- a/lightly/utils/reordering.py
+++ b/lightly/utils/reordering.py
@@ -1,0 +1,16 @@
+from typing import List, Sized
+
+
+def sort_items_by_keys(
+    keys: List[any], 
+    items: List[any], 
+    sorted_keys: List[any]
+):
+    if len(keys) != len(items) or len(keys) != len(sorted_keys):
+        raise ValueError(f"All inputs (keys,  items and sorted_keys) "
+                         f"must have the same length, "
+                         f"but their lengths are: ({len(keys)},"
+                         f"{len(items)} and {len(sorted_keys)}).")
+    lookup = {key_: item_ for key_, item_ in zip(keys, items)}
+    sorted_ = [lookup[key_] for key_ in sorted_keys]
+    return sorted_

--- a/lightly/utils/reordering.py
+++ b/lightly/utils/reordering.py
@@ -6,6 +6,32 @@ def sort_items_by_keys(
     items: List[any], 
     sorted_keys: List[any]
 ):
+    """Sorts the items in the same order as the sorted keys.
+
+    Args:
+        keys:
+            Keys by which items can be identified.
+        items:
+            Items to sort.
+        sorted_keys:
+            Keys in sorted order.
+
+    Returns:
+        The list of sorted items.
+
+    Examples:
+        >>> keys = [3, 2, 1]
+        >>> items = ['!', 'world', 'hello']
+        >>> sorted_keys = [1, 2, 3]
+        >>> sorted_items = sort_items_by_keys(
+        >>>     keys,
+        >>>     items,
+        >>>     sorted_keys,
+        >>> )
+        >>> print(sorted_items)
+        >>> > ['hello', 'world', '!']
+
+    """
     if len(keys) != len(items) or len(keys) != len(sorted_keys):
         raise ValueError(f"All inputs (keys,  items and sorted_keys) "
                          f"must have the same length, "

--- a/tests/data/test_LightlyDataset.py
+++ b/tests/data/test_LightlyDataset.py
@@ -32,7 +32,7 @@ class TestLightlyDataset(unittest.TestCase):
     def ensure_dir(self, path_to_folder: str):
         os.makedirs(path_to_folder, exist_ok=True)
 
-    def create_dataset_no_subdir(self, n_samples: int) -> Tuple[int, List[str]]:
+    def create_dataset_no_subdir(self, n_samples: int) -> Tuple[str, List[str]]:
         dataset = torchvision.datasets.FakeData(size=n_samples,
                                                 image_size=(3, 32, 32))
 

--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -1,0 +1,49 @@
+import os
+import tempfile
+import unittest
+from typing import Tuple, List
+
+import torchvision
+from hydra.experimental import initialize, compose
+from torch.utils.data import DataLoader
+
+from lightly.cli.embed_cli import get_model_from_config
+from lightly.data import LightlyDataset
+from lightly.embedding import SelfSupervisedEmbedding
+
+
+class TestLightlyDataset(unittest.TestCase):
+
+    def setUp(self):
+        self.folder_path, self.sample_names = self.create_dataset_no_subdir(100)
+        with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
+            self.cfg = compose(config_name="config", overrides=[
+                "token='123'",
+                f"input_dir={self.folder_path}",
+                "trainer.max_epochs=0"
+            ])
+
+    def create_dataset_no_subdir(self, n_samples: int) -> Tuple[str, List[str]]:
+        dataset = torchvision.datasets.FakeData(size=n_samples,
+                                                image_size=(3, 32, 32))
+
+        tmp_dir = tempfile.mkdtemp()
+        sample_names = [f'img_{i}.jpg' for i in range(n_samples)]
+        for sample_idx in range(n_samples):
+            data = dataset[sample_idx]
+            path = os.path.join(tmp_dir, sample_names[sample_idx])
+            data[0].save(path)
+        return tmp_dir, sample_names
+    
+    @unittest.skip("Failing for the moment")
+    def test_embed_correct_order(self):
+        # get dataloader
+        transform = torchvision.transforms.ToTensor()
+        dataset = LightlyDataset(self.folder_path, transform=transform)
+        dataloader = DataLoader(dataset, shuffle=True)
+
+        encoder = get_model_from_config(self.cfg)
+        
+        embeddings, labels, filenames = encoder.embed(dataloader)
+
+        self.assertListEqual(filenames, dataset.get_filenames())

--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -9,7 +9,7 @@ from hydra.experimental import initialize, compose
 from torch import manual_seed
 from torch.utils.data import DataLoader
 
-from lightly.cli.embed_cli import get_model_from_config
+from lightly.cli._helpers import get_model_from_config
 from lightly.data import LightlyDataset
 from lightly.embedding import SelfSupervisedEmbedding
 

--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -15,19 +15,20 @@ from lightly.embedding import SelfSupervisedEmbedding
 
 
 class TestLightlyDataset(unittest.TestCase):
-
     def setUp(self):
         self.folder_path, self.sample_names = self.create_dataset_no_subdir(10)
-        with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
-            self.cfg = compose(config_name="config", overrides=[
-                "token='123'",
-                f"input_dir={self.folder_path}",
-                "trainer.max_epochs=0"
-            ])
+        with initialize(config_path='../../lightly/cli/config', job_name='test_app'):
+            self.cfg = compose(
+                config_name='config',
+                overrides=[
+                    'token="123"',
+                    f'input_dir={self.folder_path}',
+                    'trainer.max_epochs=0',
+                ],
+            )
 
     def create_dataset_no_subdir(self, n_samples: int) -> Tuple[str, List[str]]:
-        dataset = torchvision.datasets.FakeData(size=n_samples,
-                                                image_size=(3, 32, 32))
+        dataset = torchvision.datasets.FakeData(size=n_samples, image_size=(3, 32, 32))
 
         tmp_dir = tempfile.mkdtemp()
         sample_names = [f'img_{i}.jpg' for i in range(n_samples)]
@@ -36,7 +37,7 @@ class TestLightlyDataset(unittest.TestCase):
             path = os.path.join(tmp_dir, sample_names[sample_idx])
             data[0].save(path)
         return tmp_dir, sample_names
-    
+
     def test_embed_correct_order(self):
         # get dataset and encoder
         transform = torchvision.transforms.ToTensor()
@@ -44,14 +45,20 @@ class TestLightlyDataset(unittest.TestCase):
         encoder = get_model_from_config(self.cfg)
 
         manual_seed(42)
-        dataloader_1_worker = DataLoader(dataset, shuffle=True, num_workers=0, batch_size=4)
-        embeddings_1_worker, labels_1_worker, filenames_1_worker\
-            = encoder.embed(dataloader_1_worker)
+        dataloader_1_worker = DataLoader(
+            dataset, shuffle=True, num_workers=0, batch_size=4
+        )
+        embeddings_1_worker, labels_1_worker, filenames_1_worker = encoder.embed(
+            dataloader_1_worker
+        )
 
         manual_seed(43)
-        dataloader_4_worker = DataLoader(dataset, shuffle=True, num_workers=4, batch_size=4)
-        embeddings_4_worker, labels_4_worker, filenames_4_worker = \
-            encoder.embed(dataloader_4_worker)
+        dataloader_4_worker = DataLoader(
+            dataset, shuffle=True, num_workers=4, batch_size=4
+        )
+        embeddings_4_worker, labels_4_worker, filenames_4_worker = encoder.embed(
+            dataloader_4_worker
+        )
 
         np.testing.assert_equal(embeddings_1_worker, embeddings_4_worker)
         np.testing.assert_equal(labels_1_worker, labels_4_worker)

--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -53,9 +53,8 @@ class TestLightlyDataset(unittest.TestCase):
         embeddings_4_worker, labels_4_worker, filenames_4_worker = \
             encoder.embed(dataloader_4_worker)
 
-        for emb_a, emb_b in zip(embeddings_1_worker, embeddings_4_worker):
-            np.testing.assert_equal(emb_a, emb_b)
-        
-        self.assertListEqual(labels_1_worker, labels_4_worker)
+        np.testing.assert_equal(embeddings_1_worker, embeddings_4_worker)
+        np.testing.assert_equal(labels_1_worker, labels_4_worker)
+
         self.assertListEqual(filenames_1_worker, filenames_4_worker)
         self.assertListEqual(filenames_1_worker, dataset.get_filenames())


### PR DESCRIPTION
## Description
- Ensures that `SelfSupervisedEmbedding.embed(dataloader)` returns the embeddings, labels and filenames exactly in the same order as in the dataset. This prohibits errors in later steps, where the embeddings are used.
- Removed `SelfSupervisedEmbedding.embed(to_numpy)` argument, as it is not used anywhere.
- Added unittest to ensure that the order is independent of the number of workers.
- Reworked `embed_cli` by extracting `get_model_from_config()` as a separate function, which is used by the unittest.
- fixed wrong typehint (unrelated)

The formatting of `embed_cli.py` and `test_embedding.py` follow black format.