### PR TITLE
Check for non-increasing timestamps

### DIFF
--- a/lightly/data/__init__.py
+++ b/lightly/data/__init__.py
@@ -13,3 +13,4 @@ from lightly.data.collate import MultiCropCollateFunction
 from lightly.data.collate import SwaVCollateFunction
 from lightly.data.collate import imagenet_normalize
 from lightly.data._video import NonIncreasingTimestampError
+from lightly.data._video import UnseekableTimestampError

--- a/lightly/data/__init__.py
+++ b/lightly/data/__init__.py
@@ -12,5 +12,7 @@ from lightly.data.collate import MoCoCollateFunction
 from lightly.data.collate import MultiCropCollateFunction
 from lightly.data.collate import SwaVCollateFunction
 from lightly.data.collate import imagenet_normalize
+from lightly.data._video import VideoError
+from lightly.data._video import EmptyVideoError
 from lightly.data._video import NonIncreasingTimestampError
 from lightly.data._video import UnseekableTimestampError

--- a/lightly/data/__init__.py
+++ b/lightly/data/__init__.py
@@ -12,3 +12,4 @@ from lightly.data.collate import MoCoCollateFunction
 from lightly.data.collate import MultiCropCollateFunction
 from lightly.data.collate import SwaVCollateFunction
 from lightly.data.collate import imagenet_normalize
+from lightly.data._video import NonIncreasingTimestampError

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -26,6 +26,12 @@ except ImportError:
 if io._HAS_VIDEO_OPT:
     torchvision.set_video_backend('video_reader')
 
+class NonIncreasingTimestampError(Exception):
+    """Exception raised when trying to load a frame that has a timestamp 
+    equal or lower than the timestamps of previous frames in the video.
+    """
+    pass
+
 # @guarin 18.02.2022
 # VideoLoader and VideoDataset multi-thread and multi-processing infos
 # --------------------------------------------------------------------
@@ -366,13 +372,6 @@ def _find_non_increasing_timestamps(
             is_non_increasing.append(True)
     
     return is_non_increasing
-
-
-class NonIncreasingTimestampError(Exception):
-    """Exception raised when trying to load a frame that has a timestamp 
-    equal or lower than the timestamps of previous frames in the video.
-    """
-    pass
 
 
 class VideoDataset(datasets.VisionDataset):

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -121,10 +121,17 @@ class VideoLoader(threading.local):
         to the right position and then load the frame.
         
         Args:
-            timestamp: Specific timestamp of frame in seconds or None (default: None)
+            timestamp: 
+                Specific timestamp of frame in seconds or None (default: None)
 
         Returns:
             A PIL Image
+
+        Raises:
+            StopIteration if video is empty or end of video is reached and
+            timestamp is None.
+            ValueError if provided timestamp is not in self.timestamps.
+            RuntimeError if loaded frame has wrong shape.
 
         """
         if not self.timestamps:

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -26,11 +26,20 @@ except ImportError:
 if io._HAS_VIDEO_OPT:
     torchvision.set_video_backend('video_reader')
 
+
 class NonIncreasingTimestampError(Exception):
     """Exception raised when trying to load a frame that has a timestamp 
     equal or lower than the timestamps of previous frames in the video.
     """
     pass
+
+
+class UnseekableTimestampError(Exception):
+    """Exception raised when trying to load a frame that has a timestamp which
+    cannot be seeked to by the video loader.
+    """
+    pass
+
 
 # @guarin 18.02.2022
 # VideoLoader and VideoDataset multi-thread and multi-processing infos
@@ -218,7 +227,7 @@ class VideoLoader(threading.local):
                     frame_info = next(self.reader)
                 except StopIteration as ex:
                     # Seeking to this timestamp simply doesn't work.
-                    raise RuntimeError(
+                    raise UnseekableTimestampError(
                         f'Cannot seek to frame with timestamp {float(timestamp)} '
                         f'in {self.path}.'
                     ) from ex

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -134,10 +134,12 @@ class VideoLoader(threading.local):
             A PIL Image
 
         Raises:
-            StopIteration if video is empty or end of video is reached and
-            timestamp is None.
-            ValueError if provided timestamp is not in self.timestamps.
-            RuntimeError if loaded frame has wrong shape.
+            StopIteration:
+                If video is empty or end of video is reached and timestamp is None.
+            ValueError: 
+                If provided timestamp is not in self.timestamps.
+            RuntimeError:
+                If loaded frame has wrong shape.
 
         """
         if not self.timestamps:

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -222,16 +222,17 @@ class VideoLoader(threading.local):
             try:
                 while True:
                     frame_info = next(self.reader)
-                    if frame_info['pts'] >= next_timestamp:
+                    if frame_info['pts'] < timestamp - self.eps:
+                        # Did not read far enough, let's continue reading more 
+                        # frames. This can happen due to decreasing timestamps.
+                        frame_info = next(self.reader)
+                    elif frame_info['pts'] >= next_timestamp:
                         # Accidentally read too far, let's seek back to the 
-                        # correct position. This can happen due to imprecise seek.
+                        # correct position and exit. This can happen due to 
+                        # imprecise seek.
                         self.reader.seek(timestamp)
                         frame_info = next(self.reader)
                         break
-                    elif frame_info['pts'] < timestamp - self.eps:
-                        # Did not read far enough, let's continue reading more frames.
-                        # This can happen due to decreasing timestamps.
-                        frame_info = next(self.reader)
                     else:
                         break
             except StopIteration:


### PR DESCRIPTION
* Mark all non-increasing timestamps on dataset loading
* Raise by default an exception if frame with non-increasing timestamp should be loaded
* Add non-increasing timestamp tests