### PR TITLE
Malte lig 1082 worker crashes on open images dataset

### DIFF
--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -26,7 +26,7 @@ def _check_av_available() -> None:
         raise av
 
 def download_image(url: str, session: requests.Session = None) -> PIL.Image.Image:
-    """Downloads an image from an url.
+    """Downloads an image from a url.
 
     Args:
         url: 
@@ -38,16 +38,14 @@ def download_image(url: str, session: requests.Session = None) -> PIL.Image.Imag
         The downloaded image.
 
     """
-    def load_image(url, session):
-        req = requests if session is None else session
+    def load_image(url, req):
         with req.get(url=url, stream=True) as response:
             image = PIL.Image.open(response.raw)
             image.load()
         return image
 
-    image = load_image(url, session)
-
-    #image = utils.retry(load_image, url, session)
+    req = requests if session is None else session
+    image = utils.retry(load_image, url, req)
     return image
 
 

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -26,7 +26,7 @@ def _check_av_available() -> None:
         raise av
 
 def download_image(url: str, session: requests.Session = None) -> PIL.Image.Image:
-    """Downloads an image from a url.
+    """Downloads an image from an url.
 
     Args:
         url: 
@@ -38,9 +38,17 @@ def download_image(url: str, session: requests.Session = None) -> PIL.Image.Imag
         The downloaded image.
 
     """
-    req = requests if session is None else session
-    response = utils.retry(req.get, url=url, stream=True)
-    return PIL.Image.open(response.raw)
+    def load_image(url, session):
+        req = requests if session is None else session
+        with req.get(url=url, stream=True) as response:
+            image = PIL.Image.open(response.raw)
+            image.load()
+        return image
+
+    image = load_image(url, session)
+
+    #image = utils.retry(load_image, url, session)
+    return image
 
 
 def download_all_video_frames(

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -48,80 +48,301 @@ def download_image(url: str, session: requests.Session = None) -> PIL.Image.Imag
     image = utils.retry(load_image, url, req)
     return image
 
+if not isinstance(av, ModuleNotFoundError):
 
-def download_all_video_frames(
-    url: str, 
-    timestamp: Union[int, None] = None,
-    as_pil_image: int = True, 
-    thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
-    video_channel: int = 0,
-) -> Iterable[Union[PIL.Image.Image, av.VideoFrame]]:
-    """Lazily retrieves all frames from a video stored at the given url.
+    def download_all_video_frames(
+        url: str,
+        timestamp: Union[int, None] = None,
+        as_pil_image: int = True,
+        thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
+        video_channel: int = 0,
+    ) -> Iterable[Union[PIL.Image.Image, av.VideoFrame]]:
+        """Lazily retrieves all frames from a video stored at the given url.
 
-    Args:
-        url: 
-            The url where video is downloaded from.
-        timestamp:
-            Timestamp in pts from the start of the video from which the frame 
-            download should start. See https://pyav.org/docs/develop/api/time.html#time
-            for details on pts.
-        as_pil_image: 
-            Whether to return the frame as PIL.Image.
-        thread_type:
-            Which multithreading method to use for decoding the video.
-            See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
-            for details.
-        video_channel:
-            The video channel from which frames are loaded.
+        Args:
+            url:
+                The url where video is downloaded from.
+            timestamp:
+                Timestamp in pts from the start of the video from which the frame
+                download should start. See https://pyav.org/docs/develop/api/time.html#time
+                for details on pts.
+            as_pil_image:
+                Whether to return the frame as PIL.Image.
+            thread_type:
+                Which multithreading method to use for decoding the video.
+                See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
+                for details.
+            video_channel:
+                The video channel from which frames are loaded.
 
-    Returns:
-        A generator that loads and returns a single frame per step.
+        Returns:
+            A generator that loads and returns a single frame per step.
 
-    """
-    _check_av_available()
-    timestamp = 0 if timestamp is None else timestamp
-    if timestamp < 0:
-        raise ValueError(f"Negative timestamp is not allowed: {timestamp}")
+        """
+        _check_av_available()
+        timestamp = 0 if timestamp is None else timestamp
+        if timestamp < 0:
+            raise ValueError(f"Negative timestamp is not allowed: {timestamp}")
 
-    with utils.retry(av.open, url) as container:
-        stream = container.streams.video[video_channel]
-        stream.thread_type = thread_type
+        with utils.retry(av.open, url) as container:
+            stream = container.streams.video[video_channel]
+            stream.thread_type = thread_type
 
-        duration = stream.duration
-        start_time = stream.start_time
-        if (duration is not None) and (start_time is not None):
-            end_time = duration + start_time
-            if timestamp > end_time:
-                raise ValueError(
-                    f"Timestamp ({timestamp} pts) exceeds maximum video timestamp "
-                    f"({end_time} pts)."
+            duration = stream.duration
+            start_time = stream.start_time
+            if (duration is not None) and (start_time is not None):
+                end_time = duration + start_time
+                if timestamp > end_time:
+                    raise ValueError(
+                        f"Timestamp ({timestamp} pts) exceeds maximum video timestamp "
+                        f"({end_time} pts)."
+                    )
+            # seek to last keyframe before the timestamp
+            container.seek(timestamp, any_frame=False, backward=True, stream=stream)
+
+            frame = None
+            for frame in container.decode(stream):
+                # advance from keyframe until correct timestamp is reached
+                if frame.pts < timestamp:
+                    continue
+                # yield next frame
+                if as_pil_image:
+                    yield frame.to_image()
+                else:
+                    yield frame
+
+
+    def download_video_frame(url: str, timestamp: int, *args, **kwargs
+                             ) -> Union[PIL.Image.Image, av.VideoFrame, None]:
+        """
+        Wrapper around download_video_frames_at_timestamps
+        for downloading only a single frame.
+        """
+        frames = download_video_frames_at_timestamps(
+            url, timestamps=[timestamp], *args, **kwargs
+        )
+        frames = list(frames)
+        return frames[0]
+
+
+    def video_frame_count(
+        url: str,
+        video_channel: int = 0,
+        thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
+        ignore_metadata: bool = False,
+    ) -> Optional[int]:
+        """Returns the number of frames in the video from the given url.
+
+        The video is only decoded if no information about the number of frames is
+        stored in the video metadata.
+
+        Args:
+            url:
+                The url of the video.
+            video_channel:
+                The video stream channel from which to find the number of frames.
+            thread_type:
+                Which multithreading method to use for decoding the video.
+                See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
+                for details.
+            ignore_metadata:
+                If True, frames are counted by iterating through the video instead
+                of relying on the video metadata.
+
+        Returns:
+            The number of frames in the video. Can be None if the video could not be
+            decoded.
+
+        """
+        with av.open(url) as container:
+            stream = container.streams.video[video_channel]
+            num_frames = 0 if ignore_metadata else stream.frames
+            # If number of frames not stored in the video file we have to decode all
+            # frames and count them.
+            if num_frames == 0:
+                stream.thread_type = thread_type
+                for _ in container.decode(stream):
+                    num_frames += 1
+        return num_frames
+
+    def all_video_frame_counts(
+        urls: List[str],
+        max_workers: int = None,
+        video_channel: int = 0,
+        thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
+        ignore_metadata: bool = False,
+    ) -> List[Optional[int]]:
+        """Finds the number of frames in the videos at the given urls.
+
+        Videos are only decoded if no information about the number of frames is
+        stored in the video metadata.
+
+        Args:
+            urls:
+                A list of video urls.
+            max_workers:
+                Maximum number of workers. If `None` the number of workers is chosen
+                based on the number of available cores.
+            video_channel:
+                The video stream channel from which to find the number of frames.
+            thread_type:
+                Which multithreading method to use for decoding the video.
+                See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
+                for details.
+            ignore_metadata:
+                If True, frames are counted by iterating through the video instead
+                of relying on the video metadata.
+
+        Returns:
+            A list with the number of frames per video. Contains None for all videos
+            that could not be decoded.
+
+        """
+
+        def job(url):
+            try:
+                return utils.retry(
+                    video_frame_count,
+                    url=url,
+                    video_channel=video_channel,
+                    thread_type=thread_type,
+                    ignore_metadata=ignore_metadata,
                 )
-        # seek to last keyframe before the timestamp
-        container.seek(timestamp, any_frame=False, backward=True, stream=stream)
-        
-        frame = None
-        for frame in container.decode(stream):
-            # advance from keyframe until correct timestamp is reached
-            if frame.pts < timestamp:
-                continue
-            # yield next frame
-            if as_pil_image:
-                yield frame.to_image()
-            else:
-                yield frame
+            except RuntimeError:
+                return
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(job, urls))
 
 
-def download_video_frame(url: str, timestamp: int, *args, **kwargs
-                         ) -> Union[PIL.Image.Image, av.VideoFrame, None]:
-    """
-    Wrapper around download_video_frames_at_timestamps
-    for downloading only a single frame.
-    """
-    frames = download_video_frames_at_timestamps(
-        url, timestamps=[timestamp], *args, **kwargs
-    )
-    frames = list(frames)
-    return frames[0]
+
+    def download_video_frames_at_timestamps(
+            url: str,
+            timestamps: List[int],
+            as_pil_image: int = True,
+            thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
+            video_channel: int = 0,
+            seek_to_first_frame: bool = True,
+        ) -> Iterable[Union[PIL.Image.Image, av.VideoFrame]]:
+            """Lazily retrieves frames from a video at a specific timestamp stored at the given url.
+
+            Args:
+                url:
+                    The url where video is downloaded from.
+                timestamps:
+                    Timestamps in pts from the start of the video. The images
+                    at these timestamps are returned.
+                    The timestamps must be strictly monotonically ascending.
+                    See https://pyav.org/docs/develop/api/time.html#time
+                    for details on pts.
+                as_pil_image:
+                    Whether to return the frame as PIL.Image.
+                thread_type:
+                    Which multithreading method to use for decoding the video.
+                    See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
+                    for details.
+                video_channel:
+                    The video channel from which frames are loaded.
+                seek_to_first_frame:
+                    Boolean indicating whether to seek to the first frame.
+
+            Returns:
+                A generator that loads and returns a single frame per step.
+
+            """
+            _check_av_available()
+
+            if len(timestamps) == 0:
+                return []
+
+            if any(
+                    timestamps[i+1] <= timestamps[i]
+                    for i
+                    in range(len(timestamps) - 1)
+            ):
+                raise ValueError("The timestamps must be sorted "
+                                 "strictly monotonically ascending, but are not.")
+            min_timestamp = timestamps[0]
+            max_timestamp = timestamps[-1]
+
+            if min_timestamp < 0:
+                raise ValueError(f"Negative timestamp is not allowed: {min_timestamp}")
+
+            with utils.retry(av.open, url) as container:
+                stream = container.streams.video[video_channel]
+                stream.thread_type = thread_type
+
+                # Heuristic to find out if a timestamp is too big.
+                # However, this heuristic is very bad, as timestamps
+                # may start at any offset and even reset in the middle
+                # See https://stackoverflow.com/questions/10570685/avcodec-pts-timestamps-not-starting-at-0
+                duration = stream.duration
+                start_time = stream.start_time
+                if (duration is not None) and (start_time is not None):
+                    end_time = duration + start_time
+                    if max_timestamp > end_time:
+                        raise ValueError(
+                            f"Timestamp ({max_timestamp} pts) exceeds maximum video timestamp "
+                            f"({end_time} pts).")
+
+                if seek_to_first_frame:
+                    # seek to last keyframe before the min_timestamp
+                    container.seek(
+                        min_timestamp,
+                        any_frame=False,
+                        backward=True,
+                        stream=stream
+                    )
+
+                index_timestamp = 0
+                for frame in container.decode(stream):
+
+                    # advance from keyframe until correct timestamp is reached
+                    if frame.pts > timestamps[index_timestamp]:
+
+                        # dropped frames!
+                        break
+
+                    # it's ok to check by equality because timestamps are ints
+                    if frame.pts == timestamps[index_timestamp]:
+
+                        # yield next frame
+                        if as_pil_image:
+                            yield frame.to_image()
+                        else:
+                            yield frame
+
+                        # update the timestamp
+                        index_timestamp += 1
+
+                    if index_timestamp >= len(timestamps):
+                        return
+
+            leftovers = timestamps[index_timestamp:]
+
+            # sometimes frames are skipped when we seek to the first frame
+            # let's retry downloading these frames without seeking
+            retry_skipped_timestamps = seek_to_first_frame
+            if retry_skipped_timestamps:
+                warnings.warn(
+                    f'Timestamps {leftovers} could not be decoded! Retrying from the start...'
+                )
+                frames = download_video_frames_at_timestamps(
+                    url,
+                    leftovers,
+                    as_pil_image=as_pil_image,
+                    thread_type=thread_type,
+                    video_channel=video_channel,
+                    seek_to_first_frame=False,
+                )
+                for frame in frames:
+                    yield frame
+                return
+
+            raise RuntimeError(
+                f'Timestamps {leftovers} in video {url} could not be decoded!'
+            )
+
 
 
 def download_and_write_file(
@@ -130,11 +351,11 @@ def download_and_write_file(
     """Downloads a file from a url and saves it to disk
 
     Args:
-        url: 
+        url:
             Url of the file to download.
-        output_path: 
+        output_path:
             Where to store the file, including filename and extension.
-        session: 
+        session:
             Session object to persist certain parameters across requests.
     """
     req = requests if session is None else session
@@ -159,7 +380,7 @@ def download_and_write_all_files(
         output_dir:
             Output directory where files will stored in.
         max_workers:
-            Maximum number of workers. If `None` the number of workers is chosen 
+            Maximum number of workers. If `None` the number of workers is chosen
             based on the number of available cores.
         verbose:
             Shows progress bar if set to `True`.
@@ -167,9 +388,9 @@ def download_and_write_all_files(
     """
 
     def thread_download_and_write(
-        file_info: Tuple[str, str], 
-        output_dir: str, 
-        lock: threading.Lock, 
+        file_info: Tuple[str, str],
+        output_dir: str,
+        lock: threading.Lock,
         sessions: Dict[str, requests.Session]
     ):
         filename, url = file_info
@@ -211,95 +432,22 @@ def download_and_write_all_files(
             except Exception as ex:
                 warnings.warn(f"Could not download {filename} from {url}")
 
-def video_frame_count(
+def download_prediction_file(
     url: str,
-    video_channel: int = 0,
-    thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
-    ignore_metadata: bool = False,
-) -> Optional[int]:
-    """Returns the number of frames in the video from the given url.
+    session: requests.Session = None,
+) -> Union[Dict, None]:
+    """Same as download_json_file. Keep this for backwards compatability.
 
-    The video is only decoded if no information about the number of frames is
-    stored in the video metadata.
-    
     Args:
         url:
-            The url of the video.
-        video_channel:
-            The video stream channel from which to find the number of frames.
-        thread_type:
-            Which multithreading method to use for decoding the video.
-            See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
-            for details.
-        ignore_metadata:
-            If True, frames are counted by iterating through the video instead
-            of relying on the video metadata.
+            Url of the file to download.
+        session:
+            Session object to persist certain parameters across requests.
 
-    Returns:
-        The number of frames in the video. Can be None if the video could not be
-        decoded.
+    Returns the content of the json file as dictionary or None.
 
     """
-    with av.open(url) as container:
-        stream = container.streams.video[video_channel]
-        num_frames = 0 if ignore_metadata else stream.frames
-        # If number of frames not stored in the video file we have to decode all
-        # frames and count them.
-        if num_frames == 0:
-            stream.thread_type = thread_type
-            for _ in container.decode(stream):
-                num_frames += 1
-    return num_frames
-
-def all_video_frame_counts(
-    urls: List[str],
-    max_workers: int = None,
-    video_channel: int = 0,
-    thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
-    ignore_metadata: bool = False,
-) -> List[Optional[int]]:
-    """Finds the number of frames in the videos at the given urls.
-
-    Videos are only decoded if no information about the number of frames is
-    stored in the video metadata.
-
-    Args:
-        urls:
-            A list of video urls.
-        max_workers:
-            Maximum number of workers. If `None` the number of workers is chosen 
-            based on the number of available cores.
-        video_channel:
-            The video stream channel from which to find the number of frames.
-        thread_type:
-            Which multithreading method to use for decoding the video.
-            See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
-            for details.
-        ignore_metadata:
-            If True, frames are counted by iterating through the video instead
-            of relying on the video metadata.
-
-    Returns:
-        A list with the number of frames per video. Contains None for all videos
-        that could not be decoded.
-
-    """
-
-    def job(url):
-        try:
-            return utils.retry(
-                video_frame_count, 
-                url=url,
-                video_channel=video_channel,
-                thread_type=thread_type,
-                ignore_metadata=ignore_metadata,
-            )
-        except RuntimeError:
-            return
-
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        return list(executor.map(job, urls))
-
+    return download_json_file(url, session=session)
 
 def download_json_file(
     url: str,
@@ -308,7 +456,7 @@ def download_json_file(
     """Downloads a json file from the provided read-url.
 
     Args:
-        url: 
+        url:
             Url of the file to download.
         session: 
             Session object to persist certain parameters across requests.
@@ -323,149 +471,3 @@ def download_json_file(
         return None # the file doesn't exist!
 
     return response.json()
-
-
-def download_prediction_file(
-    url: str,
-    session: requests.Session = None,
-) -> Union[Dict, None]:
-    """Same as download_json_file. Keep this for backwards compatability.
-
-    Args:
-        url: 
-            Url of the file to download.
-        session: 
-            Session object to persist certain parameters across requests.
-
-    Returns the content of the json file as dictionary or None.
-
-    """
-    return download_json_file(url, session=session)
-
-
-def download_video_frames_at_timestamps(
-        url: str,
-        timestamps: List[int],
-        as_pil_image: int = True,
-        thread_type: av.codec.context.ThreadType = av.codec.context.ThreadType.AUTO,
-        video_channel: int = 0,
-        seek_to_first_frame: bool = True,
-    ) -> Iterable[Union[PIL.Image.Image, av.VideoFrame]]:
-        """Lazily retrieves frames from a video at a specific timestamp stored at the given url.
-
-        Args:
-            url:
-                The url where video is downloaded from.
-            timestamps:
-                Timestamps in pts from the start of the video. The images
-                at these timestamps are returned.
-                The timestamps must be strictly monotonically ascending.
-                See https://pyav.org/docs/develop/api/time.html#time
-                for details on pts.
-            as_pil_image:
-                Whether to return the frame as PIL.Image.
-            thread_type:
-                Which multithreading method to use for decoding the video.
-                See https://pyav.org/docs/stable/api/codec.html#av.codec.context.ThreadType
-                for details.
-            video_channel:
-                The video channel from which frames are loaded.
-            seek_to_first_frame:
-                Boolean indicating whether to seek to the first frame.
-
-        Returns:
-            A generator that loads and returns a single frame per step.
-
-        """
-        _check_av_available()
-
-        if len(timestamps) == 0:
-            return []
-
-        if any(
-                timestamps[i+1] <= timestamps[i]
-                for i
-                in range(len(timestamps) - 1)
-        ):
-            raise ValueError("The timestamps must be sorted "
-                             "strictly monotonically ascending, but are not.")
-        min_timestamp = timestamps[0]
-        max_timestamp = timestamps[-1]
-
-        if min_timestamp < 0:
-            raise ValueError(f"Negative timestamp is not allowed: {min_timestamp}")
-
-        with utils.retry(av.open, url) as container:
-            stream = container.streams.video[video_channel]
-            stream.thread_type = thread_type
-
-            # Heuristic to find out if a timestamp is too big.
-            # However, this heuristic is very bad, as timestamps
-            # may start at any offset and even reset in the middle
-            # See https://stackoverflow.com/questions/10570685/avcodec-pts-timestamps-not-starting-at-0
-            duration = stream.duration
-            start_time = stream.start_time
-            if (duration is not None) and (start_time is not None):
-                end_time = duration + start_time
-                if max_timestamp > end_time:
-                    raise ValueError(
-                        f"Timestamp ({max_timestamp} pts) exceeds maximum video timestamp "
-                        f"({end_time} pts).")
-
-            if seek_to_first_frame:
-                # seek to last keyframe before the min_timestamp
-                container.seek(
-                    min_timestamp,
-                    any_frame=False,
-                    backward=True,
-                    stream=stream
-                )
-
-            index_timestamp = 0
-            for frame in container.decode(stream):
-    
-                # advance from keyframe until correct timestamp is reached
-                if frame.pts > timestamps[index_timestamp]:
-
-                    # dropped frames!
-                    break
-
-                # it's ok to check by equality because timestamps are ints
-                if frame.pts == timestamps[index_timestamp]:
-
-                    # yield next frame
-                    if as_pil_image:
-                        yield frame.to_image()
-                    else:
-                        yield frame
-
-                    # update the timestamp
-                    index_timestamp += 1
-
-                if index_timestamp >= len(timestamps):
-                    return
-
-        leftovers = timestamps[index_timestamp:]
-
-        # sometimes frames are skipped when we seek to the first frame
-        # let's retry downloading these frames without seeking
-        retry_skipped_timestamps = seek_to_first_frame
-        if retry_skipped_timestamps:
-            warnings.warn(
-                f'Timestamps {leftovers} could not be decoded! Retrying from the start...'
-            )
-            frames = download_video_frames_at_timestamps(
-                url,
-                leftovers,
-                as_pil_image=as_pil_image,
-                thread_type=thread_type,
-                video_channel=video_channel,
-                seek_to_first_frame=False,
-            )
-            for frame in frames:
-                yield frame
-            return
-
-        raise RuntimeError(
-            f'Timestamps {leftovers} in video {url} could not be decoded!'
-        )

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -45,17 +45,20 @@ def retry(func, *args, **kwargs):
     max_retries = RETRY_MAX_RETRIES
 
     # try to make the request
-    for i in range(max_retries):
+    current_retries = 0
+    while True:
         try:
             # return on success
             return func(*args, **kwargs)
-        except Exception:
+        except Exception as e:
             # sleep on failure
             time.sleep(backoff)
             backoff = 2 * backoff if backoff < max_backoff else backoff
-        
-    # max retries exceeded
-    raise RuntimeError('The connection to the server timed out.')
+            current_retries += 1
+
+            # max retries exceeded
+            if current_retries >= max_retries:
+                raise
 
 
 def getenv(key: str, default: str):

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -58,7 +58,7 @@ def retry(func, *args, **kwargs):
 
             # max retries exceeded
             if current_retries >= max_retries:
-                raise
+                raise RuntimeError from e
 
 
 def getenv(key: str, default: str):

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -58,7 +58,7 @@ def retry(func, *args, **kwargs):
 
             # max retries exceeded
             if current_retries >= max_retries:
-                raise RuntimeError from e
+                raise RuntimeError(f'Maximum retries exceeded! Original exception: {type(e)}: {str(e)}') from e
 
 
 def getenv(key: str, default: str):

--- a/tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh
+++ b/tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh
@@ -63,6 +63,9 @@ echo "############################### Test active learning"
 INPUT_DIR="${PWD}/clothing_dataset_small/test"
 python tests/UNMOCKED_end2end_tests/test_api.py $INPUT_DIR $TOKEN
 
+echo "############################### Test download of large files"
+python tests/UNMOCKED_end2end_tests/test_download_large_files.py
+
 
 echo "############################### Delete dataset again"
 rm -rf $DIR_DATASET

--- a/tests/UNMOCKED_end2end_tests/test_download_large_files.py
+++ b/tests/UNMOCKED_end2end_tests/test_download_large_files.py
@@ -1,0 +1,16 @@
+import time
+
+import lightly
+lightly.api.utils.RETRY_MAX_RETRIES = 1
+
+from lightly.api.download import download_image
+
+url_33MB = "https://cdn.eso.org/images/original/potw1130a.tif"
+url_5MB = "https://cdn.eso.org/images/large/potw1130a.jpg"
+url_1_5MB = "https://cdn.eso.org/images/publicationjpg/potw1130a.jpg"
+
+start = time.time()
+img = download_image(url_5MB)
+print(f"Took {time.time()-start:5.2f}s to download the image.")
+
+img.show()

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -72,20 +72,7 @@ class MockedResponsePartialStream(MockedResponse):
         else:
             return stream
 
-
-# Overwrite requests import in the light.api.download module.
-# lightly.api must be imported before because otherwise it
-# will be loaded by lightly.api.download and use the mocked
-# requests module instead of the real one.
-import lightly.api
-
-requests = sys.modules["requests"]
-sys.modules["requests"] = MockedRequestsModule()
-from lightly.api import download
-
-sys.modules["requests"] = requests
-
-
+@mock.patch('requests', MockedRequestsModule())
 class TestDownload(unittest.TestCase):
 
     def setUp(self):
@@ -100,7 +87,7 @@ class TestDownload(unittest.TestCase):
         lightly.api.utils.RETRY_MAX_BACKOFF = self._max_backoff
         warnings.filterwarnings("default")
 
-    @mock.patch("test_download.MockedResponse", MockedResponsePartialStream)
+    @mock.patch("tests.api.test_download.MockedResponse", MockedResponsePartialStream)
     def test_download_image_half_broken_retry_once(self):
         lightly.api.utils.RETRY_MAX_RETRIES = 1
         MockedResponse.return_partial_stream = True
@@ -111,7 +98,7 @@ class TestDownload(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 image = download.download_image(file.name)
 
-    @mock.patch("test_download.MockedResponse", MockedResponsePartialStream)
+    @mock.patch("tests.api.test_download.MockedResponse", MockedResponsePartialStream)
     def test_download_image_half_broken_retry_twice(self):
         lightly.api.utils.RETRY_MAX_RETRIES = 2
         MockedResponse.return_partial_stream = True

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -107,8 +107,11 @@ class TestDownloadPartialRespons(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix='.png') as file:
             original.save(file.name)
             # assert that the retry fails
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(RuntimeError) as error:
                 image = lightly.api.download.download_image(file.name)
+            self.assertTrue("Maximum retries exceeded" in str(error.exception))
+            self.assertTrue("<class 'OSError'>" in str(error.exception))
+            self.assertTrue("image file is truncated" in str(error.exception))
 
     def test_download_image_half_broken_retry_twice(self):
         lightly.api.utils.RETRY_MAX_RETRIES = 2

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -72,7 +72,11 @@ class MockedResponsePartialStream(MockedResponse):
         else:
             return stream
 
-@mock.patch('requests', MockedRequestsModule())
+
+import lightly
+
+
+@mock.patch('lightly.api.download.requests', MockedRequestsModule())
 class TestDownload(unittest.TestCase):
 
     def setUp(self):
@@ -96,7 +100,7 @@ class TestDownload(unittest.TestCase):
             original.save(file.name)
             # assert that the retry fails
             with self.assertRaises(RuntimeError):
-                image = download.download_image(file.name)
+                image = lightly.api.download.download_image(file.name)
 
     @mock.patch("tests.api.test_download.MockedResponse", MockedResponsePartialStream)
     def test_download_image_half_broken_retry_twice(self):
@@ -105,7 +109,7 @@ class TestDownload(unittest.TestCase):
         original = _pil_image()
         with tempfile.NamedTemporaryFile(suffix='.png') as file:
             original.save(file.name)
-            image = download.download_image(file.name)
+            image = lightly.api.download.download_image(file.name)
             assert _images_equal(image, original)
 
 
@@ -113,7 +117,7 @@ class TestDownload(unittest.TestCase):
         original = _pil_image()
         with tempfile.NamedTemporaryFile(suffix='.png') as file:
             original.save(file.name)
-            image = download.download_image(file.name)
+            image = lightly.api.download.download_image(file.name)
             assert _images_equal(image, original)
 
     def test_download_prediction(self):
@@ -121,7 +125,7 @@ class TestDownload(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix='.json', mode="w+") as file:
             with open(file.name, 'w') as f:
                 json.dump(original, f)
-            response = download.download_prediction_file(file.name)
+            response = lightly.api.download.download_prediction_file(file.name)
             self.assertDictEqual(response, original)
 
     def test_download_image_with_session(self):
@@ -129,14 +133,14 @@ class TestDownload(unittest.TestCase):
         original = _pil_image()
         with tempfile.NamedTemporaryFile(suffix='.png') as file:
             original.save(file.name)
-            image = download.download_image(file.name, session=session)
+            image = lightly.api.download.download_image(file.name, session=session)
             assert _images_equal(image, original)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_all_video_frames(self):
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
             original = _generate_video(file.name)
-            frames = list(download.download_all_video_frames(file.name))
+            frames = list(lightly.api.download.download_all_video_frames(file.name))
             for frame, orig in zip(frames, original):
                 assert _images_equal(frame, orig)
 
@@ -150,9 +154,9 @@ class TestDownload(unittest.TestCase):
                 with self.subTest(timestamp=timestamp):
                     if timestamp > n_frames:
                         with self.assertRaises(RuntimeError):
-                            frame = download.download_video_frame(file.name, timestamp)
+                            frame = lightly.api.download.download_video_frame(file.name, timestamp)
                     else:
-                        frame = download.download_video_frame(file.name, timestamp)
+                        frame = lightly.api.download.download_video_frame(file.name, timestamp)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_video_frames_at_timestamps(self):
@@ -162,7 +166,7 @@ class TestDownload(unittest.TestCase):
             original_timestamps = list(range(1, n_frames+1))
             frame_indices = list(range(2, len(original) - 1, 2))
             timestamps = [original_timestamps[i] for i in frame_indices]
-            frames = list(download.download_video_frames_at_timestamps(
+            frames = list(lightly.api.download.download_video_frames_at_timestamps(
                 file.name, timestamps
             ))
             self.assertEqual(len(frames), len(timestamps))
@@ -176,14 +180,14 @@ class TestDownload(unittest.TestCase):
             original = _generate_video(file.name)
             timestamps = [2, 1]
             with self.assertRaises(ValueError):
-                frames = list(download.download_video_frames_at_timestamps(
+                frames = list(lightly.api.download.download_video_frames_at_timestamps(
                     file.name, timestamps
                 ))
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_video_frames_at_timestamps_emtpy(self):
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
-            frames = list(download.download_video_frames_at_timestamps(
+            frames = list(lightly.api.download.download_video_frames_at_timestamps(
                     file.name, timestamps=[]
                 ))
             self.assertEqual(len(frames), 0)
@@ -194,10 +198,10 @@ class TestDownload(unittest.TestCase):
             original = _generate_video(file.name)
             with self.assertRaises(ValueError):
                 # timestamp too small
-                frames = list(download.download_all_video_frames(file.name, timestamp=-1))
+                frames = list(lightly.api.download.download_all_video_frames(file.name, timestamp=-1))
             with self.assertRaises(ValueError):
                 # timestamp too large
-                frames = list(download.download_all_video_frames(file.name, timestamp=6))
+                frames = list(lightly.api.download.download_all_video_frames(file.name, timestamp=6))
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_all_video_frames_restart_at_0(self):
@@ -205,7 +209,7 @@ class TestDownload(unittest.TestCase):
         # although it shouldn't be
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
             original = _generate_video(file.name)
-            frames = list(download.download_all_video_frames(file.name, timestamp=None))
+            frames = list(lightly.api.download.download_all_video_frames(file.name, timestamp=None))
             for frame, orig in zip(frames, original):
                 assert _images_equal(frame, orig)
 
@@ -216,7 +220,7 @@ class TestDownload(unittest.TestCase):
         restart_timestamp = 3
         with tempfile.NamedTemporaryFile(suffix='.avi') as file:
             original = _generate_video(file.name)
-            frames = list(download.download_all_video_frames(file.name, restart_timestamp))
+            frames = list(lightly.api.download.download_all_video_frames(file.name, restart_timestamp))
             for frame, orig in zip(frames, original[2:]):
                 assert _images_equal(frame, orig)
 
@@ -228,12 +232,12 @@ class TestDownload(unittest.TestCase):
                 tempfile.NamedTemporaryFile(suffix='.avi') as file:
 
                 original = _generate_video(file.name, fps=fps)
-                all_frames = download.download_all_video_frames(
+                all_frames = lightly.api.download.download_all_video_frames(
                     file.name,
                     as_pil_image=False,
                 )
                 for true_frame in all_frames:
-                    frame = download.download_video_frame(
+                    frame = lightly.api.download.download_video_frame(
                         file.name,
                         timestamp=true_frame.pts,
                         as_pil_image=False,
@@ -249,12 +253,12 @@ class TestDownload(unittest.TestCase):
                 original = _generate_video(file.name, fps=fps)
 
                 # this should be the last frame and exist
-                frame = download.download_video_frame(file.name, len(original))
+                frame = lightly.api.download.download_video_frame(file.name, len(original))
                 assert _images_equal(frame, original[-1])
 
                 # timestamp after last frame
                 with self.assertRaises(ValueError):
-                    download.download_video_frame(file.name, len(original) + 1)
+                    lightly.api.download.download_video_frame(file.name, len(original) + 1)
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
     def test_download_video_frame_negative_timestamp_exception(self):
@@ -264,7 +268,7 @@ class TestDownload(unittest.TestCase):
                 
                 _generate_video(file.name, fps=fps)
                 with self.assertRaises(ValueError):
-                    download.download_video_frame(file.name, -1)
+                    lightly.api.download.download_video_frame(file.name, -1)
 
     def test_download_and_write_file(self):
         original = _pil_image()
@@ -272,7 +276,7 @@ class TestDownload(unittest.TestCase):
             tempfile.NamedTemporaryFile(suffix='.png') as file2:
             
             original.save(file1.name)
-            download.download_and_write_file(file1.name, file2.name)
+            lightly.api.download.download_and_write_file(file1.name, file2.name)
             image = Image.open(file2.name)
             assert _images_equal(original, image)
     
@@ -283,7 +287,7 @@ class TestDownload(unittest.TestCase):
             tempfile.NamedTemporaryFile(suffix='.png') as file2:
             
             original.save(file1.name)
-            download.download_and_write_file(file1.name, file2.name, session=session)
+            lightly.api.download.download_and_write_file(file1.name, file2.name, session=session)
             image = Image.open(file2.name)
             assert _images_equal(original, image)
 
@@ -302,7 +306,7 @@ class TestDownload(unittest.TestCase):
 
             # download images from remote to local
             file_infos = list(zip(filenames, urls))
-            download.download_and_write_all_files(
+            lightly.api.download.download_and_write_all_files(
                 file_infos, 
                 output_dir=tempdir2, 
                 max_workers=max_workers
@@ -321,7 +325,7 @@ class TestDownload(unittest.TestCase):
                     self.subTest(msg=f'n_frames={true_n_frames}, extension={suffix}'):
 
                     _generate_video(file.name, n_frames=true_n_frames, fps=fps)
-                    n_frames = download.video_frame_count(file.name)
+                    n_frames = lightly.api.download.video_frame_count(file.name)
                     assert n_frames == true_n_frames
 
     @unittest.skipUnless(AV_AVAILABLE, "Pyav not installed")
@@ -333,7 +337,7 @@ class TestDownload(unittest.TestCase):
                     self.subTest(msg=f'n_frames={true_n_frames}, extension={suffix}'):
 
                     _generate_video(file.name, n_frames=true_n_frames, fps=fps)
-                    n_frames = download.video_frame_count(
+                    n_frames = lightly.api.download.video_frame_count(
                         file.name,
                         ignore_metadata=True
                     )
@@ -350,7 +354,7 @@ class TestDownload(unittest.TestCase):
 
                 _generate_video(file1.name, n_frames=true_n_frames[0], fps=fps)
                 _generate_video(file2.name, n_frames=true_n_frames[1], fps=fps)
-                frame_counts = download.all_video_frame_counts(
+                frame_counts = lightly.api.download.all_video_frame_counts(
                     urls=[file1.name, file2.name],
                 )
                 assert sum(frame_counts) == sum(true_n_frames)
@@ -367,7 +371,7 @@ class TestDownload(unittest.TestCase):
             _generate_video(file2.name, fps=fps, broken=True)
             
             urls = [file1.name, file2.name]
-            result = download.all_video_frame_counts(urls)
+            result = lightly.api.download.all_video_frame_counts(urls)
             assert result == [n_frames, None]
 
 


### PR DESCRIPTION
## Description
1. Finding the root cause for any such problems is hard, as the retry catches the real exception -> solution: Let the `retry` raise the `RuntimeError` from the real exception.

2. New `download_image` function uses
```
with req.get(url=url, stream=True) as response:
    image = PIL.Image.open(response.raw)
    image.load()
```
The actual loading of the data over the internet can happen when using `image.load()`. Thus all of this is wrapped in a retry.

Two unittests were added, which both mock the stream to only be 1024 bytes long, causing an `OSError` caught by the retry.

3. Tested the new `download_image()` function also with real urls from large images (5MB jpeg, 33MB tif). Download speeds were about 70MBit/s. 

## Open problem:
When turning off WiFi during the download of such big images, the download freezes (nothing happened for 30s. After turning WiFi on again, nothing happened (for 30 s). I tried without retry, so it was not in the return loop. Then, when hitting CTRL-C, the seek not supported error, just like in the issue, occurred:

```
  File "/Users/malteebnerlightly/Documents/GitHub/lightly/venv/lib/python3.9/site-packages/PIL/Image.py", line 2972, in open
    fp.seek(0)
io.UnsupportedOperation: seek

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/malteebnerlightly/Documents/GitHub/lightly/tests/UNMOCKED_end2end_tests/test_download_large_files.py", line 13, in <module>
    img = download_image(url_5MB)
  File "/Users/malteebnerlightly/Documents/GitHub/lightly/venv/lib/python3.9/site-packages/lightly/api/download.py", line 43, in download_image
    return PIL.Image.open(response.raw)
  File "/Users/malteebnerlightly/Documents/GitHub/lightly/venv/lib/python3.9/site-packages/PIL/Image.py", line 2974, in open
    fp = io.BytesIO(fp.read())
  File "/Users/malteebnerlightly/Documents/GitHub/lightly/venv/lib/python3.9/site-packages/urllib3/response.py", line 515, in read
    data = self._fp.read() if not fp_closed else b""
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/http/client.py", line 475, in read
    s = self._safe_read(self.length)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/http/client.py", line 625, in _safe_read
    chunk = self.fp.read(min(amt, MAXAMOUNT))
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/socket.py", line 704, in readinto
    return self._sock.recv_into(b)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ssl.py", line 1241, in recv_into
    return self.read(nbytes, buffer)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ssl.py", line 1099, in read
    return self._sslobj.read(len, buffer)
KeyboardInterrupt
```

Follow-Up issue to solve this: https://linear.app/lightly/issue/LIG-1113/add-timeout-to-retry-to-preven-frozen-docker

 ## Other
closes #LIG-1115 (Pip import of download failing if pyav is not installed)
