### PR TITLE
Malte lig 652 add cli argument for dataset upsizing

### DIFF
--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -124,7 +124,6 @@ class _UploadDatasetMixin:
         if custom_metadata is not None:
             self.verify_custom_metadata_format(custom_metadata)
             filename_to_metadata = self.index_custom_metadata_by_filename(
-                dataset.get_filenames(),
                 custom_metadata,
             )
 

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -40,7 +40,6 @@ class _UploadDatasetMixin:
                        input: Union[str, LightlyDataset],
                        max_workers: int = 8,
                        mode: str = 'thumbnails',
-                       verbose: bool = True,
                        custom_metadata: Union[Dict, None] = None):
         """Uploads a dataset to to the Lightly cloud solution.
 
@@ -50,12 +49,11 @@ class _UploadDatasetMixin:
                 or the dataset in form of a LightlyDataset
             max_workers:
                 Maximum number of workers uploading images in parallel.
-            max_requests:
-                Maximum number of requests a single worker can do before he has
-                to wait for the others.
             mode:
                 One of [full, thumbnails, metadata]. Whether to upload
                 thumbnails, full images, or metadata only.
+            custom_metadata:
+                COCO-style dictionary of custom metadata to be uploaded.
 
         Raises:
             ValueError:
@@ -89,11 +87,10 @@ class _UploadDatasetMixin:
         max_workers = max(max_workers, 1)
 
         # upload the samples
-        if verbose:
-            print(
-                f'Uploading images (with {max_workers} workers).',
-                flush=True
-            )
+        print(
+            f'Uploading images (with {max_workers} workers).',
+            flush=True
+        )
 
         # TODO: remove _size_in_bytes from image_processing
         image_processing.metadata._size_in_bytes = \

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -1,6 +1,6 @@
 import concurrent
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List
+from typing import Dict, List, Union
 from bisect import bisect_left
 
 from tqdm import tqdm
@@ -47,7 +47,8 @@ class _UploadCustomMetadataMixin:
             COCO_ANNOTATION_KEYS.custom_metadata, custom_metadata
         )
 
-    def index_custom_metadata_by_filename(self, custom_metadata: Dict):
+    def index_custom_metadata_by_filename(self, custom_metadata: Dict)\
+            -> Dict[str, Union[Dict, None]]:
         """Creates an index to lookup custom metadata by filename.
 
         Args:
@@ -56,12 +57,15 @@ class _UploadCustomMetadataMixin:
                 the required format.
 
         Returns:
-            A dictionary containing custom metadata indexed by filename.
+            A dictionary mapping from filenames to custom metadata.
+            If there are no annotations for a filename, the custom metadata
+            is None instead.
 
         """
 
         # Developer note:
-        # the mapping is filename -> image_id -> custom_metadata
+        # The mapping is filename -> image_id -> custom_metadata
+        # This mapping is created in linear time.
         filename_to_image_id = {
             image_info[COCO_ANNOTATION_KEYS.images_filename]:
                 image_info[COCO_ANNOTATION_KEYS.images_id]

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -47,6 +47,42 @@ class _UploadCustomMetadataMixin:
             COCO_ANNOTATION_KEYS.custom_metadata, custom_metadata
         )
 
+    def index_custom_metadata_by_filename(self, custom_metadata: Dict):
+        """Creates an index to lookup custom metadata by filename.
+
+        Args:
+            custom_metadata:
+                Dictionary of custom metadata, see upload_custom_metadata for
+                the required format.
+
+        Returns:
+            A dictionary containing custom metadata indexed by filename.
+
+        """
+
+        # Developer note:
+        # the mapping is filename -> image_id -> custom_metadata
+        filename_to_image_id = {
+            image_info[COCO_ANNOTATION_KEYS.images_filename]:
+                image_info[COCO_ANNOTATION_KEYS.images_id]
+            for image_info
+            in custom_metadata[COCO_ANNOTATION_KEYS.images]
+        }
+        image_id_to_custom_metadata = {
+            metadata[COCO_ANNOTATION_KEYS.custom_metadata_image_id]:
+                metadata
+            for metadata
+            in custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata]
+        }
+        filename_to_metadata = {
+            filename: image_id_to_custom_metadata.get(image_id, None)
+            for (filename, image_id)
+            in filename_to_image_id.items()
+        }
+        return filename_to_metadata
+
+
+
     def upload_custom_metadata(self,
                                custom_metadata: Dict,
                                verbose: bool = False,
@@ -157,7 +193,7 @@ class _UploadCustomMetadataMixin:
                 results = tqdm(
                     results, 
                     unit='metadata',
-                    total=len(sample_requests)
+                    total=len(upload_requests)
                 )
             # iterate over results to make sure they are completed
             list(results)

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -63,29 +63,31 @@ class _UploadCustomMetadataMixin:
             A dictionary containing custom metdata indexed by filename.
 
         """
+        custom_metadata_images = custom_metadata[COCO_ANNOTATION_KEYS.images]
+        custom_metadata_metadata = custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata]
 
         # sort images by filename
         custom_metadata[COCO_ANNOTATION_KEYS.images] = sorted(
-            custom_metadata[COCO_ANNOTATION_KEYS.images],
+            custom_metadata_images,
             key=lambda x: x[COCO_ANNOTATION_KEYS.images_filename]
         )
 
         # sort metadata by image id
         custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata] = sorted(
-            custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata],
+            custom_metadata_metadata,
             key=lambda x: x[COCO_ANNOTATION_KEYS.custom_metadata_image_id]
         )
 
         # get a list of filenames for binary search
         image_filenames = [
             image[COCO_ANNOTATION_KEYS.images_filename] for image in
-            custom_metadata[COCO_ANNOTATION_KEYS.images]
+            custom_metadata_images
         ]
 
         # get a list of image ids for binary search
         metadata_image_ids = [
             data[COCO_ANNOTATION_KEYS.custom_metadata_image_id] for data in
-            custom_metadata[COCO_ANNOTATION_KEYS.custom_metadata]
+            custom_metadata_metadata
         ]
 
         # map filename to metadata in O(n * logn)

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -173,8 +173,7 @@ class _UploadCustomMetadataMixin:
                 print_as_warning(
                     f'No image found for custom metadata annotation '
                     f'with image_id {image_id}. '
-                    f'This custom metadata annotation is skipped. '
-                    f'Please fix your custom metadata file.',
+                    f'This custom metadata annotation is skipped. ',
                     InvalidCustomMetadataWarning
                 )
                 continue
@@ -185,9 +184,7 @@ class _UploadCustomMetadataMixin:
                     f'filename {{{filename}}}, '
                     f'but a sample with this filename '
                     f'does not exist on the server. '
-                    f'This custom metadata annotation is skipped. '
-                    f'Please upload the sample to the server first or fix '
-                    f'your custom metadata file.',
+                    f'This custom metadata annotation is skipped. ',
                     InvalidCustomMetadataWarning
                 )
                 continue

--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -5,6 +5,7 @@
 import copy
 import os
 import warnings
+from typing import Type
 
 import torch
 from hydra import utils
@@ -23,11 +24,11 @@ def _custom_formatwarning(msg, *args, **kwargs):
     return f"{bcolors.WARNING}{msg}{bcolors.WARNING}\n"
 
 
-def print_as_warning(message: str):
+def print_as_warning(message: str, warning_class: Type[Warning] = UserWarning):
     old_format = copy.copy(warnings.formatwarning)
 
     warnings.formatwarning = _custom_formatwarning
-    warnings.warn(message, UserWarning)
+    warnings.warn(message, warning_class)
 
     warnings.formatwarning = old_format
 

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -18,6 +18,7 @@ dataset_id: ''                # Identifier of the dataset on the Lightly platfo
 new_dataset_name: ''          # Name of the new dataset to be created on the Lightly platform
 upload: 'full'                # Whether to upload full images, thumbnails only, or metadata only.
                               # Must be one of ['full', 'thumbnails', 'none']
+append: False                 # Must be True if you want to append samples to an existing dataset.
 resize: -1                    # Allow resizing of the images before uploading, usage =-1, =x, =[x,y]
 embedding_name: 'default'     # Name of the embedding to be used on the Lightly platform.
 emb_upload_bsz: 32            # Number of embeddings which are uploaded in a single batch.

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -32,8 +32,8 @@ def validate_cfg(cfg: DictConfig) -> bool:
     valid = True
     if cfg['trainer']['max_epochs'] > 0 and cfg['append']:
         print_as_warning('When appending to an existing dataset you must '
-                         'use the same embedding model. Thus specify'
-                         'trainer.max_epochs=0. If you had trained your own model,'
+                         'use the same embedding model. Thus specify '
+                         'trainer.max_epochs=0. If you had trained your own model, '
                          'you can use it with checkpoint="path/to/model.ckp".')
         valid = False
     return valid

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -38,7 +38,6 @@ def _upload_cli(cfg, is_cli_call=True) -> Union[str, None]:
             None
 
     """
-    print(cfg)
     input_dir = cfg['input_dir']
     if input_dir and is_cli_call:
         input_dir = fix_input_path(input_dir)

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -119,7 +119,7 @@ def _upload_cli(cfg, is_cli_call=True):
         print('Starting upload of embeddings.')
         if not cfg.append:
             try:
-                embedding = api_workflow_client.get_embedding_by_name(name=name,ignore_suffix=True)
+                embedding = api_workflow_client.get_embedding_by_name(name=name, ignore_suffix=True)
                 print_as_warning(
                     'The dataset you specified already has an embedding. '
                     'If you want to add additional samples, you need to specify '

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -117,6 +117,17 @@ def _upload_cli(cfg, is_cli_call=True):
     if path_to_embeddings:
         name = cfg['embedding_name']
         print('Starting upload of embeddings.')
+        if not cfg.append:
+            try:
+                embedding = api_workflow_client.get_embedding_by_name(name=name,ignore_suffix=True)
+                print_as_warning(
+                    'The dataset you specified already has an embedding. '
+                    'If you want to add additional samples, you need to specify '
+                    'append=True as CLI argument.'
+                )
+                return
+            except EmbeddingDoesNotExistError:
+                pass
         api_workflow_client.upload_embeddings(
             path_to_embeddings_csv=path_to_embeddings, name=name
         )

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -95,6 +95,15 @@ def _upload_cli(cfg, is_cli_call=True):
         transform = torchvision.transforms.Resize(size)
 
     if input_dir:
+        if len(api_workflow_client.get_all_tags()) > 0:
+            if not cfg.append:
+                print_as_warning(
+                    'The dataset you specified already has samples. '
+                    'If you want to add additional samples, you need to specify '
+                    'append=True as CLI argument.'
+                )
+                return
+
         mode = cfg['upload']
         dataset = LightlyDataset(input_dir=input_dir, transform=transform)
         api_workflow_client.upload_dataset(

--- a/tests/UNMOCKED_end2end_tests/test_api_append.py
+++ b/tests/UNMOCKED_end2end_tests/test_api_append.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+import torchvision
+
+from lightly.data import LightlyDataset
+from lightly.utils import format_custom_metadata
+from tests.UNMOCKED_end2end_tests.test_api import \
+    create_new_dataset_with_embeddings
+
+
+def t_est_api_append(path_to_dataset: str, token: str,
+                     dataset_name: str = "test_api_from_pip_append"):
+    files_to_delete = []
+    try:
+        print("Save custom metadata")
+        dataset = LightlyDataset(path_to_dataset)
+        path_custom_metadata = f"{path_to_dataset}/custom_metadata.csv"
+        custom_metadata = [(filename, {"metadata": f"{filename}_meta"}) for
+            filename in dataset.get_filenames()]
+
+        print("Upload to the dataset")
+        api_workflow_client = create_new_dataset_with_embeddings(
+            path_to_dataset=path_to_dataset, token=token,
+            dataset_name=dataset_name)
+        api_workflow_client.upload_custom_metadata(
+            format_custom_metadata(custom_metadata))
+
+        print("save additional images and embeddings and custom metadata")
+        n_data = 5
+        dataset = torchvision.datasets.FakeData(size=n_data,
+                                                image_size=(3, 32, 32))
+        sample_names = [f'img_{i}.jpg' for i in range(n_data)]
+        for sample_idx in range(n_data):
+            data = dataset[sample_idx]
+            path = os.path.join(path_to_dataset, sample_names[sample_idx])
+            files_to_delete.append(path)
+            data[0].save(path)
+        custom_metadata += [(filename, {"metadata": f"{filename}_meta"}) for
+            filename in sample_names]
+
+        print("Upload to the dataset")
+        api_workflow_client.upload_dataset(path_to_dataset)
+
+        print("Upload custom metadata")
+        api_workflow_client.upload_custom_metadata(
+            format_custom_metadata(custom_metadata))
+
+
+
+    finally:
+        for filename in files_to_delete:
+            try:
+                os.remove(filename)
+            except FileNotFoundError:
+                pass
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1 + 2:
+        path_to_dataset, token = (sys.argv[1 + i] for i in range(2))
+    else:
+        raise ValueError(
+            "ERROR in number of command line arguments, must be 2."
+            "Example: python test_api path/to/dataset TOKEN")
+
+    t_est_api_append(path_to_dataset=path_to_dataset, token=token)

--- a/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
+++ b/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
@@ -123,12 +123,18 @@ class TestApiWorkflowUploadCustomMetadata(MockedApiWorkflowSetup):
                     for id in image_ids_annotations
                 ],
             }
+            # The annotations must only have image_ids that are also in the images.
             custom_metadata_malformatted = \
                 len(set(image_ids_annotations) - set(image_ids_images))
+            # Only custom metadata whose filename is on the server can be uploaded.
             metatadata_without_filenames_on_server = \
                 len(set(filenames_metadata) - set(filenames_server))>0
-            if custom_metadata_malformatted \
-                    or metatadata_without_filenames_on_server:
+            if metatadata_without_filenames_on_server:
+                with self.assertRaises(ValueError):
+                    self.api_workflow_client.upload_custom_metadata(
+                        custom_metadata
+                    )
+            elif custom_metadata_malformatted:
                 with self.assertRaises(RuntimeError):
                     self.api_workflow_client.upload_custom_metadata(
                         custom_metadata

--- a/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
+++ b/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
@@ -4,12 +4,14 @@ import os
 import random
 import tempfile
 import pathlib
+from typing import List
 
 import numpy as np
 import torchvision
 
 from lightly.api.utils import MAXIMUM_FILENAME_LENGTH
 from lightly.data.dataset import LightlyDataset
+from lightly.openapi_generated.swagger_client import SampleData
 from lightly.utils.io import COCO_ANNOTATION_KEYS
 
 from tests.api_workflow.mocked_api_workflow_client import \
@@ -70,3 +72,89 @@ class TestApiWorkflowUploadCustomMetadata(MockedApiWorkflowSetup):
             custom_metadata = json.load(f)
             with self.assertRaises(ValueError):
                 self.api_workflow_client.upload_custom_metadata(custom_metadata)
+
+    def test_upload_custom_metadata_with_append(self):
+        self.create_fake_dataset()
+        self.api_workflow_client.upload_dataset(input=self.folder_path)
+        with open(self.custom_metadata_file.name, 'r') as f:
+            custom_metadata = json.load(f)
+            custom_metadata['metadata'] = custom_metadata['metadata'][:3]
+            self.api_workflow_client.upload_custom_metadata(custom_metadata)
+
+
+    def subtest_upload_custom_metadata(
+            self,
+            image_ids_images: List[int],
+            image_ids_annotations: List[int],
+            filenames_server: List[str]
+    ):
+
+        def get_samples_by_dataset_id(*args, **kwargs)-> List[SampleData]:
+            samples = [
+                SampleData(
+                    id="dfd",
+                    file_name=filename,
+                    dataset_id='dataset_id_xyz',
+                    type='Images'
+                )
+                for filename in filenames_server
+            ]
+            return samples
+        self.api_workflow_client._samples_api.get_samples_by_dataset_id = get_samples_by_dataset_id
+        filenames_metadata = [f"img_{id}.jpg" for id in image_ids_images]
+
+        with self.subTest(image_ids_images=image_ids_images,
+                image_ids_annotations=image_ids_annotations,
+                filenames_server=filenames_server
+
+        ):
+            custom_metadata = {
+                COCO_ANNOTATION_KEYS.images: [
+                        {
+                        COCO_ANNOTATION_KEYS.images_id: id,
+                        COCO_ANNOTATION_KEYS.images_filename: filename}
+                    for id, filename in zip(image_ids_images, filenames_metadata)
+                ],
+                COCO_ANNOTATION_KEYS.custom_metadata: [
+                    {
+                        COCO_ANNOTATION_KEYS.custom_metadata_image_id: id,
+                        "any_key": "any_value"
+                    }
+                    for id in image_ids_annotations
+                ],
+            }
+            custom_metadata_malformatted = \
+                len(set(image_ids_annotations) - set(image_ids_images))
+            metatadata_without_filenames_on_server = \
+                len(set(filenames_metadata) - set(filenames_server))>0
+            if custom_metadata_malformatted \
+                    or metatadata_without_filenames_on_server:
+                with self.assertRaises(RuntimeError):
+                    self.api_workflow_client.upload_custom_metadata(
+                        custom_metadata
+                    )
+            else:
+                self.api_workflow_client.upload_custom_metadata(
+                    custom_metadata
+                )
+
+
+    def test_upload_custom_metadata(self):
+        potential_image_ids_images = [[0, 1, 2], [-1, 1], list(range(10))]
+        potential_image_ids_annotations = potential_image_ids_images
+        potential_filenames_server = [[f"img_{id}.jpg" for id in ids] for ids in potential_image_ids_images]
+
+        self.create_fake_dataset()
+        self.api_workflow_client.upload_dataset(input=self.folder_path)
+
+        for image_ids_images in potential_image_ids_images:
+            for image_ids_annotations in potential_image_ids_annotations:
+                for filenames_server in potential_filenames_server:
+                    self.subtest_upload_custom_metadata(
+                        image_ids_images,
+                        image_ids_annotations,
+                        filenames_server
+                    )
+
+
+

--- a/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
+++ b/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
@@ -143,7 +143,7 @@ class TestApiWorkflowUploadCustomMetadata(MockedApiWorkflowSetup):
 
 
     def test_upload_custom_metadata(self):
-        potential_image_ids_images = [[0, 1, 2], [-1, 1], list(range(10))]
+        potential_image_ids_images = [[0, 1, 2], [-1, 1], list(range(10)), [-3]]
         potential_image_ids_annotations = potential_image_ids_images
         potential_filenames_server = [[f"img_{id}.jpg" for id in ids] for ids in potential_image_ids_images]
 

--- a/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
+++ b/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
@@ -9,6 +9,8 @@ from typing import List
 import numpy as np
 import torchvision
 
+from lightly.api.api_workflow_upload_metadata import \
+    InvalidCustomMetadataWarning
 from lightly.api.utils import MAXIMUM_FILENAME_LENGTH
 from lightly.data.dataset import LightlyDataset
 from lightly.openapi_generated.swagger_client import SampleData
@@ -70,7 +72,7 @@ class TestApiWorkflowUploadCustomMetadata(MockedApiWorkflowSetup):
         self.create_fake_dataset()
         with open(self.custom_metadata_file.name, 'r') as f:
             custom_metadata = json.load(f)
-            with self.assertRaises(ValueError):
+            with self.assertWarns(InvalidCustomMetadataWarning):
                 self.api_workflow_client.upload_custom_metadata(custom_metadata)
 
     def test_upload_custom_metadata_with_append(self):
@@ -132,7 +134,7 @@ class TestApiWorkflowUploadCustomMetadata(MockedApiWorkflowSetup):
 
             if metatadata_without_filenames_on_server \
                     or custom_metadata_malformatted:
-                with self.assertRaises(ValueError):
+                with self.assertWarns(InvalidCustomMetadataWarning):
                     self.api_workflow_client.upload_custom_metadata(
                         custom_metadata
                     )

--- a/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
+++ b/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
@@ -101,7 +101,7 @@ class TestApiWorkflowUploadCustomMetadata(MockedApiWorkflowSetup):
             ]
             return samples
         self.api_workflow_client._samples_api.get_samples_by_dataset_id = get_samples_by_dataset_id
-        filenames_metadata = [f"img_{id}.jpg" for id in image_ids_images]
+        filenames_metadata = [f"img_{id}.jpg" for id in image_ids_annotations]
 
         with self.subTest(image_ids_images=image_ids_images,
                 image_ids_annotations=image_ids_annotations,
@@ -125,17 +125,14 @@ class TestApiWorkflowUploadCustomMetadata(MockedApiWorkflowSetup):
             }
             # The annotations must only have image_ids that are also in the images.
             custom_metadata_malformatted = \
-                len(set(image_ids_annotations) - set(image_ids_images))
+                len(set(image_ids_annotations) - set(image_ids_images)) > 0
             # Only custom metadata whose filename is on the server can be uploaded.
             metatadata_without_filenames_on_server = \
-                len(set(filenames_metadata) - set(filenames_server))>0
-            if metatadata_without_filenames_on_server:
+                len(set(filenames_metadata) - set(filenames_server)) > 0
+
+            if metatadata_without_filenames_on_server \
+                    or custom_metadata_malformatted:
                 with self.assertRaises(ValueError):
-                    self.api_workflow_client.upload_custom_metadata(
-                        custom_metadata
-                    )
-            elif custom_metadata_malformatted:
-                with self.assertRaises(RuntimeError):
                     self.api_workflow_client.upload_custom_metadata(
                         custom_metadata
                     )

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -90,6 +90,13 @@ class TestCLIMagic(MockedApiWorkflowSetup):
         self.parse_cli_string(cli_string)
         lightly.cli.lightly_cli(self.cfg)
 
+    def test_magic_with_trainer_and_append(self):
+        MockedApiWorkflowClient.n_dims_embeddings_on_server = 32
+        cli_string = "lightly-magic trainer.max_epochs=1 append=True"
+        self.parse_cli_string(cli_string)
+        with self.assertWarns(UserWarning):
+            lightly.cli.lightly_cli(self.cfg)
+
     def tearDown(self) -> None:
         for filename in ["embeddings.csv", "embeddings_sorted.csv"]:
             try:

--- a/tests/cli/test_cli_upload.py
+++ b/tests/cli/test_cli_upload.py
@@ -139,6 +139,9 @@ class TestCLIUpload(MockedApiWorkflowSetup):
                         if n_dims_embeddings != n_dims_embeddings_server and append:
                             with self.assertRaises(RuntimeError):
                                 lightly.cli.upload_cli(self.cfg)
+                        elif not append:
+                            with self.assertWarns(UserWarning):
+                                lightly.cli.upload_cli(self.cfg)
                         else:
                             lightly.cli.upload_cli(self.cfg)
 

--- a/tests/cli/test_cli_upload.py
+++ b/tests/cli/test_cli_upload.py
@@ -3,13 +3,17 @@ import re
 import sys
 import json
 import tempfile
+import warnings
 
 import numpy as np
 import torchvision
 from hydra.experimental import compose, initialize
-from omegaconf import OmegaConf
 
 import lightly
+from lightly.api.api_workflow_upload_embeddings import \
+    EmbeddingDoesNotExistError
+from lightly.cli.upload_cli import SUCCESS_RETURN_VALUE
+from lightly.openapi_generated.swagger_client import DatasetEmbeddingData
 from lightly.utils import save_embeddings
 from tests.api_workflow.mocked_api_workflow_client import \
     MockedApiWorkflowSetup, MockedApiWorkflowClient, N_FILES_ON_SERVER
@@ -29,19 +33,39 @@ class TestCLIUpload(MockedApiWorkflowSetup):
                 return []
             else:
                 return ["Any tag"]
-        sys.modules["lightly.cli.upload_cli"].\
-            ApiWorkflowClient.get_all_tags = mocked_get_all_tags_zero
+        MockedApiWorkflowClient.get_all_tags = mocked_get_all_tags_zero
+
+    def set_embedding(self, has_embedding: bool):
+        def mocked_get_embedding_by_name(*args, **kwargs):
+            if has_embedding:
+                return DatasetEmbeddingData(
+                    id="embedding_id",
+                    name="name",
+                    is_processed=True,
+                    created_at=0,
+
+                )
+            else:
+                raise EmbeddingDoesNotExistError
+
+        MockedApiWorkflowClient.get_embedding_by_name = \
+            mocked_get_embedding_by_name
+
+
 
     def setUp(self):
         # make the API dataset appear empty
         self.set_tags(zero_tags=True)
+        # make it have no embeddings
+        self.set_embedding(has_embedding=False)
 
         self.create_fake_dataset()
-        with initialize(config_path="../../lightly/cli/config", job_name="test_app"):
-            self.cfg = compose(config_name="config", overrides=["token='123'", f"input_dir={self.folder_path}"])
 
-
-    def create_fake_dataset(self, n_data: int=5, n_rows_embeddings: int=5, n_dims_embeddings: int = 4):
+    def create_fake_dataset(
+            self, n_data: int = N_FILES_ON_SERVER,
+            n_rows_embeddings: int = N_FILES_ON_SERVER,
+            n_dims_embeddings: int = 4
+    ):
         self.dataset = torchvision.datasets.FakeData(size=n_data,
                                                      image_size=(3, 32, 32))
 
@@ -75,28 +99,45 @@ class TestCLIUpload(MockedApiWorkflowSetup):
             labels,
             sample_names_embeddings
         )
+        MockedApiWorkflowClient.n_dims_embeddings_on_server = n_dims_embeddings
+        MockedApiWorkflowClient.n_embedding_rows_on_server = n_rows_embeddings
 
 
-    def parse_cli_string(self, cli_words: str):
+    def parse_cli_string(
+            self,
+            cli_words: str,
+    ):
+        with initialize(config_path="../../lightly/cli/config",
+                        job_name="test_app"):
+            overrides = [
+                "token='123'",
+                f"input_dir={self.folder_path}",
+                f"embeddings={self.path_to_embeddings}",
+            ]
+            self.cfg = compose(config_name="config", overrides=overrides)
+
         sys.argv = re.split(" ", cli_words)
         self.cfg.merge_with_cli()
 
     def test_parse_cli_string(self):
-        cli_string = "lightly-upload dataset_id='XYZ' upload='thumbnails' append=false"
+        cli_string = f"lightly-upload dataset_id='XYZ' upload='thumbnails' append={True}"
         self.parse_cli_string(cli_string)
         self.assertEqual(self.cfg["dataset_id"], 'XYZ')
         self.assertEqual(self.cfg["upload"], 'thumbnails')
-        self.assertFalse(self.cfg['append'])
+        self.assertTrue(self.cfg['append'])
 
     def test_upload_no_token(self):
-        self.cfg['token']=''
+        cli_string = f"lightly-upload"
+        self.parse_cli_string(cli_string)
+        self.cfg['token'] = ''
         with self.assertWarns(UserWarning):
             lightly.cli.upload_cli(self.cfg)
 
     def test_upload_new_dataset_name(self):
         cli_string = "lightly-upload new_dataset_name='new_dataset_name_xyz'"
         self.parse_cli_string(cli_string)
-        lightly.cli.upload_cli(self.cfg)
+        result = lightly.cli.upload_cli(self.cfg)
+        self.assertEqual(result, SUCCESS_RETURN_VALUE)
         self.assertGreater(len(os.getenv(
             self.cfg['environment_variable_names'][
             'lightly_last_dataset_id']
@@ -134,6 +175,7 @@ class TestCLIUpload(MockedApiWorkflowSetup):
                         )
                         MockedApiWorkflowClient.n_embedding_rows_on_server = n_embedding_rows_on_server
                         MockedApiWorkflowClient.n_dims_embeddings_on_server = n_dims_embeddings_server
+                        self.set_embedding(has_embedding=True)
                         cli_string = f"lightly-upload new_dataset_name='new_dataset_name_xyz' embeddings={self.path_to_embeddings} append={append}"
                         self.parse_cli_string(cli_string)
                         if n_dims_embeddings != n_dims_embeddings_server and append:
@@ -143,12 +185,14 @@ class TestCLIUpload(MockedApiWorkflowSetup):
                             with self.assertWarns(UserWarning):
                                 lightly.cli.upload_cli(self.cfg)
                         else:
-                            lightly.cli.upload_cli(self.cfg)
+                            result = lightly.cli.upload_cli(self.cfg)
+                            self.assertEqual(result, SUCCESS_RETURN_VALUE)
 
     def test_upload_new_dataset_id(self):
         cli_string = "lightly-upload dataset_id='xyz'"
         self.parse_cli_string(cli_string)
-        lightly.cli.upload_cli(self.cfg)
+        result = lightly.cli.upload_cli(self.cfg)
+        self.assertEqual(result, SUCCESS_RETURN_VALUE)
 
     def test_upload_no_dataset(self):
         cli_string = "lightly-upload input_dir=data/ token='123'"
@@ -165,21 +209,55 @@ class TestCLIUpload(MockedApiWorkflowSetup):
     def test_upload_custom_metadata(self):
         cli_string = f"lightly-upload token='123' dataset_id='xyz' custom_metadata='{self.tfile.name}'"
         self.parse_cli_string(cli_string)
-        lightly.cli.upload_cli(self.cfg)
+        result = lightly.cli.upload_cli(self.cfg)
+        self.assertEqual(result, SUCCESS_RETURN_VALUE)
 
-    def test_upload_existing_dataset_without_append(self):
-        # create "existing dataset" (having tags)
-        self.set_tags(zero_tags=False)
+    def check_upload_dataset_and_embedding(
+        self,
+        input_dir: bool,
+        existing_dataset: bool,
+        embeddings_path: bool,
+        existing_embedding: bool,
+        append: bool,
+    ):
+        with self.subTest(
+            input_dir=input_dir,
+            existing_dataset=existing_dataset,
+            embeddings_path=embeddings_path,
+            existing_embedding=existing_embedding,
+            append=append,
+        ):
+            self.set_tags(zero_tags=not existing_dataset)
+            self.set_embedding(has_embedding=existing_embedding)
 
-        cli_string = "lightly-upload dataset_id='xyz'"
-        self.parse_cli_string(cli_string)
-        with self.assertWarns(UserWarning):
-            lightly.cli.upload_cli(self.cfg)
+            cli_string = f"lightly-upload dataset_id='xyz' append={append}"
+            if not input_dir:
+                cli_string += f" input_dir=''"
+            if not embeddings_path:
+                cli_string += f" embeddings=''"
+            self.parse_cli_string(cli_string)
 
-    def test_upload_existing_dataset_with_append(self):
-        # create "existing dataset" (having tags)
-        self.set_tags(zero_tags=False)
+            if not append and existing_dataset and input_dir:
+                with self.assertWarns(UserWarning):
+                    lightly.cli.upload_cli(self.cfg)
+            elif not append and existing_embedding and embeddings_path:
+                with self.assertWarns(UserWarning):
+                    lightly.cli.upload_cli(self.cfg)
+            else:
+                result = lightly.cli.upload_cli(self.cfg)
+                self.assertEqual(result, SUCCESS_RETURN_VALUE)
 
-        cli_string = "lightly-upload dataset_id='xyz' append=True"
-        self.parse_cli_string(cli_string)
-        lightly.cli.upload_cli(self.cfg)
+    def test_upload_dataset_and_embedding(self):
+
+        for input_dir in [True, False]:
+            for existing_dataset in [True, False]:
+                for embeddings_path in [True, False]:
+                    for existing_embedding in [True, False]:
+                        for append in [True, False]:
+                            self.check_upload_dataset_and_embedding(
+                                input_dir=input_dir,
+                                existing_dataset=existing_dataset,
+                                embeddings_path=embeddings_path,
+                                existing_embedding=existing_embedding,
+                                append=append,
+                            )


### PR DESCRIPTION
## Description
- Add the cli argument
- By default, appending samples to a dataset will only be tried if you have specified `append=True`. If append=False and there are already tags, the cli command aborts.
- By default, /appending embeddings to a dataset will only be tried if you have specified `append=True`. If append=False and there is already an embedding file with the specified name, the cli command aborts.
- Wrote unittest that checks that behaviour with all 2^5 = 32 possible combinations:
```python
        for input_dir in [True, False]:
            for existing_dataset in [True, False]:
                for embeddings_path in [True, False]:
                    for existing_embedding in [True, False]:
                        for append in [True, False]:
                            self.check_upload_dataset_and_embedding(
                                input_dir=input_dir,
                                existing_dataset=existing_dataset,
                                embeddings_path=embeddings_path,
                                existing_embedding=existing_embedding,
                                append=append,
                            )

```
## Reworked the upload of metadata
To understand the behaviour, it is good to know that there are 5 sets in total
```python
image_annotation_ids = [annotation['image_id`] for annotation in custom_metadata['annotations']]
image_ids = [image_info['id`] for image_info in custom_metadata['images']]
metadata_filenames = [image_info['file_name`] for image_info in custom_metadata['images']]
local_filenames = dataset.get_filenames()
server_filenames = [sample.file_name for sample in api_workflow_client.get_samples()]
```
These `image_id` sets might be equal, overlapping, one the subset of the other or exclusive. It is required that `image_ids` is a superset of `image_annotation_ids`, but not necessarily the other way round, as there might be images without custom metadata.
The 3 `filename` sets might be equal, overlapping, one the subset of the other(s) or exclusive.

#### Uploading metadata is done together with uploading samples
It is assumed that the user mainly wants to upload the samples. The metadata should only be uploaded if any is found for the local samples to be uploaded.
It is searched for metadata for every sample to be uploaded. Implemented here, the behaviour is as follows:
- If there is no `image_info['filename']` for a filename in `local_filenames`, there is NO error. We just assume that the user does not have metadata for that sample. This happens if `metadata_filenames` is not a superset of `local_filenames`. 
- If there is no `annotation['image_id]` corresponding to the `image_info['id']` in the metadata, there is NO error. We just assume that the user does not have metadata for that sample. This happens if `image_annotation_ids` is not equal to `image_ids`. 

#### Uploading metadata separately
It is assumed that the user wants to upload each and every metadata specified in `custom_metadata['annotations']`. If that fails, a `ValueError` is raised. This might happen if
- There is no `image_info['id']` corresponding to the `annotation['image_id]` in the metadata. This happens if `image_annotation_ids` is not equal to `image_ids`, which is clearly an error in the `custom_metadata` file.
- There is no filename in the `server_filenames` corresponding to the `image_info['file_name`]`. Thus the user had tried to upload custom metadata for a sample that does not exist.

- This behaviour is checked for with 4 different sets for each of the `image_annotation_ids`, `image_ids/metadata_filenames` and `server_filenames`, thus 4³ = 64 test cases.

### Completely unrelated
- Fixed docstring and some arguments of `api_workflow_client.upload_dataset()`.