### PR TITLE
Philipp add predictions utilities

### DIFF
--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -114,68 +114,24 @@ class _DatasourcesMixin:
             self.dataset_id
         )
 
-    def download_prediction_task_names(
+    def get_prediction_read_url(
         self,
-        tasks_filename: str = 'tasks.json',
-    ) -> List[str]:
-        """Downloads the task names stored in the tasks.json file.
-
+        filename: str,
+    ):
+        """Returns a read-url for .lightly/predictions/{filename}.
+    
         Args:
-            tasks_filename:
-                Naming convention of the tasks file (always tasks.json).
+            filename:
+                Filename for which to get the read-url.
 
-        Returns a list of task names.
+        Returns the read-url. If the file does not exist, a read-url is returned
+        anyways.
         
         """
-        tasks_read_url = self._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id(
+        return self._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id(
             self.dataset_id,
-            tasks_filename,
+            filename,
         )
-
-        response = requests.get(tasks_read_url, stream=True)
-        response.raise_for_status()
-
-        tasks = response.json()
-        if isinstance(tasks, dict):
-            task_names = tasks.keys()
-        elif isinstance(tasks, List):
-            task_names = tasks
-        else:
-            raise ValueError('Invalid task format for tasks.json!')
-
-
-        if any([not isinstance(task_name, str) for task_name in task_names]):
-            raise ValueError('Task names in task.json must be strings!')
-
-        return task_names
-
-    def download_task_schema(
-        self,
-        task_name: str,
-        schema_filename: str = 'schema.json',
-    ) -> Tuple[str, Dict]:
-        """Downloads the schema of a given prediction task.
-
-        Args:
-            task_name:
-                Name of the prediction task.
-            schema_filename:
-                Naming convention of the schema files (always schema.json).
-
-        Returns the task description (e.g. classification, object-detection)
-        and the schema of the specified task.
-        
-        """
-        schema_read_url = self._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id(
-            self.dataset_id,
-            f'{task_name}/{schema_filename}',
-        )
-        response = requests.get(schema_read_url, stream=True)
-        response.raise_for_status()
-
-        schema = response.json()
-        task_description = schema.get('task_description', None)
-        return task_description, schema
 
     def download_raw_predictions(
         self,

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -347,7 +347,7 @@ def all_video_frame_counts(
 def download_prediction_file(
     url: str,
     session: requests.Session = None,
-) -> Dict:
+) -> Union[Dict, None]:
     """Downloads a json file from the provided read-url.
 
     Args:

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -342,3 +342,27 @@ def all_video_frame_counts(
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         return list(executor.map(job, urls))
+
+
+def download_prediction_file(
+    url: str,
+    session: requests.Session = None,
+) -> Dict:
+    """Downloads a json file from the provided read-url.
+
+    Args:
+        url: 
+            Url of the file to download.
+        session: 
+            Session object to persist certain parameters across requests.
+
+    Returns the content of the json file as dictionary or None.
+
+    """
+    req = requests if session is None else session
+    response = req.get(url, stream=True)
+
+    if response.status_code < 200 or response.status_code >= 300:
+        return None # the file doesn't exist!
+
+    return response.json()

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -5,8 +5,10 @@
 
 import json
 import csv
+from multiprocessing.sharedctypes import Value
 from typing import List, Tuple, Dict
 import re
+from unicodedata import name
 
 import numpy as np
 
@@ -317,3 +319,53 @@ def save_custom_metadata(path: str, custom_metadata: List[Tuple[str, Dict]]):
     formatted = format_custom_metadata(custom_metadata)
     with open(path, 'w') as f:
         json.dump(formatted, f)
+
+
+
+def save_tasks(
+    path: str,
+    tasks: List[str],
+):
+    """Saves a list of prediction task names in the right format.
+
+    Args:
+        path:
+            Where to store the task names.
+        tasks:
+            List of task names.
+
+    """
+    with open(path, 'w') as f:
+        json.dump(tasks, f)
+
+
+def save_schema(
+    path: str,
+    task_description: str,
+    ids: List[int],
+    names: List[str]
+):
+    """Saves a prediction schema in the right format.
+
+    Args:
+        path:
+            Where to store the schema.
+        task_description:
+            Task description (e.g. classification, object-detection).
+        ids:
+            List of category ids.
+        names:
+            List of category names.
+    """
+    if len(ids) != len(names):
+        raise ValueError('ids and names must have same length!')
+
+    schema = {
+        'task_description': task_description,
+        'categories': [
+            { 'id': id, 'name': name}
+            for id, name in zip(ids, names)
+        ]
+    }
+    with open(path, 'w') as f:
+        json.dump(schema, f)

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -5,10 +5,8 @@
 
 import json
 import csv
-from multiprocessing.sharedctypes import Value
 from typing import List, Tuple, Dict
 import re
-from unicodedata import name
 
 import numpy as np
 

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import tempfile
 import unittest
 import warnings
@@ -35,6 +36,16 @@ class MockedResponse:
         # instead of returning the byte stream from the url
         # we just give back an openend filehandle
         return open(self._raw, 'rb')
+
+    @property
+    def status_code(self):
+        return 200
+
+    def json(self):
+        # instead of returning the byte stream from the url
+        # we just load the json and return the dictionary
+        with open(self._raw, 'r') as f:
+            return json.load(f)
 
     def __enter__(self):
         return self
@@ -75,6 +86,14 @@ class TestDownload(unittest.TestCase):
             original.save(file.name)
             image = download.download_image(file.name)
             assert _images_equal(image, original)
+
+    def test_download_prediction(self):
+        original = _json_prediction()
+        with tempfile.NamedTemporaryFile(suffix='.json', mode="w+") as file:
+            with open(file.name, 'w') as f:
+                json.dump(original, f)
+            response = download.download_prediction_file(file.name)
+            assert _dicts_equal(response, original)
 
     def test_download_image_with_session(self):
         session = MockedRequestsModule.Session()
@@ -280,11 +299,22 @@ def _images_equal(image1, image2):
     # use a lossless format, otherwise this equality will not hold
     return np.all(np.array(image1) == np.array(image2))
 
+def _dicts_equal(x, y):
+    shared_items = {k: x[k] for k in x if k in y and x[k] == y[k]}
+    return len(x) == len(shared_items) and len(y) == len(shared_items)
+
 def _pil_image(width=100, height=50, seed=0):
     np.random.seed(seed)
     image = (np.random.randn(width, height, 3) * 255).astype(np.uint8)
     image = Image.fromarray(image, mode='RGB')
     return image
+
+def _json_prediction():
+    return {
+        'string': 'Hello World',
+        'int': 1,
+        'float': 0.5,
+    }
 
 def _generate_video(
     out_file, 

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -93,7 +93,7 @@ class TestDownload(unittest.TestCase):
             with open(file.name, 'w') as f:
                 json.dump(original, f)
             response = download.download_prediction_file(file.name)
-            assert _dicts_equal(response, original)
+            self.assertDictEqual(response, original)
 
     def test_download_image_with_session(self):
         session = MockedRequestsModule.Session()
@@ -298,10 +298,6 @@ def _images_equal(image1, image2):
     # note that images saved and loaded from disk must
     # use a lossless format, otherwise this equality will not hold
     return np.all(np.array(image1) == np.array(image2))
-
-def _dicts_equal(x, y):
-    shared_items = {k: x[k] for k in x if k in y and x[k] == y[k]}
-    return len(x) == len(shared_items) and len(y) == len(shared_items)
 
 def _pil_image(width=100, height=50, seed=0):
     np.random.seed(seed)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -421,6 +421,10 @@ class MockedDatasourcesApi(DatasourcesApi):
         )    
 
 
+    def get_prediction_file_read_url_from_datasource_by_dataset_id(self):
+        return 'https://my-read-url.com'
+
+
     def update_datasource_by_dataset_id(
         self, body: DatasourceConfig, dataset_id: str, **kwargs
     ) -> None:

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -421,7 +421,7 @@ class MockedDatasourcesApi(DatasourcesApi):
         )    
 
 
-    def get_prediction_file_read_url_from_datasource_by_dataset_id(self):
+    def get_prediction_file_read_url_from_datasource_by_dataset_id(self, *args, **kwargs):
         return 'https://my-read-url.com'
 
 

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -1,3 +1,4 @@
+from multiprocessing.sharedctypes import Value
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -55,3 +55,8 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
         predictions = self.api_workflow_client.download_raw_predictions('test')
         num_samples = self.api_workflow_client._datasources_api._num_samples
         assert len(predictions) == num_samples
+
+    def test_get_prediction_read_url(self):
+        self.api_workflow_client._datasources_api.reset()
+        read_url = self.api_workflow_client.get_prediction_read_url('test.json')
+        self.assertIsNotNone(read_url)

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -49,3 +49,9 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
         new_samples = self.api_workflow_client.download_new_raw_samples()
         assert len(samples) == len(new_samples)
         assert set(samples) == set(new_samples)
+
+    def test_download_raw_samples_predictions(self):
+        self.api_workflow_client._datasources_api.reset()
+        predictions = self.api_workflow_client.download_raw_predictions('test')
+        num_samples = self.api_workflow_client._datasources_api._num_samples
+        assert len(predictions) == num_samples

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -1,4 +1,3 @@
-from multiprocessing.sharedctypes import Value
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -1,12 +1,13 @@
 import csv
 import sys
+import json
 import tempfile
 import unittest
 
 import numpy as np
 
 from lightly.utils import save_custom_metadata
-from lightly.utils.io import check_filenames, save_embeddings, check_embeddings
+from lightly.utils.io import check_filenames, save_embeddings, check_embeddings, save_tasks, save_schema
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
 
 
@@ -100,4 +101,54 @@ class TestEmbeddingsIO(unittest.TestCase):
             for row_read, row_original in zip(csv_reader, rows):
                 self.assertListEqual(row_read, row_original[:-2])
 
+    def test_save_tasks(self):
+        tasks = [
+            'task1',
+            'task2',
+            'task3',
+        ]
+        with tempfile.NamedTemporaryFile(suffix='.json') as file:
+            save_tasks(file.name, tasks)
+            with open(file.name, 'r') as f:
+                loaded = json.load(f)
+        self.assertListEqual(tasks, loaded)
 
+    def test_save_schema(self):
+        description = 'classification'
+        ids = [1, 2, 3, 4]
+        names = ['name1', 'name2', 'name3', 'name4']
+        expected_format = {
+            'task_description': 'classification',
+            'categories': [
+                {
+                    'id': 1,
+                    'name': 'name1'
+                },
+                {
+                    'id': 2,
+                    'name': 'name2'
+                },
+                {
+                    'id': 3,
+                    'name': 'name3'
+                },
+                {
+                    'id': 4,
+                    'name': 'name4'
+                },
+            ]
+        }
+        with tempfile.NamedTemporaryFile(suffix='.json') as file:
+            save_schema(file.name, description, ids, names)
+            with open(file.name, 'r') as f:
+                loaded = json.load(f)
+        self.assertListEqual(sorted(expected_format), sorted(loaded))
+
+    def test_save_schema_different(self):
+        with self.assertRaises(ValueError):
+            save_schema(
+                'name_doesnt_matter',
+                'description_doesnt_matter',
+                [1, 2],
+                ['name1'],
+            )


### PR DESCRIPTION
# add predictions utilities

Adds utilities to download predictions from a configured datasource, namely:
- `get_prediction_read_url`
- `download_raw_predictions`
- `download_prediction_file`