### PR TITLE
Philipp add api methods to download json files

### DIFF
--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -1,18 +1,12 @@
-import warnings
-from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Union
+from typing import Dict, List
 import io
 import os
 import tqdm
 from urllib.request import Request, urlopen
 from PIL import Image
 
-from lightly.openapi_generated.swagger_client import TagCreator
-from lightly.openapi_generated.swagger_client.models.sample_create_request import SampleCreateRequest
 from lightly.api.bitmask import BitMask
-from lightly.openapi_generated.swagger_client.models.initial_tag_create_request import InitialTagCreateRequest
 from lightly.openapi_generated.swagger_client.models.image_type import ImageType
-from lightly.data.dataset import LightlyDataset
 
 
 
@@ -110,3 +104,107 @@ class _DownloadDatasetMixin:
 
             if verbose:
                 pbar.update(1)
+
+    def export_label_studio_tasks_by_tag_id(
+        self,
+        tag_id: str,
+    ) -> List[Dict]:
+        """Exports samples in a format compatible with Label Studio.
+
+        The format is documented here:
+        https://labelstud.io/guide/tasks.html#Basic-Label-Studio-JSON-format
+
+        Args:
+            tag_id:
+                Id of the tag which should exported.
+
+        Returns:
+            A list of dictionaries in a format compatible with Label Studio.
+
+        """
+        label_studio_tasks = self._tags_api.export_tag_to_label_studio_tasks(
+            self.dataset_id,
+            tag_id
+        )
+        return label_studio_tasks
+
+    def export_label_studio_tasks_by_tag_name(
+        self,
+        tag_name: str,
+    ) -> List[Dict]:
+        """Exports samples in a format compatible with Label Studio.
+
+        The format is documented here:
+        https://labelstud.io/guide/tasks.html#Basic-Label-Studio-JSON-format
+
+        Args:
+            tag_name:
+                Name of the tag which should exported.
+
+        Returns:
+            A list of dictionaries in a format compatible with Label Studio.
+
+        Examples:
+            >>> # write json file which can be imported in Label Studio
+            >>> tasks = client.export_label_studio_tasks_by_tag_name(
+            >>>     'initial-tag'
+            >>> )
+            >>> 
+            >>> with open('my-label-studio-tasks.json', 'w') as f:
+            >>>     json.dump(tasks, f)
+
+        """
+        tag = self.get_tag_by_name(tag_name)
+        return self.export_label_studio_tasks_by_tag_id(tag.id)
+
+    def export_label_box_data_rows_by_tag_id(
+        self,
+        tag_id: str,
+    ) -> List[Dict]:
+        """Exports samples in a format compatible with Labelbox.
+
+        The format is documented here:
+        https://docs.labelbox.com/docs/images-json
+
+        Args:
+            tag_id:
+                Id of the tag which should exported.
+
+        Returns:
+            A list of dictionaries in a format compatible with Labelbox.
+
+        """
+        label_box_data_rows = self._tags_api.export_tag_to_label_box_data_rows(
+            self.dataset_id,
+            tag_id,
+        )
+        return label_box_data_rows
+
+    def export_label_box_data_rows_by_tag_name(
+        self,
+        tag_name: str,
+    ) -> List[Dict]:
+        """Exports samples in a format compatible with Labelbox.
+
+        The format is documented here:
+        https://docs.labelbox.com/docs/images-json
+
+        Args:
+            tag_name:
+                Name of the tag which should exported.
+
+        Returns:
+            A list of dictionaries in a format compatible with Labelbox.
+
+        Examples:
+            >>> # write json file which can be imported in Label Studio
+            >>> tasks = client.export_label_box_data_rows_by_tag_name(
+            >>>     'initial-tag'
+            >>> )
+            >>> 
+            >>> with open('my-labelbox-rows.json', 'w') as f:
+            >>>     json.dump(tasks, f)
+
+        """
+        tag = self.get_tag_by_name(tag_name)
+        return self.export_label_box_data_rows_by_tag_id(tag.id)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -209,6 +209,14 @@ class MockedTagsApi(TagsApi):
         # assert that tag is a leaf
         assert all([tag.prev_tag_id != tag_id for tag in tags])
 
+    def export_tag_to_label_studio_tasks(self, dataset_id: str, tag_id: str):
+        return [{'id': 0, 'data': {'image': 'https://api.lightly.ai/v1/datasets/62383ab8f9cb290cd83ab5f9/samples/62383cb7e6a0f29e3f31e213/readurlRedirect?type=full&CENSORED', 'lightlyFileName': '2008_006249_jpg.rf.fdd64460945ca901aa3c7e48ffceea83.jpg', 'lightlyMetaInfo': {'type': 'IMAGE', 'datasetId': '62383ab8f9cb290cd83ab5f9', 'fileName': '2008_006249_jpg.rf.fdd64460945ca901aa3c7e48ffceea83.jpg', 'exif': {}, 'index': 0, 'createdAt': 1647852727873, 'lastModifiedAt': 1647852727873, 'metaData': {'sharpness': 27.31265790443818, 'sizeInBytes': 48224, 'snr': 2.1969673926211217, 'mean': [0.24441662557257224, 0.4460417517905863, 0.6960984853824035], 'shape': [167, 500, 3], 'std': [0.12448681278605961, 0.09509570033043004, 0.0763725998175394], 'sumOfSquares': [6282.243860049413, 17367.702452895475, 40947.22059208768], 'sumOfValues': [20408.78823530978, 37244.486274513954, 58124.22352943069]}}}}]
+
+
+    def export_tag_to_label_box_data_rows(self, dataset_id: str, tag_id: str):
+        return [{'externalId': '2008_007291_jpg.rf.2fca436925b52ea33cf897125a34a2fb.jpg', 'imageUrl': 'https://api.lightly.ai/v1/datasets/62383ab8f9cb290cd83ab5f9/samples/62383cb7e6a0f29e3f31e233/readurlRedirect?type=CENSORED'}]
+
+
 class MockedScoresApi(ScoresApi):
     def create_or_update_active_learning_score_by_tag_id(self, body, dataset_id, tag_id, **kwargs) -> \
             CreateEntityResponse:

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -42,8 +42,12 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
         shutil.rmtree('path-to-dir-remove-me')
 
     def test_export_label_box_data_rows_by_tag_name(self):
-        self.api_workflow_client.export_label_box_data_rows_by_tag_name('initial-tag')
+        rows = self.api_workflow_client.export_label_box_data_rows_by_tag_name('initial-tag')
+        self.assertIsNotNone(rows)
+        self.assertTrue(all(isinstance(row, dict) for row in rows))
 
 
     def test_export_label_studio_tasks_by_tag_name(self):
-        self.api_workflow_client.export_label_studio_tasks_by_tag_name('initial-tag')
+        tasks = self.api_workflow_client.export_label_studio_tasks_by_tag_name('initial-tag')
+        self.assertIsNotNone(tasks)
+        self.assertTrue(all(isinstance(task, dict) for task in tasks))

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -41,6 +41,9 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
         self.api_workflow_client.download_dataset('path-to-dir-remove-me', tag_name='initial-tag')
         shutil.rmtree('path-to-dir-remove-me')
 
+    def test_export_label_box_data_rows_by_tag_name(self):
+        self.api_workflow_client.export_label_box_data_rows_by_tag_name('initial-tag')
 
 
-
+    def test_export_label_studio_tasks_by_tag_name(self):
+        self.api_workflow_client.export_label_studio_tasks_by_tag_name('initial-tag')


### PR DESCRIPTION
# Philipp add api methods to download json files

Allow exporting your dataset to `Labelstudio` or `LabelBox` using the `ApiWorkflowClient`.