### PR TITLE
Guarin lig 528 make metadata upload faster

### DIFF
--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -205,5 +205,4 @@ class _UploadCustomMetadataMixin:
             if verbose:
                 results = tqdm(results, total=len(sample_requests))
             # iterate over results to make sure they are completed
-            for _ in results:
-                pass
+            list(results)

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -161,6 +161,8 @@ class _UploadCustomMetadataMixin:
                 Custom metadata as described above.
             verbose:
                 If True displays a progress bar during the upload.
+            max_workers:
+                Maximum number of concurrent threads during upload.
 
         """
 

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -113,7 +113,8 @@ def _upload_cli(cfg, is_cli_call=True):
         # upload custom metadata separately
         api_workflow_client.upload_custom_metadata(
             custom_metadata,
-            verbose=True
+            verbose=True,
+            max_workers=cfg['loader']['num_workers'],
         )
 
     if new_dataset_name:


### PR DESCRIPTION
Make metadata upload requests concurrent.

I could not use the `asyn_req` parameter provided by swagger to make async requests because we cannot easily limit the number of concurrent requests.

Failed uploads are now retried.

Benchmark with cifar10 test set (10k images, 10 metadata entries per image):
Old: ~1h
New (8 workers): 3:57 min
New (16 workers): 2:13 min
New (32 workers): 1:39 min