### PR TITLE
Speed up and tiny correction in SimSiam

### DIFF
--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -37,7 +37,8 @@ class ProjectionHead(nn.Module):
 
         self.layers = []
         for input_dim, output_dim, batch_norm, non_linearity in blocks:
-            self.layers.append(nn.Linear(input_dim, output_dim))
+            use_bias = not bool(batch_norm)
+            self.layers.append(nn.Linear(input_dim, output_dim, bias=use_bias))
             if batch_norm:
                 self.layers.append(batch_norm)
             if non_linearity:
@@ -196,7 +197,7 @@ class SimSiamProjectionHead(ProjectionHead):
         super(SimSiamProjectionHead, self).__init__([
             (input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()),
             (hidden_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()),
-            (hidden_dim, output_dim, nn.BatchNorm1d(output_dim), None),
+            (hidden_dim, output_dim, nn.BatchNorm1d(output_dim, affine=False), None),
         ])
 
 


### PR DESCRIPTION
## Description
I found two tiny implementation mistakes that I would like to correct if you approve.

1. In the projection heads, there is no need for bias in the Linear layers if followed by BatchNorm. Not only the bias is always shifted to 0 by the BatchNorm one step later, but since the bias keeps changing, the running mean has hard time to capture the real mean of the data. By this change, we should expect a speed up in all trainings which involve the use of projection heads.

2. Regarding SimSiam, I added _affine=False_ to the last BatchNorm of the projection head, because we want to ensure the embeddings have 0 mean. Otherwise, the beta parameter (BatchNorm.bias) can change the mean of the data. I am not exactly sure, but if the mean is not around zero, the training could even collapse to the trivial solution. It's just safe to ensure the data has zero mean.

I hope you find these adjustments useful. I am not very experienced in public contributions, please tell me if I need to add anything else, I am happy to do so.