### PR TITLE
added hardware recommendations to docs

### DIFF
--- a/docs/source/docker/getting_started/hardware_recommendations.rst
+++ b/docs/source/docker/getting_started/hardware_recommendations.rst
@@ -14,7 +14,6 @@ based on three criteria:
 - stability: The worker should not crash because it runs out of memory.
 
 Depending on your dataset size, we recommend the following machine:
-
 - Up to 100.000 images or video frames: Use the AWS EC2 instance `g4dn.xlarge` or similar
   with 4 vCPUs, 16GB of system memory, one T4 GPU
 - Up to 1 Million images or video frames: Use the AWS EC2 instance `g4dn.2xlarge` or similar
@@ -28,10 +27,12 @@ E.g. 100 videos with 600s length each and 30 fps have 100 * 600 * 30 = 1.8 Mio f
 If you want to train an embedding model for many epochs or want to further increase computing speed,
 we recommend to switch to a V100 or A10 GPU or better.
 
-If you read the data from a local hard disk, make sure that you use a SSD.
-If you read the data from a cloud bucket instead, make sure that
+If you stream the data from a cloud bucket using the datasource feature, make sure that
 the cloud bucket is in the same region as the compute machine.
 Using the same region is very important, see also :ref:`ref-docker-network-traffic-same-region`
+If you are using the old workflow of reading from a local disk instead, use a SSD.
+However, we recommend the workflow to stream from a cloud bucket.
+
 
 Keep the configuration option `lightly.loader.num_workers` at the default (-1),
 which will set it to the number of vCPUs on your machine.

--- a/docs/source/docker/getting_started/hardware_recommendations.rst
+++ b/docs/source/docker/getting_started/hardware_recommendations.rst
@@ -3,59 +3,65 @@
 Hardware recommendations
 ========================
 
-Usually, the Lightly worker is run on a cloud machine,
-which is spin up specifically to run the docker.
-Our recommendations on the hardware configuration of this machine are
+Lightly worker is usually run on dedicated hardware
+or in the cloud on a compute instance
+which is specifically spun up to run Lightly Worker standalone.
+Our recommendations on the hardware requirements of this compute instance are
 based on three criteria:
 
 - speed: The worker should process your dataset as quickly a possible.
-- cost-effectiveness: The machine should be cheap to rent.
+- cost-effectiveness: The compute instance should be economical.
 - stability: The worker should not crash because it runs out of memory.
 
-As a starting point, we recommend a machine with the following configuration:
+Depending on your dataset size, we recommend the following machine:
 
-- 8 vCPUs
-- 30-32 GB of system memory
-- a NVIDIA-GPU with 16GB of video memory, e.g. the T4 GPU.
+- Up to 100.000 images or video frames: Use the AWS EC2 instance `g4dn.xlarge` or similar
+  with 4 vCPUs, 16GB of system memory, one T4 GPU
+- Up to 1 Million images or video frames: Use the AWS EC2 instance `g4dn.2xlarge` or similar
+  with 8 vCPUs, 32GB of system memory, one T4 GPU
+- More than 1 Million images or video frames: Use the AWS EC2 instance `g4dn.4xlarge` or similar
+  with 16 vCPUs, 64GB of system memory, one T4 GPU
 
-If you read the data from a local hard disk, make sure that the connection is fast,
-ideally faster than 100MB/s.
+You can compute the number of frames of your videos with their length and fps.
+E.g. 100 videos with 600s length each and 30 fps have 100 * 600 * 30 = 1.8 Mio frames.
 
+If you want to train an embedding model for many epochs or want to further increase computing speed,
+we recommend to switch to a V100 or A10 GPU or better.
+
+If you read the data from a local hard disk, make sure that you use a SSD.
 If you read the data from a cloud bucket instead, make sure that
-the cloud bucket is in the same region as the compute machine
-and the download speed is fast, ideally faster than 100MB/s.
+the cloud bucket is in the same region as the compute machine.
+Using the same region is very important, see also :ref:`ref-docker-network-traffic-same-region`
 
 Keep the configuration option `lightly.loader.num_workers` at the default (-1),
 which will set it to the number of vCPUs on your machine.
 
-The best machine hardware configuration is highly dependent
-on the type of data you have and how you configure the worker.
-Thus we recommend to adapt it to your needs.
-
 Finding the compute speed bottleneck
 ------------------------------------
 
-Usually, the compute speed is limited by one of three potential bottlenecks:
+Usually, the compute speed is limited by one of three potential bottlenecks.
+Different steps of the Lightly worker use these resources to a different extent.
+Thus the bottleneck changes throughout the run. The bottlenecks are:
 
 - data read speed: I/O
 - CPU
 - GPU
 
-Different steps of the Lightly worker use these resources to a different extent.
-Thus the bottleneck changes throughout the run.
-The GPU is used at three steps:
+
+The GPU is used during three steps:
 
 - training an embedding model (optional step)
 - pretagging your dataset (optional step)
 - embedding your dataset
 
-The I/O and CPUs are used at the former 3 steps and also used at the other steps that may take longer:
+The I/O and CPUs are used during the previous 3 steps and also used during the other steps that may take longer:
 
 - initializing the dataset
 - corruptness check (optional step)
 - dataset dumping & upload (optional step)
 
-Before updating one or all of resources, we recommend finding out the current bottleneck:
+Before changing the hardware configuration of your compute instance,
+we recommend to first determine the bottleneck by monitoring it:
 
 - You can find out the current disk usage of your machine using the terminal command `iotop`.
 - If you use a datasource, see the current ethernet usage using the terminal command `ifstat`.

--- a/docs/source/docker/getting_started/hardware_recommendations.rst
+++ b/docs/source/docker/getting_started/hardware_recommendations.rst
@@ -1,0 +1,82 @@
+.. _ref-hardware-recommendations:
+
+Hardware recommendations
+========================
+
+Usually, the Lightly worker is run on a cloud machine,
+which is spin up specifically to run the docker.
+Our recommendations on the hardware configuration of this machine are
+based on three criteria:
+
+- speed: The worker should process your dataset as quickly a possible.
+- cost-effectiveness: The machine should be cheap to rent.
+- stability: The worker should not crash because it runs out of memory.
+
+As a starting point, we recommend a machine with the following configuration:
+
+- 8 vCPUs
+- 30-32 GB of system memory
+- a NVIDIA-GPU with 16GB of video memory, e.g. the T4 GPU.
+
+If you read the data from a local hard disk, make sure that the connection is fast,
+ideally faster than 100MB/s.
+
+If you read the data from a cloud bucket instead, make sure that
+the cloud bucket is in the same region as the compute machine
+and the download speed is fast, ideally faster than 100MB/s.
+
+Keep the configuration option `lightly.loader.num_workers` at the default (-1),
+which will set it to the number of vCPUs on your machine.
+
+The best machine hardware configuration is highly dependent
+on the type of data you have and how you configure the worker.
+Thus we recommend to adapt it to your needs.
+
+Finding the compute speed bottleneck
+------------------------------------
+
+Usually, the compute speed is limited by one of three potential bottlenecks:
+
+- data read speed: I/O
+- CPU
+- GPU
+
+Different steps of the Lightly worker use these resources to a different extent.
+Thus the bottleneck changes throughout the run.
+The GPU is used at three steps:
+
+- training an embedding model (optional step)
+- pretagging your dataset (optional step)
+- embedding your dataset
+
+The I/O and CPUs are used at the former 3 steps and also used at the other steps that may take longer:
+
+- initializing the dataset
+- corruptness check (optional step)
+- dataset dumping & upload (optional step)
+
+Before updating one or all of resources, we recommend finding out the current bottleneck:
+
+- You can find out the current disk usage of your machine using the terminal command `iotop`.
+- If you use a datasource, see the current ethernet usage using the terminal command `ifstat`.
+- You can find out the current CPU and RAM usage of your machine using the terminal commands `top` or `htop`.
+- You can find out the current GPU usage (both compute and VRAM) using the terminal command `watch nvidia-smi`.
+- Note that you might need to install these commands using your package manager.
+
+
+Additional to using these tools, you can also compare the relative duration of the different steps to see the bottleneck.
+E.g. if the embedding step takes much longer than the corruptness check, then the GPU is the bottleneck.
+Otherwise, it is the I/O or CPU.
+
+Updating the machine
+--------------------
+
+When updating the machine, we recommend updating the resource that causes the
+bottleneck. After that, the bottleneck might have changed.
+
+If there is not one obvious bottleneck, we recommend to scale up I/O, CPUs and GPU together.
+
+To prevent the worker running out of system memory or GPU memory, we recommend
+about 4GB of RAM and 2GB ov VRAM for each vCPU.
+
+

--- a/docs/source/docker/integration/docker_with_datasource.rst
+++ b/docs/source/docker/integration/docker_with_datasource.rst
@@ -170,13 +170,15 @@ instead of only newly added data,
 then set `datasource.process_all=True` in your docker run command.
 
 
+.. _ref-docker-network-traffic-same-region:
+
 Network traffic
 ---------------
 
 Please ensure that the bucket and the instance running the Lightly Docker are
 in the same cloud region (S3, Azure) or zone (GCS). E.g. if you are using S3, 
 have the instance running in `eu-central-1` and the bucket also in 
-`eu-central-1`. If the region or zone are note the same there can be 
+`eu-central-1`. If the region or zone are not the same there can be
 **additional transfer costs** and **degraded transfer speeds**. Please consult
 the pricing page of your cloud provider for more details
 (`S3 <https://aws.amazon.com/s3/pricing/>`_,

--- a/docs/source/docker/overview.rst
+++ b/docs/source/docker/overview.rst
@@ -64,11 +64,7 @@ We worked hard to make this happen and are very proud to present you with the fo
 
 * Recommended hardware:
   
-  * 8 CPU cores or more
-
-  * 16GB free RAM (>64GB for datasets above 10m samples)
- 
-  * 1 Nvidia Tesla P100, T4, V100 or A100 GPU with CUDA 10.0+
+  * see :ref:`ref-hardware-recommendations`
 
 .. toctree::
    :maxdepth: 1
@@ -80,4 +76,5 @@ We worked hard to make this happen and are very proud to present you with the fo
    configuration/configuration.rst
    examples/overview.rst
    known_issues_faq.rst
+   getting_started/hardware_recommendations.rst
 


### PR DESCRIPTION
## Description
- Added it as a separate top-level docs, just like the other docs in getting_started.
- Split it into there parts:
  - Starting machine recommendations
  - Instructions on how to find the compute speed bottleneck
  - Instructions on how to update the machine hardware

## New page
[Hardware recommendations — lightly 1.2.15 documentation.pdf](https://github.com/lightly-ai/lightly/files/8684836/Hardware.recommendations.lightly.1.2.15.documentation.pdf)

