### PR TITLE
Fix failing codecov upload for python 3.6 CI run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,8 @@ jobs:
         pip install pytest-cov
         python -m pytest -s -v --runslow --cov=./lightly --cov-report=xml --ignore=./lightly/openapi_generated/
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
+        files: ./coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixed by specifying the coverage report file path.

Also bumped codecov github action version.