### PR TITLE
plot positive and negative example pairs

### DIFF
--- a/lightly/utils/debug.py
+++ b/lightly/utils/debug.py
@@ -1,4 +1,12 @@
+from typing import List, Union
+from PIL import Image
+import matplotlib.pyplot as plt
+
 import torch
+import torchvision
+
+from lightly.data.collate import BaseCollateFunction, MultiViewCollateFunction, SimCLRCollateFunction, DINOCollateFunction, SwaVCollateFunction
+
 
 @torch.no_grad()
 def std_of_l2_normalized(z: torch.Tensor):
@@ -31,3 +39,90 @@ def std_of_l2_normalized(z: torch.Tensor):
 
     z_norm = torch.nn.functional.normalize(z, dim=1)
     return torch.std(z_norm, dim=0).mean()
+
+
+
+def apply_transform_without_normalize(
+    image: Image.Image,
+    transform #.TODO: typehint: transforms.Transform,
+):
+    """TODO"""
+    # TODO: change this
+    if isinstance(transform, torchvision.transforms.Compose):
+        for transform_ in transform.transforms:
+            if isinstance(transform_, torchvision.transforms.Compose):
+                image = apply_transform_without_normalize(image, transform_)
+                continue
+            if isinstance(transform_, torchvision.transforms.Normalize):
+                continue
+            if isinstance(transform_, torchvision.transforms.ToTensor):
+                continue
+            print(transform_)
+            image = transform_(image)
+    else:
+        image = transform_(image)
+    return image
+
+
+
+def generate_grid_of_augmented_images(
+    input_images: List[Image.Image],
+    collate_function: Union[BaseCollateFunction, MultiViewCollateFunction],
+):
+    """TODO"""
+
+    grid = []
+    if isinstance(collate_function, BaseCollateFunction):
+        for _ in range(2):
+            grid.append([
+                apply_transform_without_normalize(image, collate_function.transform)
+                for image in input_images
+            ])
+    elif isinstance(collate_function, MultiViewCollateFunction):
+        for transform in collate_function.transforms:
+            grid.append([
+                apply_transform_without_normalize(image, transform)
+                for image in input_images
+            ])
+    else:
+        raise ValueError('TODO')
+    return grid
+
+
+def plot_augmented_images(
+    input_images: List[Image.Image],
+    collate_function: Union[BaseCollateFunction, MultiViewCollateFunction],
+):
+    """TODO"""
+
+    grid = generate_grid_of_augmented_images(input_images, collate_function)
+    nrows = len(grid) + 1 # extra row for the original images
+    ncols = len(input_images)
+
+    fig, axs = plt.subplots(nrows, ncols)
+
+    grid.insert(0, input_images)
+    for i in range(nrows):
+        for ax, img in zip(axs[i], grid[i]):
+            ax.imshow(img)
+            ax.set_axis_off()
+
+    fig.tight_layout()
+    return fig
+
+
+if __name__ == '__main__':
+
+    import numpy
+    from PIL import Image
+
+    input_images = []
+    for i in range(5):
+        imarray = numpy.random.rand(100,100,3) * 255
+        im = Image.fromarray(imarray.astype('uint8')).convert('RGB')
+        input_images.append(im)
+
+    collate_function = DINOCollateFunction()
+
+    fig = plot_augmented_images(input_images, collate_function)
+    fig.savefig('hello.png')

--- a/lightly/utils/debug.py
+++ b/lightly/utils/debug.py
@@ -144,40 +144,25 @@ def plot_augmented_images(
         raise ValueError('There must be at least one input image.')
 
     grid = generate_grid_of_augmented_images(input_images, collate_function)
+    grid.insert(0, input_images)
     nrows = len(input_images)
-    ncols = len(grid) + 1 # extra column for the original images
+    ncols = len(grid)
 
     fig, axs = plt.subplots(nrows, ncols, figsize=(ncols * 1.5, nrows * 1.5))
 
-    grid.insert(0, input_images)
     for i in range(nrows):
         for j in range(ncols):
-            ax = axs[i][j]
+            ax = axs[i][j] if len(input_images) > 1 else axs[i]
             img = grid[j][i]
             ax.imshow(img)
             ax.set_axis_off()
 
-    axs[0, 0].set(title='Original images')
-    axs[0, 0].title.set_size(8)
-    axs[0, 1].set(title='Augmented images')
-    axs[0, 1].title.set_size(8)
+    ax_top_left = axs[0, 0] if len(input_images) > 1 else axs[0]
+    ax_top_left.set(title='Original images')
+    ax_top_left.title.set_size(8)
+    ax_top_next = axs[0, 1] if len(input_images) > 1 else axs[1]
+    ax_top_next.set(title='Augmented images')
+    ax_top_next.title.set_size(8)
     fig.tight_layout()
 
     return fig
-
-
-if __name__ == '__main__':
-
-    import numpy
-    from PIL import Image
-
-    input_images_ = []
-    for i in range(2):
-        imarray = numpy.random.rand(100,100,3) * 255
-        im = Image.fromarray(imarray.astype('uint8')).convert('RGB')
-        input_images_.append(im)
-
-    collate_function = SimCLRCollateFunction()
-
-    fig = plot_augmented_images(input_images_, collate_function)
-    fig.savefig('hello.png')

--- a/lightly/utils/debug.py
+++ b/lightly/utils/debug.py
@@ -152,7 +152,7 @@ def plot_augmented_images(
 
     for i in range(nrows):
         for j in range(ncols):
-            ax = axs[i][j] if len(input_images) > 1 else axs[i]
+            ax = axs[i][j] if len(input_images) > 1 else axs[j]
             img = grid[j][i]
             ax.imshow(img)
             ax.set_axis_off()
@@ -166,3 +166,15 @@ def plot_augmented_images(
     fig.tight_layout()
 
     return fig
+
+
+
+
+images = [
+    Image.open('/datasets/monkeys_dataset/n0/n0038.jpg'),
+]
+from lightly.data.collate import DINOCollateFunction
+
+fig = plot_augmented_images(images, DINOCollateFunction())
+fig.savefig('hello.jpg')
+

--- a/tests/utils/test_debug.py
+++ b/tests/utils/test_debug.py
@@ -1,13 +1,28 @@
 import unittest
 import torch
 import math
+import numpy as np
+from PIL import Image
 
 from lightly.utils import debug
+from lightly.data import collate
+
+try:
+    import matplotlib.pyplot as plt
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
 
 BATCH_SIZE = 10
 DIMENSION = 10
 
-class TestDist(unittest.TestCase):
+
+class TestDebug(unittest.TestCase):
+
+    def _generate_random_image(self, w: int, h: int, c: int):
+        array = np.random.rand(h, w, c) * 255
+        image = Image.fromarray(array.astype('uint8')).convert('RGB')
+        return image
 
     def test_std_of_l2_normalized_collapsed(self):
         z = torch.ones(BATCH_SIZE, DIMENSION) # collapsed output
@@ -26,4 +41,48 @@ class TestDist(unittest.TestCase):
             debug.std_of_l2_normalized(z)
         z = torch.zeros(BATCH_SIZE, BATCH_SIZE, DIMENSION)
         with self.assertRaises(ValueError):
-            debug.std_of_l2_normalized(z)      
+            debug.std_of_l2_normalized(z)
+
+    @unittest.skipUnless(MATPLOTLIB_AVAILABLE, "Matplotlib not installed")
+    def test_plot_augmented_images_image_collate_function(self):
+
+        # simclr collate function is a subclass of the image collate function
+        collate_function = collate.SimCLRCollateFunction()
+
+        for n_images in range(2, 10):
+            with self.subTest():
+                images = [
+                    self._generate_random_image(100, 100, 3)
+                    for _ in range(n_images)
+                ]
+                fig = debug.plot_augmented_images(images, collate_function)
+                self.assertIsNotNone(fig)
+
+    @unittest.skipUnless(MATPLOTLIB_AVAILABLE, "Matplotlib not installed")
+    def test_plot_augmented_images_multi_view_collate_function(self):
+
+        # dion collate function is a subclass of the multi view collate function
+        collate_function = collate.DINOCollateFunction()
+
+        for n_images in range(1, 10):
+            with self.subTest():
+                images = [
+                    self._generate_random_image(100, 100, 3)
+                    for _ in range(n_images)
+                ]
+                fig = debug.plot_augmented_images(images, collate_function)
+                self.assertIsNotNone(fig)
+
+    @unittest.skipUnless(MATPLOTLIB_AVAILABLE, "Matplotlib not installed")
+    def test_plot_augmented_images_no_images(self):
+        collate_function = collate.SimCLRCollateFunction()
+        with self.assertRaises(ValueError):
+            debug.plot_augmented_images([], collate_function)
+
+    @unittest.skipUnless(MATPLOTLIB_AVAILABLE, "Matplotlib not installed")
+    def test_plot_augmented_images_invalid_collate_function(self):
+        images = [self._generate_random_image(100, 100, 3)]
+        with self.assertRaises(ValueError):
+            debug.plot_augmented_images(images, None)
+
+


### PR DESCRIPTION
# plot positive and negative example pairs

Adds a helper to plot augmented example images and their originals for the different collate functions implemented by `lightly`:

Example SimCLR:
![hello](https://user-images.githubusercontent.com/65946090/171576130-d8cca5c0-e561-4544-a111-72298a6486ac.jpg)

Example DINO (with real pictures)
![hello](https://user-images.githubusercontent.com/65946090/171576987-e9d5cc8d-446b-4c46-a641-f45b925bb308.jpg)

