### PR TITLE
Add semantic segmentation prediction docs

### DIFF
--- a/docs/source/docker/advanced/datasource_predictions.rst
+++ b/docs/source/docker/advanced/datasource_predictions.rst
@@ -266,11 +266,6 @@ Example semantic segmentation:
                 "segmentation": [...],
                 "score": 0.9
             },
-            {
-                "category_id": 2,
-                "segmentation": [...],
-                "score": 0.5
-            }
         ]
     }
 


### PR DESCRIPTION
[Add Predictions to a Datasource — lightly 1.2.17 documentation.pdf](https://github.com/lightly-ai/lightly/files/8806431/Add.Predictions.to.a.Datasource.lightly.1.2.17.documentation.pdf)
