### PR TITLE
Jeremy lig 741 improve datasource docs

### DIFF
--- a/docs/source/docker/integration/docker_with_datasource.rst
+++ b/docs/source/docker/integration/docker_with_datasource.rst
@@ -16,8 +16,13 @@ the following workloads in one single run:
 - compute the metadata of the images
 - create a dataset in the Lightly Platform from the sampled subset
 
-Support for streaming from Google Cloud Storage and Azure Blob Storage is
-planned. If you need any of these, write us so that we prioritize implementing it.
+Streaming from Google Cloud Storage and Azure Blob Storage is also supported.
+Please follow the
+`Google Cloud Storage <https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_gcloud_bucket.html`_
+ or the
+`Azure Blob Storage <https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_azure_storage.html>`_
+ guide to learn how to setup your bucket and configure a datasource.
+
 
 Advantages
 ----------
@@ -32,6 +37,12 @@ Advantages
   everytime new data comes into your S3 bucket.
 - Your images and videos are never saved anywhere but in your S3 bucket,
   maintaining your privacy and security.
+
+
+.. note:: Please ensure that the region of your bucket and where you intend to be running the
+          Lightly Docker instance should be the same. Traffic is free
+          must not necessarily include the same keys for all images but it is strongly
+          recommended.
 
 
 Requirements

--- a/docs/source/docker/integration/docker_with_datasource.rst
+++ b/docs/source/docker/integration/docker_with_datasource.rst
@@ -16,12 +16,8 @@ the following workloads in one single run:
 - compute the metadata of the images
 - create a dataset in the Lightly Platform from the sampled subset
 
-Streaming from Google Cloud Storage and Azure Blob Storage is also supported.
-Please follow the
-`Google Cloud Storage <https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_gcloud_bucket.html`_
- or the
-`Azure Blob Storage <https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_azure_storage.html>`_
- guide to learn how to setup your bucket and configure a datasource.
+Support for streaming from Google Cloud Storage and Azure Blob Storage is
+planned. If you need any of these, write us so that we prioritize implementing it.
 
 
 Advantages
@@ -43,7 +39,7 @@ Advantages
           Lightly Docker instance should be the same (e.g. `eu-central-1`). If the region is not
           the same there can be
           `degraded transfer speeds and additional costs will be incurred by AWS <https://aws.amazon.com/premiumsupport/knowledge-center/s3-transfer-data-bucket-instance/>`_!
-          We highly recommend using the same region
+          We highly recommend using the same region.
 
 
 Requirements

--- a/docs/source/docker/integration/docker_with_datasource.rst
+++ b/docs/source/docker/integration/docker_with_datasource.rst
@@ -40,9 +40,10 @@ Advantages
 
 
 .. note:: Please ensure that the region of your bucket and where you intend to be running the
-          Lightly Docker instance should be the same. Traffic is free
-          must not necessarily include the same keys for all images but it is strongly
-          recommended.
+          Lightly Docker instance should be the same (e.g. `eu-central-1`). If the region is not
+          the same there can be
+          `degraded transfer speeds and additional costs will be incurred by AWS <https://aws.amazon.com/premiumsupport/knowledge-center/s3-transfer-data-bucket-instance/>`_!
+          We highly recommend using the same region
 
 
 Requirements

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -18,7 +18,7 @@ Let us assume your bucket is called `datalake`. And let us assume the folder you
 **Setting up IAM**
 
 1. Go to the `Identity and Access Management IAM page <https://console.aws.amazon.com/iamv2/home?#/users>`_ and create a new user for Lightly.
-2. Choose a unique name of your choice and select "Programmatic access" as "Access type". Click next
+2. Choose a unique name of your choice and select **"Programmatic access"** as **"Access type"**. Click next
     
     .. figure:: ../resources/AWSCreateUser2.png
         :align: center
@@ -26,7 +26,7 @@ Let us assume your bucket is called `datalake`. And let us assume the folder you
 
         Create AWS User
 
-3. We will want to create very restrictive permissions for this new user so that it can't access other resources of your company. Click on "Attach existing policies directly" and then on "Create policy". This will bring you to a new page
+3. We will want to create very restrictive permissions for this new user so that it can't access other resources of your company. Click on **"Attach existing policies directly"** and then on **"Create policy"**. This will bring you to a new page
     
     .. figure:: ../resources/AWSCreateUser3.png
         :align: center
@@ -72,7 +72,7 @@ Let us assume your bucket is called `datalake`. And let us assume the folder you
         :alt: Review and name permission policy in AWS
 
         Review and name permission policy in AWS
-6. Return to the previous page as shown in the screenshot below and reload. Now when filtering policies your newly created policy will show up. Select it and continue setting up your new user.
+6. Return to the previous page as shown in the screenshot below and reload. Now when filtering policies, your newly created policy will show up. Select it and continue setting up your new user.
     
     .. figure:: ../resources/AWSCreateUser6.png
         :align: center

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -34,7 +34,7 @@ For the :ref:`lightly-command-line-tool` to be able to create embeddings and ext
  
 1. Install AzCopy cli by following the `guide of Azure <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10>`_
 2. To sync your data from the container to your local machine (or vice versa), you need a shared access token. On your `storage account` page of the Azure portal, on the left, go to **"Security + networking"** > **"Shared access signature"**. Generate a shared access signature (SAS) which allows access to the container and objects.
-3. Copy the `SAS token`` and use the following command to sync the Azure blob storage with your local folder:
+3. Copy the `SAS token` and use the following command to sync the Azure blob storage with your local folder:
 
     .. code-block::
 

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -21,8 +21,9 @@ For the purpose of this guide we assume you have a storage account called `light
 We further assume the container you want to use with lightly is called `farm-animals` and already contains images.
 If you don't have a storage account or container yet follow the instructions `here <https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal>`_.
 
-Go to **"Security + networking"** > **"Shared access signature"**. There, configure the access rights to your liking. Lightly requires at least read and list access to the container. Make sure to
-*also* tick the boxes for the required resource types (Container and Object). Set an expiry date and then click on **"Generate SAS and connection string"**. Copy the generated `SAS token` *including the "?"*
+Go to **"Security + networking"** > **"Shared access signature"**. There, configure the access rights to your liking.
+Lightly requires at least read and list access to the container. Write access is required for thumbnails or when working with videos and object level.
+Make sure to *also* tick the boxes for the required resource types (Container and Object). Set an expiry date and then click on **"Generate SAS and connection string"**. Copy the generated `SAS token` *including the "?"*
 and store it in a secure location. Head to the next section to see how you can configure the Lightly dataset.
 
 
@@ -32,7 +33,7 @@ Preparing your data
 For the :ref:`lightly-command-line-tool` to be able to create embeddings and extract metadata from your data, `lightly-magic` needs to be able to access your data. You can download/sync your data from Azure blob storage.
  
 1. Install AzCopy cli by following the `guide of Azure <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10>`_
-2. To sync your data from the container to your local machine (or vice versa), you need a shared access token. On your `storage account`` page of the Azure portal, on the left, go to **"Security + networking"** > **"Shared access signature"**. Generate a shared access signature (SAS) which allows access to the container and objects.
+2. To sync your data from the container to your local machine (or vice versa), you need a shared access token. On your `storage account` page of the Azure portal, on the left, go to **"Security + networking"** > **"Shared access signature"**. Generate a shared access signature (SAS) which allows access to the container and objects.
 3. Copy the `SAS token`` and use the following command to sync the Azure blob storage with your local folder:
 
     .. code-block::
@@ -54,7 +55,7 @@ Uploading your data
         :align: center
         :alt: Edit your dataset.
 
-        To edit your dataset click the **`Edit`** button on the top.
+        To edit your dataset click the **"Edit"** button on the top.
 
 3. As your container name enter `farm-animals`.
 4. Enter the storage account name and SAS token from the previous step.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -21,8 +21,8 @@ For the purpose of this guide we assume you have a storage account called `light
 We further assume the container you want to use with lightly is called `farm-animals` and already contains images.
 If you don't have a storage account or container yet follow the instructions `here <https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal>`_.
 
-Go to "Security + networking > Shared access signature". There, configure the access rights to your liking. Lightly requires at least read and list access to the container. Make sure to
-also tick the boxes for the required resource types (Container and Object). Set an expiry date and then click on "Generate SAS and connection string". Copy the generated "SAS token" including the "?"
+Go to **"Security + networking"** > **"Shared access signature"**. There, configure the access rights to your liking. Lightly requires at least read and list access to the container. Make sure to
+*also* tick the boxes for the required resource types (Container and Object). Set an expiry date and then click on **"Generate SAS and connection string"**. Copy the generated `SAS token` *including the "?"*
 and store it in a secure location. Head to the next section to see how you can configure the Lightly dataset.
 
 
@@ -32,8 +32,8 @@ Preparing your data
 For the :ref:`lightly-command-line-tool` to be able to create embeddings and extract metadata from your data, `lightly-magic` needs to be able to access your data. You can download/sync your data from Azure blob storage.
  
 1. Install AzCopy cli by following the `guide of Azure <https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10>`_
-2. To sync your data from the container to your local machine (or vice versa), you need a shared access token. On your *storage account* page of the Azure portal, on the left, go to "Security + networking > Shared access signature". Generate a shared access signature (SAS) which allows access to the container and objects.
-3. Copy the SAS token and use the following command to sync the Azure blob storage with your local folder:
+2. To sync your data from the container to your local machine (or vice versa), you need a shared access token. On your `storage account`` page of the Azure portal, on the left, go to **"Security + networking"** > **"Shared access signature"**. Generate a shared access signature (SAS) which allows access to the container and objects.
+3. Copy the `SAS token`` and use the following command to sync the Azure blob storage with your local folder:
 
     .. code-block::
 
@@ -54,7 +54,7 @@ Uploading your data
         :align: center
         :alt: Edit your dataset.
 
-        To edit your dataset click the `Edit` button on the top.
+        To edit your dataset click the **`Edit`** button on the top.
 
 3. As your container name enter `farm-animals`.
 4. Enter the storage account name and SAS token from the previous step.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -69,7 +69,7 @@ If it is not, change it to uniform.
 
 - Create a new role, with the same title and ID.
   E.g. call it `LIGHTLY_DATASET_ACCESS`.
-- Click on `Add Permissions`, search for `storage.objects`
+- Click on **"Add Permissions"**, search for `storage.objects`
 - Add the permissions `storage.objects.get`, `storage.objects.list`, and `storage.objects.create`.
   The create permissions are needed if you want Lightly to create thumbnails
   in your bucket . Otherwise you can leave them away.
@@ -82,14 +82,14 @@ If it is not, change it to uniform.
 
 5. Navigate to `APIs -> Credentials <https://console.cloud.google.com/apis/credentials>`_.
 
-- Click on `Create Credentials`, choose `Service Account` and insert the name
+- Click on **"Create Credentials"**, choose `Service Account` and insert the name
   `LIGHTLY_USER_WILD_ANIMALS`.
 - The description can be `service account for the Lightly API to access the wild animals dataset`.
-- Click on `Create and Continue`.
+- Click on **"Create and Continue"**.
 - Choose the Role you just created, i.e. `LIGHTLY_DATASET_ACCESS`.
 - Add a condition with the title `BUCKET_PROJECTS_WILD_ANIMALS`
   and insert the condition below in the Condition editor. Remember to change the bucket name
-  and path to the folder. However, you must keep the "objects" inbetween.
+  and path to the folder. However, you must keep the "objects" in between.
 
 .. code::
 
@@ -115,7 +115,7 @@ whose name starts with `projects/wild-animals`.
 
 
 
-- Click on `Done` to create the service account.
+- Click on **"Done"** to create the service account.
 - You can change the roles of the service account later in the
   `IAM <https://console.cloud.google.com/iam-admin/iam>`_.
 
@@ -123,8 +123,8 @@ whose name starts with `projects/wild-animals`.
    again if you are not already there.
 
 - Find the just created user in the list of all service accounts.
-- Click on the user and navigate to the `keys` tab.
-- Click on `Add key` and create a new private key in JSON Format.
+- Click on the user and navigate to the **"keys"** tab.
+- Click on **"Add key"** and create a new private key in JSON Format.
   It will download the corresponding key file.
 
 .. figure:: images_gcloud_bucket/screenshot_gcloud_service_account_key_creation.jpg
@@ -165,7 +165,7 @@ Create and configure a dataset
 
 3. As the resource path, enter the full URI to your resource eg. `gs://lightly-datalake/projects/wild-animals`
 4. Enter the Google Project ID you wrote down in the first step.
-5. Click on `Select Credentials File` to add the key file you downloaded in the previous step.
+5. Click on **"Select Credentials File"** to add the key file you downloaded in the previous step.
 6. The thumbnail suffix depends on the option you chose in the first step
 
 - You want Lightly to create the thumbnail for you.


### PR DESCRIPTION
closes lig-741
closes lig-871
- highlight important "click" parts of the datasource documentations
- correct statement that streaming is only possible with S3 and link to GCS and Azure docs
- add note that instance and bucket should be in the same region