### PR TITLE
Philipp document role based access

### DIFF
--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -130,6 +130,7 @@ To set up IAM Delegated Access
                     "Resource": [
                         "arn:aws:s3:::{YOUR_BUCKET}/*",
                         "arn:aws:s3:::{YOUR_BUCKET}"
+                    ]
                     
                 }
             ]

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -131,7 +131,6 @@ To set up IAM Delegated Access
                         "arn:aws:s3:::{YOUR_BUCKET}/*",
                         "arn:aws:s3:::{YOUR_BUCKET}"
                     ]
-                    
                 }
             ]
         }


### PR DESCRIPTION
# Philipp document role based access

Documents the delegated role based access to an S3 bucket.

I decided against adding it to every example and only show it in the `first steps` section see #841 and this PR.