### PR TITLE
Malte lig 868 add download video frames subset

### DIFF
--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -366,3 +366,82 @@ def download_prediction_file(
         return None # the file doesn't exist!
 
     return response.json()
+
+def download_video_frames_at_timestamps(
+        url: str,
+        timestamps: List[int],
+        as_pil_image: int = True,
+        thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
+        video_channel: int = 0,
+    ) -> Iterable[Union[PIL.Image.Image, av.VideoFrame]]:
+        """Lazily retrieves frames from a video at a specific timestamp stored at the given url.
+
+        Args:
+            url:
+                The url where video is downloaded from.
+            timestamps:
+                Timestamps in pts from the start of the video. The images
+                at these timestamps are returned.
+                The timestamps must be strictly monotonically ascending.
+                See https://pyav.org/docs/develop/api/time.html#time
+                for details on pts.
+            as_pil_image:
+                Whether to return the frame as PIL.Image.
+            thread_type:
+                Which multithreading method to use for decoding the video.
+                See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
+                for details.
+            video_channel:
+                The video channel from which frames are loaded.
+
+        Returns:
+            A generator that loads and returns a single frame per step.
+
+        """
+        _check_av_available()
+
+        if any(
+                timestamps[i+1] <= timestamps[i]
+                for i
+                in range(len(timestamps) - 1)
+        ):
+            raise ValueError("The timestamps must be sorted "
+                             "strictly monotonically ascending, but are not.")
+        min_timestamp = timestamps[0]
+        max_timestamp = timestamps[-1]
+
+        if min_timestamp < 0:
+            raise ValueError(f"Negative timestamp is not allowed: {min_timestamp}")
+
+        with utils.retry(av.open, url) as container:
+            stream = container.streams.video[video_channel]
+            stream.thread_type = thread_type
+
+            duration = stream.duration
+            start_time = stream.start_time
+            if (duration is not None) and (start_time is not None):
+                end_time = duration + start_time
+                if max_timestamp > end_time:
+                    raise ValueError(
+                        f"Timestamp ({max_timestamp} pts) exceeds maximum video timestamp "
+                        f"({end_time} pts).")
+
+            # seek to last keyframe before the min_timestamp
+            container.seek(min_timestamp, any_frame=False, backward=True,
+                           stream=stream)
+
+            index_timestamp = 0
+            for frame in container.decode(stream):
+                # advance from keyframe until correct timestamp is reached
+                #print(frame.pts)
+                if frame.pts < timestamps[index_timestamp]:
+                    continue
+                # update the timestamp
+                index_timestamp += 1
+                if index_timestamp >= len(timestamps):
+                    break
+                # yield next frame
+                if as_pil_image:
+                    yield frame.to_image()
+                else:
+                    yield frame

--- a/tests/api/benchmark_video_download.py
+++ b/tests/api/benchmark_video_download.py
@@ -10,6 +10,9 @@ from lightly.api.download import download_video_frames_at_timestamps, \
 
 @unittest.skip("Only used for benchmarks")
 class BenchmarkDownloadVideoFrames(unittest.TestCase):
+    """
+    some timings: https://github.com/lightly-ai/lightly/pull/754
+    """
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -17,9 +20,8 @@ class BenchmarkDownloadVideoFrames(unittest.TestCase):
         with av.open(cls.video_url_12min_100mb ) as container:
             stream = container.streams.video[0]
             duration = stream.duration
-            start_time = stream.start_time
-            end_time = start_time + duration
-        cls.timestamps = np.linspace(start_time, end_time, num=1000).astype(int).tolist()
+        # This video has its timestamps 0-based
+        cls.timestamps = np.linspace(0, duration, num=1000).astype(int).tolist()
 
     def setUp(self) -> None:
         self.start_time = time.time()

--- a/tests/api/benchmark_video_download.py
+++ b/tests/api/benchmark_video_download.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from lightly.api.download import download_video_frames_at_timestamps, \
     download_all_video_frames, download_video_frame
 
-#@unittest.skip("Only used for benchmarks")
+@unittest.skip("Only used for benchmarks")
 class BenchmarkDownloadVideoFrames(unittest.TestCase):
 
     @classmethod

--- a/tests/api/benchmark_video_download.py
+++ b/tests/api/benchmark_video_download.py
@@ -1,0 +1,58 @@
+import time
+import unittest
+
+import av
+import numpy as np
+from tqdm import tqdm
+
+from lightly.api.download import download_video_frames_at_timestamps, \
+    download_all_video_frames, download_video_frame
+
+#@unittest.skip("Only used for benchmarks")
+class BenchmarkDownloadVideoFrames(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.video_url_12min_100mb = "https://mediandr-a.akamaihd.net/progressive/2018/0912/TV-20180912-1628-0000.ln.mp4"
+        with av.open(cls.video_url_12min_100mb ) as container:
+            stream = container.streams.video[0]
+            duration = stream.duration
+            start_time = stream.start_time
+            end_time = start_time + duration
+        cls.timestamps = np.linspace(start_time, end_time, num=1000).astype(int).tolist()
+
+    def setUp(self) -> None:
+        self.start_time = time.time()
+
+    def test_download_full(self):
+        all_video_frames = download_all_video_frames(self.video_url_12min_100mb)
+        for i, frame in enumerate(tqdm(all_video_frames)):
+            pass
+
+    # Takes very long for many frames, but is very quick for little frames
+    # The reason is that
+    # - every function call has quite some overhead
+    # - as many frames are skipped by the seek, this only reads a little number of frames per function call.
+    def test_download_at_timestamps_for_loop(self):
+        for timestamp in tqdm(self.timestamps):
+            frame = download_video_frame(self.video_url_12min_100mb, timestamp)
+
+    def test_download_at_timestamps(self):
+        frames = download_video_frames_at_timestamps(self.video_url_12min_100mb, self.timestamps)
+        frames = list(tqdm(frames, total=len(self.timestamps)))
+
+    # Takes long as it downloads the whole video first
+    # Takes long, as it access the frames even at random locations, similar to
+    # downloading specific frame in a for loop.
+    def test_download_at_indices_decord(self):
+        """
+        See https://github.com/dmlc/decord/issues/199
+        """
+        import decord
+        vr = decord.VideoReader(self.video_url_12min_100mb)
+        decord.bridge.set_bridge('torch')
+        print(f"Took {time.time() - self.start_time}s for creating the video reader.")
+        frames = vr.get_batch(list(range(0, 18000, 18)))
+
+    def tearDown(self) -> None:
+        print(f"Took {time.time()-self.start_time}s")

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -112,6 +112,18 @@ class TestDownload(unittest.TestCase):
                 assert _images_equal(frame, orig)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
+    def test_download_video_frames_at_timestamps(self):
+        with tempfile.NamedTemporaryFile(suffix='.avi') as file:
+            original = _generate_video(file.name, n_frames=20)
+            timestamps = list(range(2, len(original) - 1, 2))
+            frames = list(download.download_video_frames_at_timestamps(
+                file.name, timestamps
+            ))
+            for frame, timestamp in zip(frames, sorted(timestamps)):
+                orig = original[timestamp]
+                assert _images_equal(frame, orig)
+
+    @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_all_video_frames_restart_throws(self):
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
             original = _generate_video(file.name)

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -112,6 +112,19 @@ class TestDownload(unittest.TestCase):
                 assert _images_equal(frame, orig)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
+    def test_download_last_video_frame(self):
+        with tempfile.NamedTemporaryFile(suffix='.avi') as file:
+            n_frames = 5
+            original = _generate_video(file.name, n_frames=n_frames)
+            timestamps = list(range(n_frames+1))
+            for timestamp in timestamps:
+                with self.subTest(timestamp=timestamp):
+                    if timestamp > n_frames:
+                        with self.assertRaises(ValueError):
+                            frame = download.download_video_frame(file.name, timestamp)
+                    frame = download.download_video_frame(file.name, timestamp)
+
+    @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_video_frames_at_timestamps(self):
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
             n_frames = 5
@@ -136,6 +149,14 @@ class TestDownload(unittest.TestCase):
                 frames = list(download.download_video_frames_at_timestamps(
                     file.name, timestamps
                 ))
+
+    @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
+    def test_download_video_frames_at_timestamps_emtpy(self):
+        with tempfile.NamedTemporaryFile(suffix='.avi') as file:
+            frames = list(download.download_video_frames_at_timestamps(
+                    file.name, timestamps=[]
+                ))
+            self.assertEqual(len(frames), 0)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_all_video_frames_restart_throws(self):

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -128,6 +128,16 @@ class TestDownload(unittest.TestCase):
                 assert _images_equal(frame, orig)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
+    def test_download_video_frames_at_timestamps_wrong_order(self):
+        with tempfile.NamedTemporaryFile(suffix='.avi') as file:
+            original = _generate_video(file.name)
+            timestamps = [2, 1]
+            with self.assertRaises(ValueError):
+                frames = list(download.download_video_frames_at_timestamps(
+                    file.name, timestamps
+                ))
+
+    @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_all_video_frames_restart_throws(self):
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
             original = _generate_video(file.name)

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -114,12 +114,16 @@ class TestDownload(unittest.TestCase):
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_video_frames_at_timestamps(self):
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
-            original = _generate_video(file.name, n_frames=20)
-            timestamps = list(range(2, len(original) - 1, 2))
+            n_frames = 5
+            original = _generate_video(file.name, n_frames=n_frames)
+            original_timestamps = list(range(1, n_frames+1))
+            frame_indices = list(range(2, len(original) - 1, 2))
+            timestamps = [original_timestamps[i] for i in frame_indices]
             frames = list(download.download_video_frames_at_timestamps(
                 file.name, timestamps
             ))
-            for frame, timestamp in zip(frames, sorted(timestamps)):
+            self.assertEqual(len(frames), len(timestamps))
+            for frame, timestamp in zip(frames, frame_indices):
                 orig = original[timestamp]
                 assert _images_equal(frame, orig)
 


### PR DESCRIPTION
## Description
- Created the function `download_video_frames_at_timestamps` return a generator over frames as specified timestamps.
- Wrote a unittest for it.
- Wrote a skipped unittest class for benchmarking the different download options.

## Timings 
- with 100Mbit Internet connection
- video has 18k frames, 116 MB, 12min length, 25fps

#### with 5 frames equally distributed
- test_download_full: 18s, 1000 iterations per second
- test_download_at_timestamps_for_loop: 3.6s, 1.3 iterations per second
- test_download_at_timestamps: 10.2s, 0.5 iterations per second

#### with 50 frames equally distributed
- test_download_full: 19.4s (should be equal to the other, so this is the measurement variance)
- test_download_at_timestamps_for_loop: 38s, again 1.3 iterations per second
- test_download_at_timestamps: 10.5s, 4.8 iterations per second