### PR TITLE
Philipp add second datasource option docs

### DIFF
--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -121,31 +121,25 @@ Create and configure a dataset
    depending on the type of files in your S3 bucket.
 2. Edit your dataset and select S3 as your datasource
 
-    .. figure:: ../resources/LightlyEdit1.png
-        :align: center
-        :alt: Edit your dataset.
-
-
-3. As the resource path, enter the full S3 URI to your resource eg. `s3://datalake/projects/farm-animals/`
-4. Enter the `access key` and the `secret access key` we obtained from creating a new user in the previous step and select the AWS region in which you created your bucket in
-5. The thumbnail suffix allows you to configure
-   
-    - where your thumbnails are stored when you already have generated thumbnails in your S3 bucket
-    - where your thumbnails will be stored when you want Lightly to create thumbnails for you. For this to work, the user policy you have created must possess write permissions.
-    - when the thumbnail suffix is not defined/empty, we will load the full image even when requesting the thumbnail.
-    
-    .. figure:: ../resources/LightlyEdit2.png
+    .. figure:: ../resources/resources_datasource_configure/LightlyEditAWS.jpg
         :align: center
         :alt: Lightly S3 connection config
         :width: 60%
 
         Lightly S3 connection config
 
-6. Press save and ensure that at least the lights for List and Read turn green.
 
+3. As the resource path, enter the full S3 URI to your resource eg. `s3://datalake/projects/farm-animals/`
+4. Enter the `access key` and the `secret access key` we obtained from creating a new user in the previous step and select the AWS region in which you created your bucket in
+5. Toggle the **"Generate thumbnail"** switch if you want Lightly to generate thumbnails for you.
+6. If you want to store outputs from Lightly (like thumbnails or extracted frames) in a different directory, you can toggle **"Use a different output datasource"** and enter a different path in your bucket. This allows you to keep your input directory clean as nothing gets ever written there.
+  .. note:: 
 
-Use Lightly
+    Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
+7. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
+
 Use `lightly-magic` and `lightly-upload` just as you always would with the following considerations;
 
-- If you already have generated thumbnails, don't want to see thumbnails or just want to use the full image for a thumbnail (by setting the thumbnail suffix to empty), add `upload=metadata` to the `lightly-magic` command.
-- If you want Lightly to create thumbnails for you, you can add `upload=thumbnails` to the `lightly-magic` command.
+- Use `input_dir=datalake/farm-animals`
+- If you chose the option to generate thumbnails in your bucket, use the argument `upload=thumbnails`
+- Otherwise, use `upload=metadata` instead.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -69,8 +69,6 @@ Uploading your data
     Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
 7. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
 
-8. Press save and ensure that all lights turn green.
-
 
 To add the images to the dataset use `lightly-magic` or `lightly-upload` with the following parameters:
 

--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -8,11 +8,16 @@ Lightly allows you to configure a remote datasource like Microsoft's Azure blob 
 In this guide, we will show you how to setup your Azure blob storage container and configure your dataset to use said container.
 
 One decision you need to make first is whether you want to use thumbnails.
-Using thumbnails makes the Lightly Platform more responsive, as it's enough to
-load the thumbnails instead of the full images in many cases.
-As a drawback, the thumbnails will be stored in your bucket and thus need storage.
-Depending on this decision, the following steps will differ slightly.
+Using thumbnails makes the Lightly Platform more responsive, as not always
+the full images will be loaded.
+However, the thumbnails will be stored in your container and thus need storage.
 
+.. note::
+  
+    If you want to use thumbnails you need to give
+    Lightly write access to your container to create the thumbnails there for you.
+    The write access can be configured not to allow overwriting and
+    deleting, thus existing data cannot get lost.
 
 Setting up Azure
 ------------------
@@ -42,40 +47,29 @@ For the :ref:`lightly-command-line-tool` to be able to create embeddings and ext
 
 
 
-
-
-
 Uploading your data
 --------------------
 
 1. `Create a new dataset <https://app.lightly.ai/dataset/create>`_ in Lightly
 2. Edit your dataset and select `Azure Blob Storage` as your datasource
 
-    .. figure:: ../resources/LightlyEdit1.png
-        :align: center
-        :alt: Edit your dataset.
-
-        To edit your dataset click the **"Edit"** button on the top.
-
-3. As your container name enter `farm-animals`.
-4. Enter the storage account name and SAS token from the previous step.
-5. The thumbnail suffix depends on the option you chose in the first step
-   
-    - You want Lightly to create the thumbnail for you.
-      Then choose the naming scheme to your liking.
-    - You have already generated thumbnails in your bucket.
-      Then choose the thumbnail suffix such that it reflects your naming scheme.
-    - You don't want to use thumbnails.
-      Then leave the thumbnail suffix undefined/empty.
-
-    .. figure:: ../resources/LightlyEditAzure.jpg
+    .. figure:: ../resources/resources_datasource_configure/LightlyEditAzure.jpg
         :align: center
         :alt: Lightly Azure Blob Storage config.
         :width: 60%
 
         Lightly Azure Blob Storage config.
 
-6. Press save and ensure that all lights turn green.
+3. As your container name enter `farm-animals`.
+4. Enter the storage account name and SAS token from the previous step.
+5. Toggle the **"Generate thumbnail"** switch if you want Lightly to generate thumbnails for you.
+6. If you want to store outputs from Lightly (like thumbnails or extracted frames) in a different directory, you can toggle **"Use a different output datasource"** and enter a different path in your bucket. This allows you to keep your input directory clean as nothing gets ever written there.
+  .. note:: 
+
+    Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
+7. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
+
+8. Press save and ensure that all lights turn green.
 
 
 To add the images to the dataset use `lightly-magic` or `lightly-upload` with the following parameters:

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -164,8 +164,6 @@ Create and configure a dataset
     Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
 8. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
 
-9. After closing the pop-up by clicking the X, you should be on the dataset creation page again.
-
 
 Use `lightly-magic` and `lightly-upload` with the following parameters:
 

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -12,7 +12,7 @@ while keeping your data private.
 One decision you need to make first is whether you want to use thumbnails.
 Using thumbnails makes the Lightly Platform more responsive, as not always
 the full images will be loaded.
-However, the thumbnails will be stored in you bucket and thus need storage.
+However, the thumbnails will be stored in your bucket and thus need storage.
 
 .. note::
   

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -13,22 +13,13 @@ One decision you need to make first is whether you want to use thumbnails.
 Using thumbnails makes the Lightly Platform more responsive, as not always
 the full images will be loaded.
 However, the thumbnails will be stored in you bucket and thus need storage.
-You have three options:
 
--   You want to use thumbnails, but don't have them yet. Then you need to give
+.. note::
+  
+    If you want to use thumbnails you need to give
     Lightly write access to your bucket to create the thumbnails there for you.
     The write access can be configured not to allow overwriting and
     deleting, thus existing data cannot get lost.
-
--   You already have thumbnails in your bucket with a consistent name scheme, e.g.
-    an image called `img.jpg` has a corresponding thumbnail called `img_thumb.jpg`.
-    In this case, a read access to your bucket is sufficient.
-
--   You don't want to use thumbnails. Then a read access to your bucket
-    is sufficient. The Lightly Platform will load the full image
-    even when requesting the thumbnail.
-
-Depending on this decision, the following steps will differ slightly.
 
 
 Setting up Google Cloud Storage
@@ -157,7 +148,7 @@ Create and configure a dataset
 1. `Create a new dataset <https://app.lightly.ai/dataset/create>`_ in Lightly
 2. Edit your dataset and select `Google Cloud Storage` as your datasource
 
-.. figure:: images_gcloud_bucket/screenshot_gcloud_create_dataset.jpg
+.. figure:: ../resources/resources_datasource_configure/LightlyEditGCS.jpg
     :align: center
     :alt: Configure google cloud bucket datasource in Lightly Platform
     :width: 60%
@@ -166,21 +157,14 @@ Create and configure a dataset
 3. As the resource path, enter the full URI to your resource eg. `gs://lightly-datalake/projects/wild-animals`
 4. Enter the Google Project ID you wrote down in the first step.
 5. Click on **"Select Credentials File"** to add the key file you downloaded in the previous step.
-6. The thumbnail suffix depends on the option you chose in the first step
+6. Toggle the **"Generate thumbnail"** switch if you want Lightly to generate thumbnails for you.
+7. If you want to store outputs from Lightly (like thumbnails or extracted frames) in a different directory, you can toggle **"Use a different output datasource"** and enter a different path in your bucket. This allows you to keep your input directory clean as nothing gets ever written there.
+  .. note:: 
 
-- You want Lightly to create the thumbnail for you.
-  Then choose the naming scheme to your liking.
-- You already have thumbnails in your bucket.
-  Then choose the thumbnail suffix such that it reflects your naming scheme.
-- You don't want to use thumbnails.
-  Then leave the thumbnail suffix undefined/empty.
+    Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
+8. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
 
-
-
-6. Press save and ensure that at least the lights for List and Read turn green.
-If you added permissions for writing, this light should also turn green.
-
-7. After closing the pop-up by clicking the X, you should be on the dataset creation page again.
+9. After closing the pop-up by clicking the X, you should be on the dataset creation page again.
 
 
 Use `lightly-magic` and `lightly-upload` with the following parameters:


### PR DESCRIPTION
# Philipp add second datasource option docs

Update documentation to include information about how to configure an "output" datasource.