### PR TITLE
embedding: clone label to free file handler

### DIFF
--- a/lightly/embedding/embedding.py
+++ b/lightly/embedding/embedding.py
@@ -122,6 +122,8 @@ class SelfSupervisedEmbedding(BaseEmbedding):
             start_timepoint = time.time()
             for (img, label, fname) in pbar:
 
+                # this following 2 lines are needed to prevent a file handler leak,
+                # see https://github.com/lightly-ai/lightly/pull/676
                 img = img.to(device)
                 label = label.clone()
 

--- a/lightly/embedding/embedding.py
+++ b/lightly/embedding/embedding.py
@@ -123,6 +123,7 @@ class SelfSupervisedEmbedding(BaseEmbedding):
             for (img, label, fname) in pbar:
 
                 img = img.to(device)
+                label = label.clone()
 
                 fnames += [*fname]
 


### PR DESCRIPTION
## Description

This solves the problem of the embedding leaking one file handler per batch.

The following now runs through:
```
pip uninstall lightly -y
export BRANCH_NAME="malte-lig-593-lightly-magic-fails-when-creating"
pip install "git+https://github.com/lightly-ai/lightly.git@$BRANCH_NAME" 
INPUT_DIR="/datasets/my_dataset"    
LIMIT=100   
ulimit -Sn $LIMIT && ulimit -Hn $LIMIT && lightly-embed input_dir=$INPUT_DIR loader.num_workers=8
```

## Details of Fix
I assume that cloning the label or moving it to the device frees the reference to the label provided by the dataloader. Thus the dataloader can delete the label and free its file handler. 