### PR TITLE
add lightly version and platform information to user_agent

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -1,6 +1,7 @@
 import warnings
 from io import IOBase
 from typing import *
+import platform
 
 import requests
 from lightly.api.api_workflow_tags import _TagsMixin
@@ -87,6 +88,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
                 
         configuration.api_key = {'token': token}
         api_client = ApiClient(configuration=configuration)
+        self.user_agent = f"Lightly/{__version__}/python ({platform.platform()})"
         self.api_client = api_client
 
         self.token = token


### PR DESCRIPTION
closes lig-1040
- add lightly version and platform information to the user_agent so that its easier to detect platform issues and pin it to a lightly version