### PR TITLE
Add PIRL

### DIFF
--- a/lightly/data/__init__.py
+++ b/lightly/data/__init__.py
@@ -8,6 +8,7 @@ from lightly.data.collate import BaseCollateFunction
 from lightly.data.collate import DINOCollateFunction
 from lightly.data.collate import ImageCollateFunction
 from lightly.data.collate import MAECollateFunction
+from lightly.data.collate import PIRLCollateFunction
 from lightly.data.collate import SimCLRCollateFunction
 from lightly.data.collate import MoCoCollateFunction
 from lightly.data.collate import MultiCropCollateFunction

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -687,3 +687,77 @@ class MAECollateFunction(MultiViewCollateFunction):
         views, labels, fnames = super().forward(batch)
         # Return only first view as MAE needs only a single view per image.
         return views[0], labels, fnames
+
+class PIRLCollateFunction(BaseCollateFunction):
+    """Implements the transformations for PIRL [0].
+
+    - [0] PIRL, 2019: https://arxiv.org/abs/1912.01991
+
+    Attributes:
+        input_size:
+            Size of the input image in pixels.
+        cj_prob:
+            Probability that color jitter is applied.
+        cj_bright:
+            How much to jitter brightness.
+        cj_contrast:
+            How much to jitter constrast.
+        cj_sat:
+            How much to jitter saturation.
+        cj_hue:
+            How much to jitter hue.
+        min_scale:
+            Minimum size of the randomized crop relative to the input_size.
+        random_gray_scale:
+            Probability of conversion to grayscale.
+        hf_prob:
+            Probability that horizontal flip is applied.
+        normalize:
+            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
+
+    Examples:
+
+        >>> # PIRL for ImageNet
+        >>> collate_fn = PIRLCollateFunction()
+        >>> 
+        >>> # PIRL for CIFAR-10
+        >>> collate_fn = PIRLCollateFunction(
+        >>>     input_size=32,
+        >>> )
+
+    """
+
+    def __init__(self,
+                 input_size: int = 64,
+                 cj_prob: float = 0.8,
+                 cj_bright: float = 0.4,
+                 cj_contrast: float = 0.4,
+                 cj_sat: float = 0.4,
+                 cj_hue: float = 0.4,
+                 min_scale: float = 0.08,
+                 random_gray_scale: float = 0.2,
+                 hf_prob: float = 0.5,
+                 normalize: dict = imagenet_normalize
+        ):
+        color_jitter = T.ColorJitter(
+            cj_bright, cj_contrast, cj_sat, cj_hue
+        )
+
+        transform = [T.RandomResizedCrop(size=input_size,
+                                         scale=(min_scale, 1.0)),
+             T.RandomHorizontalFlip(p=hf_prob),
+             T.RandomApply([color_jitter], p=cj_prob),
+             T.RandomGrayscale(p=random_gray_scale),
+             T.ToTensor()
+        ]
+
+        if normalize:
+            transform += [
+             T.Normalize(
+                mean=normalize['mean'],
+                std=normalize['std'])
+             ]
+           
+        transform = T.Compose(transform)
+
+        super(ImageCollateFunction, self).__init__(transform)

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -64,4 +64,5 @@ class Jigsaw(object):
                          self.yy[i] + r_y[i]: self.yy[i] + r_y[i] + self.crop_size, :])
         crops = [Image.fromarray(crop) for crop in crops]
         crops = torch.stack([self.transform(crop) for crop in crops])
+        crops = crops[np.random.permutation(self.n_grid ** 2)]
         return crops

--- a/tests/data/test_data_collate.py
+++ b/tests/data/test_data_collate.py
@@ -10,6 +10,7 @@ from lightly.data import ImageCollateFunction
 from lightly.data import SimCLRCollateFunction
 from lightly.data import MultiCropCollateFunction
 from lightly.data import SwaVCollateFunction
+from lightly.data import PIRLCollateFunction
 from lightly.data.collate import DINOCollateFunction, MAECollateFunction, MultiViewCollateFunction
 
 
@@ -147,3 +148,32 @@ class TestDataCollate(unittest.TestCase):
         batch = self.create_batch()
         collate_fn = MAECollateFunction()
         views, labels, fnames = collate_fn(batch)
+
+    def test_pirl_collate_init(self):
+        PIRLCollateFunction()
+    
+    def test_pirl_collate_forward_tuple_input_size(self):
+        batch = self.create_batch()
+        img_collate = PIRLCollateFunction(
+            input_size=(32, 32),
+        )
+        samples, labels, fnames = img_collate(batch)
+        samples0, samples1 = samples
+
+        self.assertIsNotNone(img_collate)
+        self.assertEqual(len(samples0), len(samples1))
+        self.assertEqual(len(samples1), len(labels), len(fnames))
+    
+    def test_pirl_collate_forward_n_grid(self):
+        batch = self.create_batch()
+        img_collate = PIRLCollateFunction(
+            input_size=32,
+            n_grid=3
+        )
+        samples, labels, fnames = img_collate(batch)
+        samples0, samples1 = samples
+
+        self.assertIsNotNone(img_collate)
+        self.assertEqual(len(samples0), len(samples1))
+        self.assertEqual(len(samples1), len(labels), len(fnames))
+        self.assertEqual(samples1.shape, (16,9,3,10,10))


### PR DESCRIPTION
- `collate.py`: Added new class `PIRLCollateFunction`, which inherits from `nn.Module`.
-  `jigsaw.py`: Added shuffling of the crops within jigsaw augmentation.
-  `test_data_collate.py`: Added three tests for `PIRLCollateFunction`.

This collate function directly inherits from `nn.Module` because PIRL requires data differently, compared to all other collate function classes that inherit from `BaseCollateFunction`. This collate function gives us two batches, one with the original image and another with 9 crops of size `input_size // n_grid`. As per #396.