### PR TITLE
LIG-673: ApiWorkflowClient can receive LIGHTLY_TOKEN env variable

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -81,6 +81,10 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         configuration.host = getenv('LIGHTLY_SERVER_LOCATION', 'https://api.lightly.ai')
         if token is None:
             token = getenv('LIGHTLY_TOKEN', None)
+            if token is None:
+                raise ValueError(f"Either provide a 'token' argument or export"
+                                 f" a LIGHTLY_TOKEN environment variable")
+                
         configuration.api_key = {'token': token}
         api_client = ApiClient(configuration=configuration)
         self.api_client = api_client

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -73,12 +73,14 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             but used by a workflow, the newest embedding is taken by default
     """
 
-    def __init__(self, token: str, dataset_id: str = None, embedding_id: str = None):
+    def __init__(self, token: str = None, dataset_id: str = None, embedding_id: str = None):
 
         self.check_version_compatibility()
 
         configuration = Configuration()
         configuration.host = getenv('LIGHTLY_SERVER_LOCATION', 'https://api.lightly.ai')
+        if token is None:
+            token = getenv('LIGHTLY_TOKEN', None)
         configuration.api_key = {'token': token}
         api_client = ApiClient(configuration=configuration)
         self.api_client = api_client

--- a/tests/api_workflow/test_api_workflow.py
+++ b/tests/api_workflow/test_api_workflow.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os
 
 import lightly
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowClient, MockedApiWorkflowSetup
@@ -9,6 +10,15 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
     def setUp(self) -> None:
         lightly.api.api_workflow_client.__version__ = lightly.__version__
         self.api_workflow_client = MockedApiWorkflowClient(token="token_xyz")
+
+    def test_init_with_env_token(self):
+        os.environ["LIGHTLY_TOKEN"] = "token_xyz"
+        MockedApiWorkflowClient()
+        del os.environ["LIGHTLY_TOKEN"]
+
+    def test_error_if_init_without_token(self):
+        with self.assertRaises(ValueError):
+            MockedApiWorkflowClient()
 
     def test_error_if_version_is_incompatible(self):
         lightly.api.api_workflow_client.__version__ = "0.0.0"


### PR DESCRIPTION

- ApiWorkflowClient can be initialized with or without a token argument (alternative: LIGHTLY_TOKEN can be provided)