### PR TITLE
Update pretagging and object level docs

### DIFF
--- a/docs/source/docker/advanced/code_examples/object_level_worker_config_pretagging.txt
+++ b/docs/source/docker/advanced/code_examples/object_level_worker_config_pretagging.txt
@@ -1,0 +1,24 @@
+{
+  object_level: {
+    task_name: 'lightly_pretagging'
+  },
+  enable_corruptness_check: true,
+  remove_exact_duplicates: true,
+  enable_training: false,
+  pretagging: true,
+  pretagging_debug: false,
+  method: 'coreset',
+  stopping_condition: {
+    n_samples: 0.1,
+    min_distance: -1
+  },
+  scorer: 'object-frequency',
+  scorer_config: {
+    frequency_penalty: 0.25,
+    min_score: 0.9
+  },
+  active_learning: {
+    task_name: '',
+    score_name: 'uncertainty_margin'
+  }
+}

--- a/docs/source/docker/advanced/code_examples/python_run_object_level_pretagging.py
+++ b/docs/source/docker/advanced/code_examples/python_run_object_level_pretagging.py
@@ -3,7 +3,8 @@ import lightly
 # Create the Lightly client to connect to the API.
 client = lightly.api.ApiWorkflowClient(token="TOKEN", dataset_id="DATASET_ID")
 
-# Schedule the docker run with the "object_level.task_name" argument set. 
+# Schedule the docker run with the "object_level.task_name" argument set to
+# "lightly_pretagging" and with "pretagging" set to True.
 # All other settings are default values and we show them so you can easily edit
 # the values according to your need.
 client.schedule_compute_worker_run(

--- a/docs/source/docker/advanced/code_examples/python_run_object_level_pretagging.py
+++ b/docs/source/docker/advanced/code_examples/python_run_object_level_pretagging.py
@@ -1,0 +1,75 @@
+import lightly
+
+# Create the Lightly client to connect to the API.
+client = lightly.api.ApiWorkflowClient(token="TOKEN", dataset_id="DATASET_ID")
+
+# Schedule the docker run with the "object_level.task_name" argument set. 
+# All other settings are default values and we show them so you can easily edit
+# the values according to your need.
+client.schedule_compute_worker_run(
+    worker_config={
+        "object_level": {
+            "task_name": "lightly_pretagging"
+        },
+        "enable_corruptness_check": True,
+        "remove_exact_duplicates": True,
+        "enable_training": False,
+        "pretagging": True,
+        "pretagging_debug": False,
+        "method": "coreset",
+        "stopping_condition": {
+          "n_samples": 0.1,
+          "min_distance": -1
+        },
+        "scorer": "object-frequency",
+        "scorer_config": {
+          "frequency_penalty": 0.25,
+          "min_score": 0.9
+        },
+        "active_learning": {
+          "task_name": "",
+          "score_name": "uncertainty_margin"
+        }
+    },
+    lightly_config={
+        'loader': {
+            'batch_size': 16,
+            'shuffle': True,
+            'num_workers': -1,
+            'drop_last': True
+        },
+        'model': {
+            'name': 'resnet-18',
+            'out_dim': 128,
+            'num_ftrs': 32,
+            'width': 1
+        },
+        'trainer': {
+            'gpus': 1,
+            'max_epochs': 100,
+            'precision': 32
+        },
+        'criterion': {
+            'temperature': 0.5
+        },
+        'optimizer': {
+            'lr': 1,
+            'weight_decay': 0.00001
+        },
+        'collate': {
+            'input_size': 64,
+            'cj_prob': 0.8,
+            'cj_bright': 0.7,
+            'cj_contrast': 0.7,
+            'cj_sat': 0.7,
+            'cj_hue': 0.2,
+            'min_scale': 0.15,
+            'random_gray_scale': 0.2,
+            'gaussian_blur': 0.5,
+            'kernel_size': 0.1,
+            'vf_prob': 0,
+            'hf_prob': 0.5,
+            'rr_prob': 0
+        }
+    }
+)

--- a/docs/source/docker/advanced/object_level.rst
+++ b/docs/source/docker/advanced/object_level.rst
@@ -25,6 +25,12 @@ following things:
 - Object detection predictions uploaded to the datasource (see next section)
 
 
+.. note::
+
+    If you don't have any predictions available, you can use the Lightly pretagging
+    model. See :ref:`Pretagging <object-level-pretagging>` for more information.
+
+
 Predictions
 -----------
 Lightly needs to know which objects to process. This information is provided
@@ -156,6 +162,39 @@ from python code. Examples on how to schedule the job are provided below.
     .. tab:: Python Code
 
         .. literalinclude:: code_examples/python_run_object_level.py
+
+
+.. _object-level-pretagging:
+
+Lightly Pretagging
+------------------
+Instead of providing your own predictions, it's also possible to use the built-in pretagging model from Lightly. To do so,
+set `pretagging=True` in your config and use the `object_level.task_name="lightly_pretagging"`. For more information
+about the prediction model and classes, go to :ref:`Lightly Pretagging Model <ref-docker-pretagging>`
+
+.. tabs::
+
+    .. tab:: Web App
+
+        .. literalinclude:: code_examples/object_level_worker_config_pretagging.txt
+            :caption: Docker Config
+            :language: javascript
+
+        The Lightly config remains unchanged.
+
+    .. tab:: Python Code
+
+        .. literalinclude:: code_examples/python_run_object_level_pretagging.py
+
+
+Padding
+-------
+Lightly makes it possible to add a padding around your bounding boxes. This allows
+for better visualization of the cropped images in the web-app and can improve the
+embeddings of the objects as the embedding model sees the objects in context. To add
+padding, simply specify `object_level.padding=X` where `X` is the padding relative
+to the bounding box size. For example, a padding of `X=0.1` will extend both width and
+height of all bounding boxes by 10 percent.
 
 
 Object Crops Dataset

--- a/docs/source/docker/advanced/pretagging.rst
+++ b/docs/source/docker/advanced/pretagging.rst
@@ -85,7 +85,7 @@ Pretagging can be activated by passing the following argument to your docker
 run command: `pretagging=True`
 
 - `pretagging=True` enables the use of the pretagging model
-- `pretagging_debug=True` add a few images to the report for debugging showing showing the image with the bounding box predictions.
+- `pretagging_debug=True` add a few images to the report for debugging showing the image with the bounding box predictions.
 - `pretagging_upload=True` enables uploading of the predictions to a configured datasource.
 
 

--- a/docs/source/docker/advanced/pretagging.rst
+++ b/docs/source/docker/advanced/pretagging.rst
@@ -85,12 +85,9 @@ Pretagging can be activated by passing the following argument to your docker
 run command: `pretagging=True`
 
 - `pretagging=True` enables the use of the pretagging model
-- `pretagging_debug=True` add a few images to the report for debugging showing
-  showing the image with the bounding box predictions. 
+- `pretagging_debug=True` add a few images to the report for debugging showing showing the image with the bounding box predictions.
+- `pretagging_upload=True` enables uploading of the predictions to a configured datasource.
 
-  .. note:: The debug mode for pretagging is currently not available for video
-            datasets.
-  
 
 The final docker run command to enable pretagging as well as pretagging_debug
 should look like this:

--- a/docs/source/docker/configuration/configuration.rst
+++ b/docs/source/docker/configuration/configuration.rst
@@ -160,6 +160,8 @@ The following are parameters which can be passed to the container:
     # Name of the additional crop dataset on the Lightly Platform. A new dataset
     # is created if no dataset with this name exists.
     crop_dataset_name: ''
+    # Padding relative to the bbox size
+    padding: 0.0
 
   # Upload report to the Ligthly platform.
   upload_report: True

--- a/docs/source/docker/configuration/configuration.rst
+++ b/docs/source/docker/configuration/configuration.rst
@@ -99,6 +99,7 @@ The following are parameters which can be passed to the container:
   pretagging: False
   pretagging_debug: False
   pretagging_config: ''
+  pretagging_upload: False
 
   # Append weak labels.
   append_weak_labels: False


### PR DESCRIPTION
# Update pretagging and object level docs

- Clean up the docs a bit
- Show how to run with `pretagging=True` and `object_level.task_name=pretagging_lightly`
- Add docs on padding for object level