### PR TITLE
lig-891 cd for docs

### DIFF
--- a/docs/source/tutorials_source/platform/tutorial_active_learning.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning.py
@@ -242,3 +242,13 @@ unlabeled_set_features = dataset.get_features(agent.unlabeled_set)
 unlabeled_set_labels = dataset.get_labels(agent.unlabeled_set)
 accuracy_on_unlabeled_set = classifier.score(X=unlabeled_set_features, y=unlabeled_set_labels)
 print(f"accuracy on unlabeled set: {accuracy_on_unlabeled_set}")
+
+# %%
+# Optional: here we created tags 'initial-selection' and 'al-iteration-1' for our dataset ("active_learning_clothing_dataset").
+# These can be viewed on the `Lightly Platform <https://app.lightly.ai>`_.
+# To re-use the dataset without tags from past experiments, we can (optionally!) remove 
+# tags other than the initial-tag:
+
+for tag in api_workflow_client.get_all_tags():
+  if tag.prev_tag_id is not None:
+    api_workflow_client.delete_tag_by_id(tag.id)

--- a/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
@@ -318,12 +318,24 @@ for i in range(5):
   predict_and_overlay(predictor, to_label[i])
 
 # %%
+# Samples selected in the step above were placed in the 'active-learning-loop-1' tag.
+# This can be viewed on the `Lightly Platform <https://app.lightly.ai/datasets>`_.
+
+# %%
+# To re-use a dataset without tags from past experiments, we can (optionally!) remove 
+# tags other than the initial-tag:
+
+for tag in api_client.get_all_tags():
+  if tag.prev_tag_id is not None:
+    api_client.delete_tag_by_id(tag.id)
+
+# %%
 # Next Steps
 # -------------
 # 
 # We showed in this tutorial how you can use Lightly Active Learning to discover 
 # the images you should label next. You can close the loop by annotating 
-# the 100 images and re-train your model. Then start the next iteration 
+# the 100 images and re-training your model. Then start the next iteration 
 # by making new model predictions on the `query_set`.
 #
 # Using Lightly Active Learning has two advantages:


### PR DESCRIPTION
- in active learning tutorials (platform 3 and 4), now shows how to remove created tags
- the real motivation for this is to allow for (sufficiently) idempotent docs builds
- when a tutorial is built creating tags, tags are also then deleted during the build, avoiding naming collisions on the next build

![Screenshot from 2022-05-18 10-06-35](https://user-images.githubusercontent.com/1595173/168990027-de3f11c0-95a3-4e1e-9890-8ea5a8f7f264.png)
![Screenshot from 2022-05-18 10-06-49](https://user-images.githubusercontent.com/1595173/168990031-2a796e6e-e688-4a90-9286-319d3a7ccb9e.png)
