### PR TITLE
Igor lig 747 document compute worker changes in lig

### DIFF
--- a/docs/source/docker/configuration/configuration.rst
+++ b/docs/source/docker/configuration/configuration.rst
@@ -138,6 +138,9 @@ The following are parameters which can be passed to the container:
   # to False if you observe slow report generation or work with many videos (>20).
   show_video_sampling_timeline: True
 
+  # optional deterministic unique output subdirectory for run, in place of timestamp
+  run_directory:
+
 Additionally, you can pass all arguments which can be passed to the lightly CLI tool with the `lightly` prefix.
 For example,
 

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -112,6 +112,22 @@ Now, let's see how this will look in action!
              path after the **:** since this path is describing the internal
              file system within the container!
 
+When running the above docker command you will find a new folder with the current date
+and time in the {OUTPUT_DIR} folder. This can be inconvenient if you want to run the docker
+in an automated pipeline as the current date and time change.
+
+Using the **run_directory** parameter you can use a custom and deterministic output folder.
+The following docker run command would for example store the output in the 
+*docker_out* folder.
+
+.. code-block:: console
+
+    docker run --gpus all --rm -it \
+        -v {INPUT_DIR}:/home/input_dir:ro \
+        -v {OUTPUT_DIR}:/home/output_dir \
+        lightly/sampling:latest \
+        token=MYAWESOMETOKEN \
+        run_directory="docker_out"
 
 Specify Relevant Files
 ----------------------------

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -118,7 +118,7 @@ in an automated pipeline as the current date and time change.
 
 Using the **run_directory** parameter you can use a custom and deterministic output folder.
 The following docker run command would for example store the output in the 
-*docker_out* folder.
+*{OUTPUT_DIR}/docker_out* folder.
 
 .. code-block:: console
 


### PR DESCRIPTION
## Changes

- add documentation for specifying the output directory using the `run_directory` argument