### PR TITLE
before upload to server: check embeddings and remove additional columns

### DIFF
--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -12,7 +12,7 @@ from lightly.openapi_generated.swagger_client.models.dataset_embedding_data \
     import DatasetEmbeddingData
 from lightly.openapi_generated.swagger_client.models.write_csv_url_data \
     import WriteCSVUrlData
-from lightly.utils.io import check_filenames
+from lightly.utils.io import check_filenames, check_embeddings
 
 
 class EmbeddingDoesNotExistError(ValueError):
@@ -88,7 +88,7 @@ class _UploadEmbeddingsMixin:
     def upload_embeddings(self, path_to_embeddings_csv: str, name: str):
         """Uploads embeddings to the server.
 
-        First checks that the specified embedding name is not on ther server. If it is, the upload is aborted.
+        First checks that the specified embedding name is not on the server. If it is, the upload is aborted.
         Then creates a new csv with the embeddings in the order specified on the server. Next it uploads it to the server.
         The received embedding_id is saved as a property of self.
 
@@ -100,6 +100,7 @@ class _UploadEmbeddingsMixin:
                 the upload is aborted.
 
         """
+        check_embeddings(path_to_embeddings_csv, remove_additional_columns=True)
 
         # Try to append the embeddings on the server, if they exist
         try:

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -36,7 +36,7 @@ def check_filenames(filenames: List[str]):
         raise ValueError(f'Invalid filename(s): {invalid_filenames}')
 
 
-def check_embeddings(path: str):
+def check_embeddings(path: str, remove_additional_columns: bool=False):
     """Raises an error if the embeddings csv file has not the correct format
     
     Use this check whenever you want to upload an embedding to the Lightly 
@@ -47,11 +47,14 @@ def check_embeddings(path: str):
     Args:
         path:
             Path to the embedding csv file
+        remove_additional_columns:
+            If True, all additional columns
+            which are not in {filenames, embeddings_x, labels} are removed.
+            If false, they are kept unchanged.
 
     Raises:
         RuntimeError
     """
-    header = []
     with open(path, 'r', newline='') as csv_file:
         reader = csv.reader(csv_file, delimiter=',')
         header: List[str] = next(reader)
@@ -90,6 +93,18 @@ def check_embeddings(path: str):
                     f'Embeddings csv file must not have empty rows. '
                     f'Found empty row on line {i}.'
                     )
+
+    if remove_additional_columns:
+        new_rows = []
+        with open(path, 'r', newline='') as csv_file:
+            reader = csv.reader(csv_file, delimiter=',')
+            for row in reader:
+                row = row[:header_labels_idx+1]
+                new_rows.append(row)
+        with open(path, 'w', newline='') as csv_file:
+            writer = csv.writer(csv_file, delimiter=',')
+            writer.writerows(new_rows)
+
 
 def save_embeddings(path: str,
                     embeddings: np.ndarray,

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -1,3 +1,4 @@
+import csv
 import sys
 import tempfile
 import unittest
@@ -80,3 +81,23 @@ class TestEmbeddingsIO(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             check_embeddings(self.embeddings_path)
         self.assertTrue('must not have empty rows' in str(context.exception))
+
+    def test_embeddings_extra_rows(self):
+        rows = [
+            ['filenames', 'embedding_0', 'embedding_1', 'labels', 'selected',
+             'masked'],
+            ['image_0.jpg', '3.4', '0.23', '0', '1', '0'],
+            ['image_1.jpg', '3.4', '0.23', '1', '0', '1']
+        ]
+        with open(self.embeddings_path, 'w') as f:
+            csv_writer = csv.writer(f)
+            csv_writer.writerows(rows)
+
+        check_embeddings(self.embeddings_path, remove_additional_columns=True)
+
+        with open(self.embeddings_path) as csv_file:
+            csv_reader = csv.reader(csv_file, delimiter=',')
+            for row_read, row_original in zip(csv_reader, rows):
+                self.assertListEqual(row_read, row_original[:-2])
+
+


### PR DESCRIPTION
## Reason for issue
There embedding file uploaded to the server should not include additional columns for some reasons:
- It makes the file smaller.
- It disallows uploading "selected" and "masked" via the embedding file and assuming that they mean something instead of relying on the "preselected_tag" and "query_tag"
- It can cause errors when appending embedding files if the columns are not the same.

For more details and discussion, see the issue https://linear.app/lightly/issue/LIG-565/make-sure-docker-only-uploads-embedding-files-without-additional

## Description
- Added check of embedding file format before uploading embeddings.
- Uploading embeddings now removes additional columns, but keeps the standard ones (filenames, embeddings_x, labels)

