### PR TITLE
Malte lig 890 fix docs creation with html noplot

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,11 +3,11 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS     			?=
-SPHINXBUILD    			?= sphinx-build
-SOURCEDIR      			= source
-BUILDDIR       			= build
-DATADIR	       			= _data
+SPHINXOPTS	 			?=
+SPHINXBUILD				?= sphinx-build
+SOURCEDIR	  			= source
+BUILDDIR	   			= build
+DATADIR		   			= _data
 PACKAGESOURCE  			= source/tutorials_source/package
 PLATFORMSOURCE 			= source/tutorials_source/platform
 DOCKERSOURCE   			= source/docker
@@ -20,7 +20,7 @@ DATADIR_CIFAR10 = /datasets/cifar10
 # Missing dataset: Sentinel dataset is private
 # Missing dataset: vin big data (https://github.com/vinbigdata-medical/vindr-cxr)
 
-ZIPOPTS        ?= -qo
+ZIPOPTS		?= -qo
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -37,7 +37,37 @@ help:
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
-download:
+download-noplot:
+	mkdir -p $(GETTING_STARTED_IMAGES)
+
+	# download resources for s3 integration
+	wget -N https://storage.googleapis.com/datasets_boris/resources_s3_integration.zip -P $(DATADIR);\
+	unzip $(ZIPOPTS) $(DATADIR)/resources_s3_integration.zip  -d $(GETTING_STARTED_IMAGES);\
+
+	# download resources for azure integration
+	wget -N https://storage.googleapis.com/datasets_boris/resources_azure_integration.zip -P $(DATADIR);\
+	unzip $(ZIPOPTS) $(DATADIR)/resources_azure_integration.zip -d $(GETTING_STARTED_IMAGES);\
+
+	# download images and report for docker
+	wget -N https://storage.googleapis.com/datasets_boris/resources.zip -P $(DATADIR);\
+	unzip $(ZIPOPTS) $(DATADIR)/resources.zip  -d $(DOCKERSOURCE);\
+
+	# pizza dataset
+	@if [ ! -d $(PLATFORMSOURCE)/pizzas/salami ]; then \
+		wget -N https://storage.googleapis.com/datasets_boris/pizzas.zip -P $(DATADIR);\
+		unzip $(ZIPOPTS) $(DATADIR)/pizzas.zip  -d $(PLATFORMSOURCE);\
+		mkdir -p $(PLATFORMSOURCE)/pizzas/margherita;\
+		mkdir -p $(PLATFORMSOURCE)/pizzas/salami;\
+		mv $(PLATFORMSOURCE)/pizzas/margherita*.jpg $(PLATFORMSOURCE)/pizzas/margherita;\
+		mv $(PLATFORMSOURCE)/pizzas/salami*.jpg $(PLATFORMSOURCE)/pizzas/salami;\
+	fi
+
+	# sunflowers dataset
+	@if [ ! -f $(DATADIR)/Sunflowers.zip ]; then \
+		wget -N https://storage.googleapis.com/datasets_boris/Sunflowers.zip -P $(DATADIR);\
+	fi
+
+download: download-noplot
 	# inspired by https://github.com/pytorch/tutorials/blob/master/Makefile
 	echo "start downloading datasets..."
 	mkdir -p $(DATADIR)
@@ -61,25 +91,6 @@ download:
 		tar -xf $(DATADIR)/cifar10.tar -C $(DATADIR_CIFAR10);\
 		mv $(DATADIR_CIFAR10)/cifar10/** $(DATADIR_CIFAR10)/;\
 		rm -d $(DATADIR_CIFAR10)/cifar10;\
-	fi
-
-	# download resources for s3 integration
-	@if [ ! -d $(GETTING_STARTED_IMAGES)/resources_s3_integration ]; then \
-		mkdir -p $(GETTING_STARTED_IMAGES);\
-		wget -N https://storage.googleapis.com/datasets_boris/resources_s3_integration.zip -P $(DATADIR);\
-		unzip $(ZIPOPTS) $(DATADIR)/resources_s3_integration.zip  -d $(GETTING_STARTED_IMAGES);\
-	fi
-
-	# download resources for azure integration
-	@if [ ! -d $(GETTING_STARTED_IMAGES)/resources_azure_integration ]; then \
-		wget -N https://storage.googleapis.com/datasets_boris/resources_azure_integration.zip -P $(DATADIR);\
-		unzip $(ZIPOPTS) $(DATADIR)/resources_azure_integration.zip -d $(GETTING_STARTED_IMAGES);\
-	fi
-
-	# download images and report for docker
-	if [ ! -d $(DOCKERSOURCE)/resources ]; then \
-		wget -N https://storage.googleapis.com/datasets_boris/resources.zip -P $(DATADIR);\
-		unzip $(ZIPOPTS) $(DATADIR)/resources.zip  -d $(DOCKERSOURCE);\
 	fi
 
 clean-tutorials:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,12 +41,16 @@ download-noplot:
 	mkdir -p $(GETTING_STARTED_IMAGES)
 
 	# download resources for s3 integration
-	wget -N https://storage.googleapis.com/datasets_boris/resources_s3_integration.zip -P $(DATADIR);\
-	unzip $(ZIPOPTS) $(DATADIR)/resources_s3_integration.zip  -d $(GETTING_STARTED_IMAGES);\
+	wget -N https://storage.googleapis.com/datasets_boris/resources_s3_integration.zip -P $(DATADIR)
+	unzip $(ZIPOPTS) $(DATADIR)/resources_s3_integration.zip  -d $(GETTING_STARTED_IMAGES)
 
 	# download resources for azure integration
-	wget -N https://storage.googleapis.com/datasets_boris/resources_azure_integration.zip -P $(DATADIR);\
-	unzip $(ZIPOPTS) $(DATADIR)/resources_azure_integration.zip -d $(GETTING_STARTED_IMAGES);\
+	wget -N https://storage.googleapis.com/datasets_boris/resources_azure_integration.zip -P $(DATADIR)
+	unzip $(ZIPOPTS) $(DATADIR)/resources_azure_integration.zip -d $(GETTING_STARTED_IMAGES)
+	@if [ -d $(GETTING_STARTED_IMAGES)/resources ]; then \
+		mv $(GETTING_STARTED_IMAGES)/resources/* $(GETTING_STARTED_IMAGES)/;\
+		rm -R $(GETTING_STARTED_IMAGES)/resources/;\
+	fi
 
 	# download images and report for docker
 	wget -N https://storage.googleapis.com/datasets_boris/resources.zip -P $(DATADIR);\
@@ -97,7 +101,11 @@ clean-tutorials:
 	rm -fr source/tutorials/package
 	rm -fr source/tutorials/platform
 	rm -fr $(PLATFORMSOURCE)/lightning_logs
+	rm -fr $(PLATFORMSOURCE)/data
+	rm -fr $(PLATFORMSOURCE)/pizzas
 	rm -fr $(DOCKERSOURCE)/resources
+	rm -fr $(GETTING_STARTED_IMAGES)
 
 clean-all: clean-tutorials
 	rm -fr $(DATADIR)
+	rm -fr build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -34,9 +34,11 @@ help:
 	make download
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -v
 
+# Build the docs without running the python tutorials
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"
 
+# Download the datasets and images needed for html-noplot
 download-noplot:
 	mkdir -p $(GETTING_STARTED_IMAGES)
 
@@ -71,6 +73,7 @@ download-noplot:
 		wget -N https://storage.googleapis.com/datasets_boris/Sunflowers.zip -P $(DATADIR);\
 	fi
 
+# Download also the datasets needed for the tutorials
 download: download-noplot
 	# inspired by https://github.com/pytorch/tutorials/blob/master/Makefile
 	echo "start downloading datasets..."

--- a/docs/source/docker/integration/docker_trigger_from_api.rst
+++ b/docs/source/docker/integration/docker_trigger_from_api.rst
@@ -209,9 +209,6 @@ export it for labeling. In our case we come to the conclusion that the raw data
 we have does not cover enough cases and thus decide that we want to first 
 collect more street videos.
 
-
-.. _ref-docker-with-datasource-datapool:
-
 Process new data in your S3 bucket using a datapool
 ------------------------------------------------------
 You probably get new raw data from time to time added to your S3 bucket. In our 

--- a/docs/source/docker/integration/docker_trigger_from_api.rst
+++ b/docs/source/docker/integration/docker_trigger_from_api.rst
@@ -71,10 +71,9 @@ provided through our Web App or you can use our Python package and build a scrip
       configured to use the data in your AWS S3 bucket. Create such a dataset in 2 steps:
 
       1. `Create a new dataset <https://app.lightly.ai/dataset/create>`_ in Lightly.
-        Make sure that you choose the input type `Images` or `Videos` correctly,
-        depending on the type of files in your cloud storage bucket.
+         Make sure that you choose the input type `Images` or `Videos` correctly, depending on the type of files in your cloud storage bucket.
       2. Edit your dataset, select the storage source as your datasource and fill out the form.
-        In our example we use an S3 bucket.
+         In our example we use an S3 bucket.
 
           .. figure:: ../../getting_started/resources/LightlyEdit2.png
               :align: center
@@ -110,8 +109,6 @@ And now we can schedule a new job.
       .. image:: images/schedule-compute-run-config.png
 
       In our example we use the following parameters.
-
-
 
       .. code-block:: javascript
         :caption: Docker Config

--- a/docs/source/docker/integration/docker_with_datasource.rst
+++ b/docs/source/docker/integration/docker_with_datasource.rst
@@ -110,8 +110,10 @@ does not cover enough cases and thus
 decide that we want to first collect more street videos.
 
 .. _ref-docker-with-datasource-datapool:
+
 Process new data in your S3 bucket using a datapool
 ---------------------------------------------------
+
 You probably get new raw data from time to time added to your S3 bucket.
 In our case we added 4 more street videos to the S3 bucket.
 The new raw data might include samples which should be added to your dataset


### PR DESCRIPTION
closes https://linear.app/lightly/issue/LIG-890/fix-docs-creation-with-html-noplot


## Description
After various fixes, only 3 errors are left:
```
/Users/malteebnerlightly/Documents/GitHub/lightly/docs/source/tutorials/platform/tutorial_active_learning_detectron2.rst:35: WARNING: image file not readable: tutorials/platform/images/sphx_glr_tutorial_active_learning_detectron2_003.png
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] tutorials/platform/tutorial_active_learning_detectron2                                                                                                                                         
/Users/malteebnerlightly/Documents/GitHub/lightly/docs/source/tutorials/platform/index.rst:64: WARNING: Failed to create a cross reference. A title or caption not found: sphx_glr_tutorials_platform_tutorial_aquarium_custom_metadata.py
/Users/malteebnerlightly/Documents/GitHub/lightly/docs/source/tutorials/platform/index.rst:106: WARNING: Failed to create a cross reference. A title or caption not found: sphx_glr_tutorials_platform_tutorial_pizza_filter.py
```
They only occur when running `make html-noplot` and having no cache. The tutorials generate images (in python code) which are referenced by the non-python code also needed with `make html-noplot`.

## Changes in makefile
- added download of pizza and sunflowers back again
- separated download for `make html-noplot` and for full tutorials
- added more to be deleted by `make clean` 

## New appearance of docker trigger from api
![image](https://user-images.githubusercontent.com/20324507/159890423-ed28804d-0e76-4bfd-a67d-8aff20497a1c.jpeg)









