### PR TITLE
Philipp error when loading kitware dataset

### DIFF
--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -447,7 +447,7 @@ def download_video_frames_at_timestamps(
         retry_skipped_timestamps = seek_to_first_frame
         if retry_skipped_timestamps:
             warnings.warn(
-                f'Timestamps {leftovers} were not decoded! Retrying...'
+                f'Timestamps {leftovers} could not be decoded! Retrying from the start...'
             )
             frames = download_video_frames_at_timestamps(
                 url,

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -408,12 +408,12 @@ def download_video_frames_at_timestamps(
                         f"({end_time} pts).")
 
             # seek to last keyframe before the min_timestamp
-            container.seek(
-                max(min_timestamp - 1, 0),
-                any_frame=False,
-                backward=True,
-                stream=stream
-            )
+            # container.seek(
+            #     max(min_timestamp - 1, 0),
+            #     any_frame=False,
+            #     backward=True,
+            #     stream=stream
+            # )
 
             index_timestamp = 0
             print(timestamps)

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -412,9 +412,17 @@ def download_video_frames_at_timestamps(
                            stream=stream)
 
             index_timestamp = 0
+            print(timestamps)
             for frame in container.decode(stream):
                 # advance from keyframe until correct timestamp is reached
                 if frame.pts >= timestamps[index_timestamp]:
+                    print(frame.pts)
+
+                    if frame.pts > timestamps[index_timestamp]:
+                        warnings.warn(
+                            f'Potentially skipped a frame @ {timestamps[index_timestamp]} '
+                            f'(loaded frame @ {frame.pts} instead)'
+                        )
 
                     # yield next frame
                     if as_pil_image:

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -461,9 +461,11 @@ def download_video_frames_at_timestamps(
                     # update the timestamp
                     index_timestamp += 1
 
-                if index_timestamp >= len(timestamps) \
-                    and len(skipped_timestamps) == 0:
-                    return
+                if index_timestamp >= len(timestamps):
+                    break
+
+        if len(skipped_timestamps) == 0:
+            return
 
         # sometimes frames are skipped when we seek to the first frame
         # let's retry downloading these frames without seeking

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -440,7 +440,7 @@ def download_video_frames_at_timestamps(
 
                     if actual_index_timestamp == index_timestamp:
                         # edge case: skipped frame is the last timestamp in the list
-                        skipped_timestamps.append(index_timestamp)
+                        skipped_timestamps.append(timestamps[index_timestamp])
                     else:
                         skipped_timestamps.extend(
                             timestamps[index_timestamp:actual_index_timestamp]

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -408,8 +408,12 @@ def download_video_frames_at_timestamps(
                         f"({end_time} pts).")
 
             # seek to last keyframe before the min_timestamp
-            container.seek(min_timestamp, any_frame=False, backward=True,
-                           stream=stream)
+            container.seek(
+                max(min_timestamp - 1, 0),
+                any_frame=False,
+                backward=True,
+                stream=stream
+            )
 
             index_timestamp = 0
             print(timestamps)

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -377,10 +377,6 @@ def download_video_frames_at_timestamps(
         if len(timestamps) == 0:
             return []
 
-        frame_count = video_frame_count(url)
-        if len(timestamps) > frame_count:
-            raise RuntimeError(f'Got {len(timestamps)} timestamps for video with {frame_count} frames!')
-
         if any(
                 timestamps[i+1] <= timestamps[i]
                 for i

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -414,6 +414,7 @@ def download_video_frames_at_timestamps(
             #     backward=True,
             #     stream=stream
             # )
+            print(start_time, duration, end_time)
 
             index_timestamp = 0
             print(timestamps)

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -436,11 +436,15 @@ def download_video_frames_at_timestamps(
                         )
                     except StopIteration:
                         # there exists no timestamp larger than frame.pts
-                        actual_index_timestamp = len(timestamps)
+                        actual_index_timestamp = len(timestamps) - 1
 
-                    skipped_timestamps.extend(
-                        timestamps[index_timestamp:actual_index_timestamp]
-                    )
+                    if actual_index_timestamp == index_timestamp:
+                        # edge case: skipped frame is the last timestamp in the list
+                        skipped_timestamps.append(index_timestamp)
+                    else:
+                        skipped_timestamps.extend(
+                            timestamps[index_timestamp:actual_index_timestamp]
+                        )
 
                     # update the timestamp
                     index_timestamp = actual_index_timestamp

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -436,7 +436,7 @@ def download_video_frames_at_timestamps(
                         )
                     except StopIteration:
                         # there exists no timestamp larger than frame.pts
-                        actual_index_timestamp = len(timestamps) - 1
+                        actual_index_timestamp = len(timestamps)
 
                     skipped_timestamps.extend(
                         timestamps[index_timestamp:actual_index_timestamp]
@@ -466,8 +466,7 @@ def download_video_frames_at_timestamps(
         retry_skipped_timestamps = seek_to_first_frame
         if len(skipped_timestamps) > 0 and retry_skipped_timestamps:
             warnings.warn(
-                f'Timestamps {skipped_timestamps} were dropped by the decoder! '
-                f'Retrying...'
+                f'Timestamps {skipped_timestamps} were dropped by the decoder! Retrying...'
             )
             frames = download_video_frames_at_timestamps(
                 url,

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -441,6 +441,7 @@ def download_video_frames_at_timestamps(
                     if actual_index_timestamp == index_timestamp:
                         # edge case: skipped frame is the last timestamp in the list
                         skipped_timestamps.append(timestamps[index_timestamp])
+                        break
                     else:
                         skipped_timestamps.extend(
                             timestamps[index_timestamp:actual_index_timestamp]

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -8,7 +8,6 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import PIL
-from pendulum import time
 import requests
 import tqdm
 from lightly.api import utils

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -412,7 +412,7 @@ def download_video_frames_at_timestamps(
                         f"({end_time} pts).")
 
             if seek_to_first_frame:
-            # seek to last keyframe before the min_timestamp
+                # seek to last keyframe before the min_timestamp
                 container.seek(
                     min_timestamp,
                     any_frame=False,
@@ -463,8 +463,8 @@ def download_video_frames_at_timestamps(
 
         # sometimes frames are skipped when we seek to the first frame
         # let's retry downloading these frames without seeking
-        retry_skipped_timestamps = not seek_to_first_frame
-        if len(skipped_timestamps) and retry_skipped_timestamps:
+        retry_skipped_timestamps = seek_to_first_frame
+        if len(skipped_timestamps) > 0 and retry_skipped_timestamps:
             warnings.warn(
                 f'Timestamps {skipped_timestamps} were dropped by the decoder! '
                 f'Retrying...'

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -416,7 +416,6 @@ def download_video_frames_at_timestamps(
                 )
 
             index_timestamp = 0
-            leftovers = []
             for frame in container.decode(stream):
     
                 # advance from keyframe until correct timestamp is reached

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -426,4 +426,5 @@ def download_video_frames_at_timestamps(
         raise ValueError(f"You requested to get the frame at "
                          f"({timestamps[index_timestamp]} pts), "
                          f"but that timestamp "
-                         f"is bigger than all timestamps in the video.")
+                         f"is bigger than all timestamps in video "
+                         f"at {url}")

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -440,7 +440,7 @@ def download_video_frames_at_timestamps(
                 if index_timestamp >= len(timestamps):
                     return
 
-        leftovers = timestamps[:index_timestamp]
+        leftovers = timestamps[index_timestamp:]
 
         # sometimes frames are skipped when we seek to the first frame
         # let's retry downloading these frames without seeking

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -373,6 +373,10 @@ def download_video_frames_at_timestamps(
         if len(timestamps) == 0:
             return []
 
+        frame_count = video_frame_count(url)
+        if len(timestamps) > frame_count:
+            raise RuntimeError(f'Got {len(timestamps)} timestamps for video with {frame_count} frames!')
+
         if any(
                 timestamps[i+1] <= timestamps[i]
                 for i

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -120,7 +120,7 @@ class TestDownload(unittest.TestCase):
             for timestamp in timestamps:
                 with self.subTest(timestamp=timestamp):
                     if timestamp > n_frames:
-                        with self.assertRaises(ValueError):
+                        with self.assertRaises(RuntimeError):
                             frame = download.download_video_frame(file.name, timestamp)
                     frame = download.download_video_frame(file.name, timestamp)
 

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -116,13 +116,14 @@ class TestDownload(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
             n_frames = 5
             original = _generate_video(file.name, n_frames=n_frames)
-            timestamps = list(range(n_frames+1))
+            timestamps = list(range(1, n_frames+1))
             for timestamp in timestamps:
                 with self.subTest(timestamp=timestamp):
                     if timestamp > n_frames:
                         with self.assertRaises(RuntimeError):
                             frame = download.download_video_frame(file.name, timestamp)
-                    frame = download.download_video_frame(file.name, timestamp)
+                    else:
+                        frame = download.download_video_frame(file.name, timestamp)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_video_frames_at_timestamps(self):


### PR DESCRIPTION
# Philipp error when loading kitware dataset

Sometimes frames are dropped if we seek to a certain position before loading them. This PR resolves this problem by redownloading the dropped frames without seeking beforehand.