### PR TITLE
Add collapse detection helper

### DIFF
--- a/lightly/utils/__init__.py
+++ b/lightly/utils/__init__.py
@@ -18,3 +18,4 @@ from lightly.utils.io import save_custom_metadata
 from lightly.utils.embeddings_2d import fit_pca
 from lightly.utils.benchmarking import BenchmarkModule
 from lightly.utils.benchmarking import knn_predict
+from lightly.utils.debug import std_of_l2_normalized

--- a/lightly/utils/debug.py
+++ b/lightly/utils/debug.py
@@ -1,0 +1,25 @@
+import torch
+
+@torch.no_grad()
+def std_of_l2_normalized(z: torch.Tensor):
+    """Calculates the mean of the standard deviation of z along each dimension.
+
+    Args:
+        z:
+            A torch tensor of shape batch_size x dimension.
+
+    Returns:
+        The mean of the standard deviation of the l2 normalized tensor z along
+        each dimension.
+    
+    """
+
+    if len(z.shape) != 2:
+        raise ValueError(
+            f'Input tensor must have two dimensions but has {len(z.shape)}!'
+        )
+
+    _, d = z.shape
+
+    z_norm = torch.nn.functional.normalize(z, dim=1)
+    return torch.std(z_norm, dim=0).mean()

--- a/lightly/utils/debug.py
+++ b/lightly/utils/debug.py
@@ -4,6 +4,14 @@ import torch
 def std_of_l2_normalized(z: torch.Tensor):
     """Calculates the mean of the standard deviation of z along each dimension.
 
+    This measure was used by [0] to determine the level of collapse of the
+    learned representations. If the returned number is 0., the outputs z have
+    collapsed to a constant vector. "If the output z has a zero-mean isotropic
+    Gaussian distribution" [0], the returned number should be close to 1/sqrt(d)
+    where d is the dimensionality of the output.
+
+    [0]: https://arxiv.org/abs/2011.10566
+
     Args:
         z:
             A torch tensor of shape batch_size x dimension.

--- a/tests/utils/test_debug.py
+++ b/tests/utils/test_debug.py
@@ -1,0 +1,29 @@
+import unittest
+import torch
+import math
+
+from lightly.utils import debug
+
+BATCH_SIZE = 10
+DIMENSION = 10
+
+class TestDist(unittest.TestCase):
+
+    def test_std_of_l2_normalized_collapsed(self):
+        z = torch.ones(BATCH_SIZE, DIMENSION) # collapsed output
+        self.assertEqual(debug.std_of_l2_normalized(z), 0.0)
+
+    def test_std_of_l2_normalized_uniform(self, eps: float = 1e-5):
+        z = torch.eye(BATCH_SIZE)
+        self.assertLessEqual(
+            abs(debug.std_of_l2_normalized(z) - 1 / math.sqrt(z.shape[1])),
+            eps,
+        )
+
+    def test_std_of_l2_normalized_raises(self):
+        z = torch.zeros(BATCH_SIZE)
+        with self.assertRaises(ValueError):
+            debug.std_of_l2_normalized(z)
+        z = torch.zeros(BATCH_SIZE, BATCH_SIZE, DIMENSION)
+        with self.assertRaises(ValueError):
+            debug.std_of_l2_normalized(z)      


### PR DESCRIPTION
# Add collapse detection helper

As described [here](https://ar5iv.labs.arxiv.org/html/2011.10566#S4.SS1) this can be used to monitor the level of collapse of the output of a self-supervised model.