### PR TITLE
Malte lig 1014 improve video indexing speed for local datasets

### DIFF
--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -211,7 +211,7 @@ if not isinstance(av, ModuleNotFoundError):
             except RuntimeError:
                 return
 
-        with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
             return list(executor.map(job, urls))
 
 

--- a/lightly/api/download.py
+++ b/lightly/api/download.py
@@ -4,7 +4,7 @@ import pathlib
 import shutil
 import threading
 import warnings
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import PIL
@@ -211,7 +211,7 @@ if not isinstance(av, ModuleNotFoundError):
             except RuntimeError:
                 return
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        with ProcessPoolExecutor(max_workers=max_workers) as executor:
             return list(executor.map(job, urls))
 
 

--- a/lightly/data/_helpers.py
+++ b/lightly/data/_helpers.py
@@ -90,6 +90,7 @@ def _load_dataset_from_folder(
         root: str, transform,
         is_valid_file: Optional[Callable[[str], bool]] = None,
         tqdm_args: Dict[str, Any] = None,
+        num_workers_video_frame_counting: int = 0
 ):
     """Initializes dataset from folder.
 
@@ -124,7 +125,8 @@ def _load_dataset_from_folder(
             extensions=VIDEO_EXTENSIONS,
             transform=transform,
             is_valid_file=is_valid_file,
-            tqdm_args=tqdm_args
+            tqdm_args=tqdm_args,
+            num_workers=num_workers_video_frame_counting
         )
     elif _contains_subdirs(root):
         # root contains subdirectories -> create an image folder dataset

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -10,6 +10,7 @@ import threading
 import weakref
 import warnings
 
+import numpy as np
 from PIL import Image
 
 import torch
@@ -359,44 +360,27 @@ def _make_dataset(
         video_instances,
         **tqdm_args
     )
-    for instance in pbar:
+    def timestamp_fps_instance_from_instance(instance):
+        ts, fps = io.read_video_timestamps(instance, pts_unit=pts_unit)
+        return ts, fps, instance
 
-        if AV_AVAILABLE and torchvision.get_video_backend() == 'pyav':
-            # This is a hacky solution to estimate the timestamps.
-            # When using the video_reader this approach fails because the 
-            # estimated timestamps are not correct.
-            with av.open(instance) as av_video:
-                stream = av_video.streams.video[0]
-
-                # check if we can extract the video duration
-                if not stream.duration:
-                    print(f'Video {instance} has no timestamp and will be skipped...')
-                    continue # skip this broken video
-
-                duration = stream.duration * stream.time_base
-                fps = stream.base_rate
-                n_frames = int(int(duration) * fps)
-
-            timestamps.append([Fraction(i, fps) for i in range(n_frames)])
-            fpss.append(fps)
-        else:
-            ts, fps = io.read_video_timestamps(instance, pts_unit=pts_unit)
-            timestamps.append(ts)
-            fpss.append(fps)
-        video_instances_unbroken.append(instance)
+    timestamps_fpss_instances = [
+        timestamp_fps_instance_from_instance(instance)
+        for instance
+        in pbar
+    ]
+    timestamps, fpss, video_instances_unbroken = zip(*timestamps_fpss_instances)
 
     # get frame offsets
     offsets = [len(ts) for ts in timestamps]
-    offsets = [0] + offsets[:-1]
-    for i in range(1, len(offsets)):
-        offsets[i] = offsets[i-1] + offsets[i] # cumsum
+    offsets = list(np.cumsum(offsets))
 
     return video_instances_unbroken, timestamps, offsets, fpss
 
 
 def _find_non_increasing_timestamps(
     timestamps: List[Fraction]
-    ) -> List[bool]:
+    ) -> np.ndarray:
     """Finds all non-increasing timestamps.
 
     Arguments:
@@ -408,17 +392,13 @@ def _find_non_increasing_timestamps(
         non-increasing and False otherwise.
 
     """
-    is_non_increasing = []
-    max_timestamp = None
-    for timestamp in timestamps:
-        if (
-            max_timestamp is None
-            or timestamp > max_timestamp
-         ):
-            is_non_increasing.append(False)
+    is_non_increasing = np.zeros(shape=len(timestamps), dtype=bool, )
+    max_timestamp = timestamps[0]-1
+    for i, timestamp in enumerate(timestamps):
+        if timestamp > max_timestamp:
             max_timestamp = timestamp
         else:
-            is_non_increasing.append(True)
+            is_non_increasing[i] = True
     
     return is_non_increasing
 

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -4,7 +4,6 @@
 # All Rights Reserved
 
 import os
-from multiprocessing import freeze_support
 from typing import List, Tuple, Dict, Any
 from fractions import Fraction
 import threading

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -4,6 +4,7 @@
 # All Rights Reserved
 
 import os
+from multiprocessing import freeze_support
 from typing import List, Tuple, Dict, Any
 from fractions import Fraction
 import threading
@@ -15,6 +16,7 @@ from PIL import Image
 
 import torch
 import torchvision
+from torch.utils.data import DataLoader, Dataset
 from torchvision import datasets
 from torchvision import io
 from tqdm import tqdm
@@ -124,9 +126,9 @@ class VideoLoader(threading.local):
         >>> frame = video_loader.read_frame()
     """
     def __init__(
-        self, 
-        path: str, 
-        timestamps: List[float], 
+        self,
+        path: str,
+        timestamps: List[float],
         backend: str = 'video_reader',
         eps: float = 1e-6,
     ):
@@ -143,7 +145,7 @@ class VideoLoader(threading.local):
             self.reader = io.VideoReader(path = self.path)
         else:
             self.reader = None
-    
+
     def read_frame(self, timestamp = None):
         """Reads the next frame or from timestamp.
 
@@ -294,12 +296,29 @@ class VideoLoader(threading.local):
         image = Image.fromarray(frame.numpy())
         return image
 
+
+class _TimestampFpsFromVideosDataset(Dataset):
+
+    def __init__(self, video_instances: List[str], pts_unit: str):
+        self.video_instances = video_instances
+        self.pts_unit = pts_unit
+
+    def __len__(self):
+        return len(self.video_instances)
+
+    def __getitem__(self, index):
+        instance = self.video_instances[index]
+        ts, fps = io.read_video_timestamps(instance, pts_unit=self.pts_unit)
+        return ts, fps
+
+
 def _make_dataset(
         directory,
         extensions=None,
         is_valid_file=None,
         pts_unit='sec',
-        tqdm_args=None
+        tqdm_args=None,
+        num_workers: int = 0
 ):
     """Returns a list of all video files, timestamps, and offsets.
 
@@ -312,6 +331,10 @@ def _make_dataset(
             Used to find valid files.
         pts_unit:
             Unit of the timestamps.
+        tqdm_args:
+            arguments to pass to tqdm
+        num_workers:
+            number of workers to use for multithreading
 
     Returns:
         A list of video files, timestamps, frame offsets, and fps.
@@ -350,37 +373,34 @@ def _make_dataset(
             path = os.path.join(root, fname)
             video_instances.append(path)
 
-    # get timestamps
-    timestamps, fpss = [], []
-    video_instances_unbroken = []
+    # define loader to get the timestamps
+    num_workers = min(num_workers, len(video_instances))
+    if len(video_instances) == 1:
+        num_workers = 0
+    loader = DataLoader(
+        _TimestampFpsFromVideosDataset(video_instances, pts_unit=pts_unit),
+        num_workers=num_workers,
+        batch_size=None,
+        shuffle=False
+    )
+
+    # actually load the data
     tqdm_args = dict(tqdm_args)
     tqdm_args.setdefault('unit', ' video')
     tqdm_args.setdefault('desc', 'Counting frames in videos')
-    pbar = tqdm(
-        video_instances,
-        **tqdm_args
-    )
-    def timestamp_fps_instance_from_instance(instance):
-        ts, fps = io.read_video_timestamps(instance, pts_unit=pts_unit)
-        return ts, fps, instance
-
-    timestamps_fpss_instances = [
-        timestamp_fps_instance_from_instance(instance)
-        for instance
-        in pbar
-    ]
-    timestamps, fpss, video_instances_unbroken = zip(*timestamps_fpss_instances)
+    timestamps_fpss = list(tqdm(loader, **tqdm_args))
+    timestamps, fpss = zip(*timestamps_fpss)
 
     # get frame offsets
     offsets = [len(ts) for ts in timestamps]
-    offsets = list(np.cumsum(offsets))
+    offsets = list(np.cumsum(offsets) - offsets[0])
 
-    return video_instances_unbroken, timestamps, offsets, fpss
+    return video_instances, timestamps, offsets, fpss
 
 
 def _find_non_increasing_timestamps(
     timestamps: List[Fraction]
-    ) -> np.ndarray:
+    ) -> List[bool]:
     """Finds all non-increasing timestamps.
 
     Arguments:
@@ -392,6 +412,8 @@ def _find_non_increasing_timestamps(
         non-increasing and False otherwise.
 
     """
+    if len(timestamps) == 0:
+        return []
     is_non_increasing = np.zeros(shape=len(timestamps), dtype=bool, )
     max_timestamp = timestamps[0]-1
     for i, timestamp in enumerate(timestamps):
@@ -399,8 +421,8 @@ def _find_non_increasing_timestamps(
             max_timestamp = timestamp
         else:
             is_non_increasing[i] = True
-    
-    return is_non_increasing
+
+    return list(is_non_increasing)
 
 
 class VideoDataset(datasets.VisionDataset):
@@ -434,16 +456,22 @@ class VideoDataset(datasets.VisionDataset):
                  target_transform=None,
                  is_valid_file=None,
                  exception_on_non_increasing_timestamp=True,
-                 tqdm_args: Dict[str, Any]=None
+                 tqdm_args: Dict[str, Any]=None,
+                 num_workers: int = 0,
                  ):
-        
+
         super(VideoDataset, self).__init__(root,
                                            transform=transform,
                                            target_transform=target_transform)
 
         videos, video_timestamps, offsets, fps = _make_dataset(
-            self.root, extensions, is_valid_file, tqdm_args=tqdm_args)
-        
+            self.root,
+            extensions,
+            is_valid_file,
+            tqdm_args=tqdm_args,
+            num_workers=num_workers
+        )
+
         if len(videos) == 0:
             msg = 'Found 0 videos in folder: {}\n'.format(self.root)
             if extensions is not None:
@@ -466,7 +494,7 @@ class VideoDataset(datasets.VisionDataset):
         self.video_timestamps_is_non_increasing = [
             _find_non_increasing_timestamps(timestamps) for timestamps in video_timestamps
         ]
-        
+
         # offsets[i] indicates the index of the first frame of the i-th video.
         # e.g. for two videos of length 10 and 20, the offsets will be [0, 10].
         self.offsets = offsets
@@ -589,7 +617,7 @@ class VideoDataset(datasets.VisionDataset):
         if index < 0 or index >= self.__len__():
             raise IndexError(f'Index {index} is out of bounds for VideoDataset'
                              f' of size {self.__len__()}.')
-    
+
         # each sample belongs to a video, to load the sample at index, we need
         # to find the video to which the sample belongs and then read the frame
         # from this video on the disk.
@@ -603,7 +631,7 @@ class VideoDataset(datasets.VisionDataset):
 
         # get frame number
         frame_number = index - self.offsets[i]
-        
+
         n_frames = self._video_frame_count(i)
         zero_padding = len(str(n_frames))
 
@@ -662,10 +690,10 @@ class VideoDataset(datasets.VisionDataset):
 
     def _format_filename(
         self,
-        video_name: str, 
-        frame_number: int, 
-        video_format: str, 
-        zero_padding: int = 8, 
+        video_name: str,
+        frame_number: int,
+        video_format: str,
+        zero_padding: int = 8,
         extension: str = 'png'
     ) -> str:
         return f'{video_name}-{frame_number:0{zero_padding}}-{video_format}.{extension}'
@@ -690,5 +718,5 @@ class VideoDataset(datasets.VisionDataset):
                 timestamps = self.video_timestamps[video_index]
                 self._video_loader = VideoLoader(video, timestamps, backend=self.backend)
                 self._video_index = video_index
-        
+
             return self._video_loader

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -156,6 +156,7 @@ class LightlyDataset:
                  Callable[[datasets.VisionDataset, int], str] = None,
                  filenames: List[str] = None,
                  tqdm_args: Dict[str, Any] = None,
+                 num_workers_video_frame_counting: int = 0
                  ):
 
         # can pass input_dir=None to create an "empty" dataset
@@ -174,7 +175,11 @@ class LightlyDataset:
 
         if self.input_dir is not None:
             self.dataset = _load_dataset_from_folder(
-                self.input_dir, transform, is_valid_file=is_valid_file, tqdm_args=tqdm_args
+                self.input_dir,
+                transform,
+                is_valid_file=is_valid_file,
+                tqdm_args=tqdm_args,
+                num_workers_video_frame_counting=num_workers_video_frame_counting
             )
         elif transform is not None:
             raise ValueError(

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import warnings
 from fractions import Fraction
 import unittest
 import os
@@ -103,12 +104,21 @@ class TestVideoDataset(unittest.TestCase):
         printed = f.getvalue()
         self.assertTrue(desc in printed)
 
-    def test_video_dataset_dataloader(self):
+    def test_video_dataset_init_dataloader(self):
         self.create_dataset()
-        dataset = LightlyDataset(
+        dataset_4_workers = LightlyDataset(
             self.input_dir,
             num_workers_video_frame_counting=4
         )
+        dataset_0_workers = LightlyDataset(
+            self.input_dir,
+            num_workers_video_frame_counting=0
+        )
+        self.assertListEqual(dataset_0_workers.get_filenames(), dataset_4_workers.get_filenames())
+        self.assertListEqual(dataset_0_workers.dataset.offsets, dataset_4_workers.dataset.offsets)
+        for timestamps_0_workers, timestamps_4_workers in zip(dataset_0_workers.dataset.video_timestamps, dataset_4_workers. dataset.video_timestamps):
+            self.assertListEqual(timestamps_0_workers, timestamps_4_workers)
+        self.assertTupleEqual(dataset_0_workers.dataset.fps, dataset_4_workers.dataset.fps)
 
 
 
@@ -147,7 +157,8 @@ class TestVideoDataset(unittest.TestCase):
         shutil.rmtree(self.input_dir)
 
     def test_video_dataset_no_read_rights(self):
-        self.create_dataset()
+        n_videos = 7
+        self.create_dataset(n_videos=n_videos)
 
         with self.subTest("no read rights files"):
             for subdir, dirs, files in os.walk(self.input_dir):
@@ -156,12 +167,11 @@ class TestVideoDataset(unittest.TestCase):
                     os.chmod(filepath, 0o000)
             # This will not raise any Permissions error, as they are caught by torchvision:
             # https://github.com/pytorch/vision/blob/5985504cc32011fbd4312600b4492d8ae0dd13b4/torchvision/io/video.py#L397
-            f = io.StringIO()
-            with contextlib.redirect_stderr(f):
+            with warnings.catch_warnings(record=True) as caught_warning:
                 dataset = LightlyDataset(self.input_dir)
-            printed = f.getvalue()
             expected_warning = "Caught error: [Errno 13] Permission denied:"
-            self.assertTrue(expected_warning in printed)
+            has_warning = [True for warning in caught_warning if expected_warning in str(warning)]
+            self.assertEqual(len(has_warning), n_videos)
             self.assertEqual(len(dataset), 0)
 
         with self.subTest("no read rights subdirs"):

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -58,8 +58,9 @@ class TestVideoDataset(unittest.TestCase):
             out.release()
 
     def test_video_similar_timestamps_for_different_backends(self):
-
-        self.create_dataset()
+        n_videos = 5
+        n_frames_per_video = 10
+        self.create_dataset(n_videos=n_videos, n_frames_per_video=n_frames_per_video)
 
         timestamps = []
         offsets = []
@@ -80,7 +81,8 @@ class TestVideoDataset(unittest.TestCase):
 
         # we expect the same timestamps and offsets
         self.assertEqual(timestamps[0], timestamps[1])
-        self.assertEqual(offsets[0], offsets[1])
+        expected_offsets = list(n_frames_per_video * i for i in range(n_videos))
+        self.assertEqual(offsets[0], offsets[1], expected_offsets)
 
         shutil.rmtree(self.input_dir)
 
@@ -100,6 +102,13 @@ class TestVideoDataset(unittest.TestCase):
         shutil.rmtree(self.input_dir)
         printed = f.getvalue()
         self.assertTrue(desc in printed)
+
+    def test_video_dataset_dataloader(self):
+        self.create_dataset()
+        dataset = LightlyDataset(
+            self.input_dir,
+            num_workers_video_frame_counting=4
+        )
 
 
 
@@ -145,8 +154,15 @@ class TestVideoDataset(unittest.TestCase):
                 for filename in files:
                     filepath = os.path.join(self.input_dir, filename)
                     os.chmod(filepath, 0o000)
-            with self.assertRaises(PermissionError):
+            # This will not raise any Permissions error, as they are caught by torchvision:
+            # https://github.com/pytorch/vision/blob/5985504cc32011fbd4312600b4492d8ae0dd13b4/torchvision/io/video.py#L397
+            f = io.StringIO()
+            with contextlib.redirect_stderr(f):
                 dataset = LightlyDataset(self.input_dir)
+            printed = f.getvalue()
+            expected_warning = "Caught error: [Errno 13] Permission denied:"
+            self.assertTrue(expected_warning in printed)
+            self.assertEqual(len(dataset), 0)
 
         with self.subTest("no read rights subdirs"):
             for subdir, dirs, files in os.walk(self.input_dir):


### PR DESCRIPTION
## Description
- remove code trying to estimate the number of frames differently with pyav because it is buggy and deprecated. See https://lightly-ai.slack.com/archives/C014FJT529M/p1651762322215329?thread_ts=1651761912.070349&cid=C014FJT529M
- make offset and timestamp increasing calculation a bit faster using numpy and pre-allocated arrays.
- use multithreading for counting the frames (implemented with a torch dataloader and dataset). Once we switch to torch >= 1.11, we could use datapipes instead: https://github.com/pytorch/pytorch/tree/master/torch/utils/data/datapipes

## Tests:
with dataset with 2000 videos, 1.5GB
on a  6-core MBP

with 0 workers: 335s
with 4 workers: 94s
with 6 workers: 73s
with 12 workers: 76s


## Limitations
I did not have a look at improving the video indexing speed for `IterableDatasets`. It is already parallelized here: https://github.com/lightly-ai/lightly/blob/ac09efa69c183a0a98447350d2f30307956e1dcd/lightly/api/download.py#L294-L295 
This should be handled in a separate issue in my eyes.