### PR TITLE
mark lightly/openapi_generated as generated to prevent it from being shown in a PR review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lightly/openapi_generated linguist-generated=true


### PR DESCRIPTION
Docs: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github