### PR TITLE
Add new method for creating tags from a list of filenames

### DIFF
--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -76,14 +76,14 @@ class _TagsMixin:
 
     def create_tag_from_filenames(
         self,
-        list_of_filenames: List[str],
+        fnames_new_tag: List[str],
         new_tag_name: str,
         parent_tag_id: str = None
     ) -> TagData:
         """Creates a new tag from a list of filenames.
 
         Args:
-            list_of_filenames:
+            fnames_new_tag:
                 A list of filenames to be included in the new tag.
             new_tag_name:
                 The name of the new tag.
@@ -111,24 +111,25 @@ class _TagsMixin:
         tot_size = tags[-1].tot_size
 
         # get list of filenames from tag
-        fnames_tag = self.get_filenames_in_tag(tags[-1])
+        fnames_server = self.get_filenames()
 
         # create new bitmask 
         bitmask = BitMask(tot_size)
-        for i, fname in enumerate(fnames_tag):
+        for i, fname_server in enumerate(fnames_server):
             bitmask.unset_kth_bit(i)
-            for fname_selected in list_of_filenames:
-                if fname_selected == fname:
-                    bitmask.set_kth_bit(i)
-                    break
+            if fname_server in fnames_new_tag:
+                bitmask.set_kth_bit(i)
+
         
         # quick sanity check
-        num_selected_samples = len(bitmask.masked_select_from_list(fnames_tag))
-        if num_selected_samples != len(list_of_filenames):
+        num_selected_samples = len(bitmask.to_indices())
+        if num_selected_samples != len(fnames_new_tag):
             raise RuntimeError(
-                f'An error occured when creating the new subset!'
+                f'An error occured when creating the new subset! '
                 f'Found {num_selected_samples} samples newly selected '
-                f'instead of {len(list_of_filenames)}.'
+                f'instead of {len(fnames_new_tag)}. '
+                f'Make sure you use the correct filenames. '
+                f'Valid filename example from the dataset: {fnames_server[0]}'
                 )
 
         # create new tag

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -106,12 +106,11 @@ class _TagsMixin:
 
         # fallback to initial tag if no parent tag is provided
         if parent_tag_id is None:
-            parent_tag_id = tags[-1].id
-
-        tot_size = tags[-1].tot_size
+            parent_tag_id = next(tag.id for tag in tags if tag.name=='initial-tag')
 
         # get list of filenames from tag
         fnames_server = self.get_filenames()
+        tot_size = len(fnames_server)
 
         # create new bitmask for the new tag
         bitmask = BitMask(0)
@@ -125,8 +124,9 @@ class _TagsMixin:
         if num_selected_samples != len(fnames_new_tag):
             raise RuntimeError(
                 f'An error occured when creating the new subset! '
-                f'Found {num_selected_samples} samples newly selected '
-                f'instead of {len(fnames_new_tag)}. '
+                f'Out of the {len(fnames_new_tag)} filenames you provided '
+                f'to create a new tag, only {num_selected_samples} have been '
+                f'found on the server. '
                 f'Make sure you use the correct filenames. '
                 f'Valid filename example from the dataset: {fnames_server[0]}'
                 )

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -113,13 +113,12 @@ class _TagsMixin:
         # get list of filenames from tag
         fnames_server = self.get_filenames()
 
-        # create new bitmask 
-        bitmask = BitMask(tot_size)
-        for i, fname_server in enumerate(fnames_server):
-            bitmask.unset_kth_bit(i)
-            if fname_server in fnames_new_tag:
+        # create new bitmask for the new tag
+        bitmask = BitMask(0)
+        fnames_new_tag = set(fnames_new_tag)
+        for i, fname in enumerate(fnames_server):
+            if fname in fnames_new_tag:
                 bitmask.set_kth_bit(i)
-
         
         # quick sanity check
         num_selected_samples = len(bitmask.to_indices())

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -181,6 +181,13 @@ class MockedTagsApi(TagsApi):
         _check_dataset_id(dataset_id)
         assert body.upsize_tag_creator == TagCreator.USER_PIP
 
+    def create_tag_by_dataset_id(self, body, dataset_id, **kwargs):
+        _check_dataset_id(dataset_id)
+        tag = TagData(id='inital_tag_id', dataset_id=dataset_id, prev_tag_id=None,
+                      bit_mask_data="0xF", name=body['name'], tot_size=10,
+                      created_at=1577836800, changes=dict())
+        return tag
+        
 
 class MockedScoresApi(ScoresApi):
     def create_or_update_active_learning_score_by_tag_id(self, body, dataset_id, tag_id, **kwargs) -> \

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -183,8 +183,8 @@ class MockedTagsApi(TagsApi):
 
     def create_tag_by_dataset_id(self, body, dataset_id, **kwargs):
         _check_dataset_id(dataset_id)
-        tag = TagData(id='inital_tag_id', dataset_id=dataset_id, prev_tag_id=None,
-                      bit_mask_data="0xF", name=body['name'], tot_size=10,
+        tag = TagData(id='inital_tag_id', dataset_id=dataset_id, prev_tag_id=body['prev_tag_id'],
+                      bit_mask_data=body['bit_mask_data'], name=body['name'], tot_size=10,
                       created_at=1577836800, changes=dict())
         return tag
         

--- a/tests/api_workflow/test_api_workflow_tags.py
+++ b/tests/api_workflow/test_api_workflow_tags.py
@@ -60,6 +60,17 @@ class TestApiWorkflowTags(MockedApiWorkflowSetup):
         filenames = self.api_workflow_client.get_filenames()
         self.api_workflow_client.get_filenames_in_tag(tag_data, filenames, exclude_parent_tag=True)
 
+    def test_create_tag_from_filenames(self):
+        filenames_server = self.api_workflow_client.get_filenames()
+        filenames_new_tag = filenames_server[:10][::3]
+        self.api_workflow_client.create_tag_from_filenames(filenames_new_tag, new_tag_name="funny_new_tag")
+
+    def test_create_tag_from_filenames(self):
+        filenames_server = self.api_workflow_client.get_filenames()
+        filenames_new_tag = filenames_server[:10][::3]
+        filenames_new_tag[0] = 'some-random-non-existing-filename.jpg'
+        with self.assertRaises(RuntimeError):
+            self.api_workflow_client.create_tag_from_filenames(filenames_new_tag, new_tag_name="funny_new_tag")
 
 
 


### PR DESCRIPTION
## Changes

- Added the `create_tag_from_filenames` method
- I tested it and it seems to work fine :)
- Usage example:
![image](https://user-images.githubusercontent.com/1522766/153023203-6bdf6de1-9ade-47eb-8914-4fa2c8377eb7.png)
 