### PR TITLE
Add tqdm for VideoDataset inialization frame counting.

### DIFF
--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -4,7 +4,7 @@
 # All Rights Reserved
 
 import os
-from typing import List, Set, Optional, Callable
+from typing import List, Set, Optional, Callable, Dict, Any
 
 from torchvision import datasets
 
@@ -89,7 +89,7 @@ def _contains_subdirs(root: str):
 def _load_dataset_from_folder(
         root: str, transform,
         is_valid_file: Optional[Callable[[str], bool]] = None,
-        **tqdm_kwargs,
+        tqdm_args: Dict[str, Any] = None,
 ):
     """Initializes dataset from folder.
 
@@ -124,7 +124,7 @@ def _load_dataset_from_folder(
             extensions=VIDEO_EXTENSIONS,
             transform=transform,
             is_valid_file=is_valid_file,
-            **tqdm_kwargs
+            tqdm_args=tqdm_args
         )
     elif _contains_subdirs(root):
         # root contains subdirectories -> create an image folder dataset

--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -88,8 +88,9 @@ def _contains_subdirs(root: str):
 
 def _load_dataset_from_folder(
         root: str, transform,
-        is_valid_file: Optional[Callable[[str], bool]] = None
-    ):
+        is_valid_file: Optional[Callable[[str], bool]] = None,
+        **tqdm_kwargs,
+):
     """Initializes dataset from folder.
 
     Args:
@@ -118,11 +119,13 @@ def _load_dataset_from_folder(
 
     if contains_videos:
         # root contains videos -> create a video dataset
-        dataset = VideoDataset(root,
-                               extensions=VIDEO_EXTENSIONS,
-                               transform=transform,
-                               is_valid_file=is_valid_file
-                               )
+        dataset = VideoDataset(
+            root,
+            extensions=VIDEO_EXTENSIONS,
+            transform=transform,
+            is_valid_file=is_valid_file,
+            **tqdm_kwargs
+        )
     elif _contains_subdirs(root):
         # root contains subdirectories -> create an image folder dataset
         dataset = datasets.ImageFolder(root,

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -4,7 +4,7 @@
 # All Rights Reserved
 
 import os
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Any
 from fractions import Fraction
 import threading
 import weakref
@@ -298,7 +298,7 @@ def _make_dataset(
         extensions=None,
         is_valid_file=None,
         pts_unit='sec',
-        **tqdm_kwargs
+        tqdm_args=None
 ):
     """Returns a list of all video files, timestamps, and offsets.
 
@@ -317,6 +317,8 @@ def _make_dataset(
 
     """
 
+    if tqdm_args is None:
+        tqdm_args = {}
     if extensions is None:
         if is_valid_file is None:
             ValueError('Both extensions and is_valid_file cannot be None')
@@ -350,12 +352,12 @@ def _make_dataset(
     # get timestamps
     timestamps, fpss = [], []
     video_instances_unbroken = []
-    tqdm_kwargs = dict(tqdm_kwargs)
-    tqdm_kwargs.setdefault('unit', ' video')
-    tqdm_kwargs.setdefault('desc', 'Counting frames in videos')
+    tqdm_args = dict(tqdm_args)
+    tqdm_args.setdefault('unit', ' video')
+    tqdm_args.setdefault('desc', 'Counting frames in videos')
     pbar = tqdm(
         video_instances,
-        **tqdm_kwargs
+        **tqdm_args
     )
     for instance in pbar:
 
@@ -452,7 +454,7 @@ class VideoDataset(datasets.VisionDataset):
                  target_transform=None,
                  is_valid_file=None,
                  exception_on_non_increasing_timestamp=True,
-                 **tqdm_kwargs
+                 tqdm_args: Dict[str, Any]=None
                  ):
         
         super(VideoDataset, self).__init__(root,
@@ -460,7 +462,7 @@ class VideoDataset(datasets.VisionDataset):
                                            target_transform=target_transform)
 
         videos, video_timestamps, offsets, fps = _make_dataset(
-            self.root, extensions, is_valid_file, **tqdm_kwargs)
+            self.root, extensions, is_valid_file, tqdm_args=tqdm_args)
         
         if len(videos) == 0:
             msg = 'Found 0 videos in folder: {}\n'.format(self.root)

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -154,7 +154,9 @@ class LightlyDataset:
                  transform: transforms.Compose = None,
                  index_to_filename:
                  Callable[[datasets.VisionDataset, int], str] = None,
-                 filenames: List[str] = None):
+                 filenames: List[str] = None,
+                 **tqdm_kwargs
+                 ):
 
         # can pass input_dir=None to create an "empty" dataset
         self.input_dir = input_dir
@@ -172,7 +174,7 @@ class LightlyDataset:
 
         if self.input_dir is not None:
             self.dataset = _load_dataset_from_folder(
-                self.input_dir, transform, is_valid_file=is_valid_file
+                self.input_dir, transform, is_valid_file=is_valid_file, **tqdm_kwargs
             )
         elif transform is not None:
             raise ValueError(

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 
 from PIL import Image
-from typing import List, Union, Callable
+from typing import List, Union, Callable, Dict, Any
 from torch._C import Value
 
 import torchvision.datasets as datasets
@@ -155,7 +155,7 @@ class LightlyDataset:
                  index_to_filename:
                  Callable[[datasets.VisionDataset, int], str] = None,
                  filenames: List[str] = None,
-                 **tqdm_kwargs
+                 tqdm_args: Dict[str, Any] = None,
                  ):
 
         # can pass input_dir=None to create an "empty" dataset
@@ -174,7 +174,7 @@ class LightlyDataset:
 
         if self.input_dir is not None:
             self.dataset = _load_dataset_from_folder(
-                self.input_dir, transform, is_valid_file=is_valid_file, **tqdm_kwargs
+                self.input_dir, transform, is_valid_file=is_valid_file, tqdm_args=tqdm_args
             )
         elif transform is not None:
             raise ValueError(

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -1,11 +1,13 @@
+import contextlib
+import io
 from fractions import Fraction
 import unittest
 import os
 import shutil
 from unittest import mock
+
 import numpy as np
 import tempfile
-import warnings
 import PIL
 import torch
 import torchvision
@@ -82,16 +84,23 @@ class TestVideoDataset(unittest.TestCase):
 
         shutil.rmtree(self.input_dir)
 
-    def test_video_dataset_kwargs(self):
+    def test_video_dataset_tqdm_args(self):
 
         self.create_dataset()
-        dataset = VideoDataset(
-            self.input_dir,
-            extensions=self.extensions,
-            desc="Counting frames",
-            unit="video"
-        )
+        desc = "test_video_dataset_tqdm_args description asdf"
+        f = io.StringIO()
+        with contextlib.redirect_stderr(f):
+            dataset = VideoDataset(
+                self.input_dir,
+                extensions=self.extensions,
+                tqdm_args={
+                    "desc": desc,
+                }
+            )
         shutil.rmtree(self.input_dir)
+        printed = f.getvalue()
+        self.assertTrue(desc in printed)
+
 
 
     def test_video_dataset_from_folder(self):

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -163,8 +163,8 @@ class TestVideoDataset(unittest.TestCase):
         self.create_dataset(n_videos=2, n_frames_per_video=5)
         
         # overwrite the _make_dataset function to return a wrong timestamp
-        def _make_dataset_with_non_increasing_timestamps(*args):
-            video_instances, timestamps, offsets, fpss = _make_dataset(*args)
+        def _make_dataset_with_non_increasing_timestamps(*args, **kwargs):
+            video_instances, timestamps, offsets, fpss = _make_dataset(*args, **kwargs)
             # set timestamp of 4th frame in 1st video to timestamp of 2nd frame.
             timestamps[0][3] = timestamps[0][1]
             return video_instances, timestamps, offsets, fpss

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -82,6 +82,17 @@ class TestVideoDataset(unittest.TestCase):
 
         shutil.rmtree(self.input_dir)
 
+    def test_video_dataset_kwargs(self):
+
+        self.create_dataset()
+        dataset = VideoDataset(
+            self.input_dir,
+            extensions=self.extensions,
+            desc="Counting frames",
+            unit="video"
+        )
+        shutil.rmtree(self.input_dir)
+
 
     def test_video_dataset_from_folder(self):
 


### PR DESCRIPTION
## Description
- `LightyDataset` now supports `**tqdm_kwargs`
- `VideoDataset` initialisation frame counting now has a tqdm progress bar.
- The tqdm args for this progress bar can be set via the `LightlyDataset(**kwargs)`
- They default to `unit="video"` and `desc="Counting frames in videos"`

Example:
`Counting frames in videos:  34%|███▎      | 641/1900 [00:11<00:20, 62.68 video/s]`

## Why is there no progress bar for image datasets?
- Listing all files in a folder is pretty fast.
- We don't know the number of files beforehand, making a progress bar less useful.
- All files in a folder are listed twice anyway: Once for finding out if the folder has videos, then once again when actually getting the paths. This could be optimised, but should be left to a bigger refactoring.

