### PR TITLE
make sure train_model_and_embed_images returns everything

### DIFF
--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -9,8 +9,10 @@ command-line interface.
 # All Rights Reserved
 
 import os
+from typing import Union, Tuple, List
 
 import hydra
+import numpy as np
 import torch
 import torchvision
 from torch.utils.hipify.hipify_python import bcolors
@@ -24,7 +26,17 @@ from lightly.cli._helpers import fix_input_path
 from lightly.cli._helpers import cpu_count
 
 
-def _embed_cli(cfg, is_cli_call=True):
+def _embed_cli(cfg, is_cli_call=True) -> \
+    Union[
+        Tuple[List[np.ndarray], List[int], List[str]],
+        str
+    ]:
+    """ See embed_cli() for usage documentation
+
+        is_cli_call:
+            If True, saves the embeddings as file and returns the filepath.
+            If False, returns the embeddings, labels, filenames as tuple.
+    """
     input_dir = cfg['input_dir']
     if input_dir and is_cli_call:
         input_dir = fix_input_path(input_dir)
@@ -79,7 +91,7 @@ def _embed_cli(cfg, is_cli_call=True):
 
 
 @hydra.main(config_path='config', config_name='config')
-def embed_cli(cfg):
+def embed_cli(cfg) -> str:
     """Embed images from the command-line.
 
     Args:
@@ -94,6 +106,9 @@ def embed_cli(cfg):
         checkpoint:
             Path to the checkpoint of a pretrained model. If left
             empty, a pretrained model by lightly is used.
+
+    Returns:
+        The path to the created embeddings file.
 
     Examples:
         >>> # embed images with default settings and a lightly model

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -28,14 +28,18 @@ from lightly.cli._helpers import cpu_count
 
 def _embed_cli(cfg, is_cli_call=True) -> \
     Union[
-        Tuple[List[np.ndarray], List[int], List[str]],
+        Tuple[np.ndarray, List[int], List[str]],
         str
     ]:
     """ See embed_cli() for usage documentation
 
         is_cli_call:
-            If True, saves the embeddings as file and returns the filepath.
-            If False, returns the embeddings, labels, filenames as tuple.
+            If True:
+                Saves the embeddings as file and returns the filepath.
+            If False:
+                Returns the embeddings, labels, filenames as tuple.
+                Embeddings are of shape (n_samples, embedding_size)
+                len(labels) = len(filenames) = n_samples
     """
     input_dir = cfg['input_dir']
     if input_dir and is_cli_call:

--- a/lightly/core.py
+++ b/lightly/core.py
@@ -77,13 +77,14 @@ def _add_kwargs(cfg, kwargs):
 
 
 def train_model_and_embed_images(config_path: str = None, **kwargs) -> Tuple[
-    List[np.ndarray], List[int], List[str]
+    np.ndarray, List[int], List[str]
 ]:
     """Train a self-supervised model and use it to embed images.
 
-    Calls the same function as lightly-magic. All arguments passed to
-    lightly-magic can also be passed to this function (see below for an
-    example).
+    First trains a modle using the _train_cli(),
+    then embeds with the _embed_cli().
+    All arguments passed to the CLI functions
+    can also be passed to this function (see below for an example).
 
     Args:
         config_path:
@@ -93,6 +94,8 @@ def train_model_and_embed_images(config_path: str = None, **kwargs) -> Tuple[
 
     Returns:
         Embeddings, labels, and filenames of the images.
+        Embeddings are of shape (n_samples, embedding_size)
+        len(labels) = len(filenames) = n_samples
 
     Examples:
         >>> import lightly
@@ -110,8 +113,6 @@ def train_model_and_embed_images(config_path: str = None, **kwargs) -> Tuple[
         >>> my_trainer = {max_epochs: 10}
         >>> embeddings, _, _ = lightly.train_model_and_embed_images(
         >>>     input_dir='path/to/data', trainer=my_trainer)
-        >>> # the command above is equivalent to:
-        >>> # lightly-magic input_dir='path/to/data' trainer.max_epochs=10
 
     """
     config_path = _get_config_path(config_path)

--- a/lightly/core.py
+++ b/lightly/core.py
@@ -2,6 +2,9 @@
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
+from typing import Tuple, List
+
+import numpy as np
 
 from lightly.cli.train_cli import _train_cli
 from lightly.cli.embed_cli import _embed_cli
@@ -73,7 +76,9 @@ def _add_kwargs(cfg, kwargs):
     return cfg
 
 
-def train_model_and_embed_images(config_path: str = None, **kwargs):
+def train_model_and_embed_images(config_path: str = None, **kwargs) -> Tuple[
+    List[np.ndarray], List[int], List[str]
+]:
     """Train a self-supervised model and use it to embed images.
 
     Calls the same function as lightly-magic. All arguments passed to
@@ -112,7 +117,11 @@ def train_model_and_embed_images(config_path: str = None, **kwargs):
     config_path = _get_config_path(config_path)
     config_args = _load_config_file(config_path)
     config_args = _add_kwargs(config_args, kwargs)
-    return _lightly_cli(config_args, is_cli_call=False)
+
+    checkpoint = _train_cli(config_args, is_cli_call=False)
+    config_args['checkpoint'] = checkpoint
+    embeddings, labels, filenames = _embed_cli(config_args, is_cli_call=False)
+    return embeddings, labels, filenames
 
 
 def train_embedding_model(config_path: str = None, **kwargs):

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -60,8 +60,8 @@ class TestCLIMagic(MockedApiWorkflowSetup):
                 self.cfg[key_subparts[0]][key_subparts[1]] = value
             else:
                 raise ValueError(
-                    f"Keys with more than 2 subparts are not supported,"
-                     "but you entered {key}."
+                    f'Keys with more than 2 subparts are not supported,'
+                     'but you entered {key}.'
                 )
 
 

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -61,7 +61,7 @@ class TestCLIMagic(MockedApiWorkflowSetup):
             else:
                 raise ValueError(
                     f'Keys with more than 2 subparts are not supported,'
-                     'but you entered {key}.'
+                    f'but you entered {key}.'
                 )
 
 


### PR DESCRIPTION
## Description
- wrote unittest reproducing the issue
- fixed it in the `train_model_and_embed_images()` function than now uses the `_train_cli()` and `_embed_cli()` instead of the `_lightly_cli()`
- added comments to the `_embed_cli()` to make the return type much clearer
- added a unittest to the lightly-cli to prevent lines from becoming uncovered

closes #696 