### PR TITLE
Allow session passing and remove runtimerror

### DIFF
--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -7,6 +7,7 @@ from collections import defaultdict, namedtuple
 import json
 
 import numpy as np
+import requests
 from requests import Response
 from lightly.openapi_generated.swagger_client.api.docker_api import DockerApi
 from lightly.openapi_generated.swagger_client.models.create_docker_worker_registry_entry_request import CreateDockerWorkerRegistryEntryRequest
@@ -651,6 +652,7 @@ class MockedApiWorkflowClient(ApiWorkflowClient):
     def upload_file_with_signed_url(
             self, file: IOBase, signed_write_url: str,
             max_backoff: int = 32, max_retries: int = 5, headers: Dict = None,
+            session: Optional[requests.Session] = None,
     ) -> Response:
         res = Response()
         return res

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest import mock
+
+import requests
+
+from lightly.api import ApiWorkflowClient
+
+class TestApiWorkflowClient(unittest.TestCase):
+
+    def test_upload_file_with_signed_url(self):
+        with mock.patch('lightly.api.api_workflow_client.requests') as requests:
+            client = ApiWorkflowClient(token="")
+            file = mock.Mock()
+            signed_write_url = mock.Mock()
+            client.upload_file_with_signed_url(
+                file=file,
+                signed_write_url=signed_write_url,
+            )
+            requests.put.assert_called_with(signed_write_url, data=file)
+
+    def test_upload_file_with_signed_url_session(self):
+        session = mock.Mock()
+        file = mock.Mock()
+        signed_write_url = mock.Mock()
+        client = ApiWorkflowClient(token="")
+        client.upload_file_with_signed_url(
+            file=file,
+            signed_write_url=signed_write_url,
+            session=session
+        )
+        session.put.assert_called_with(signed_write_url, data=file)
+
+    def test_upload_file_with_signed_url_raise_status(self):
+        def raise_connection_error(*args, **kwargs):
+            raise requests.exceptions.ConnectionError()
+
+        with mock.patch('lightly.api.api_workflow_client.requests.put', raise_connection_error):
+            client = ApiWorkflowClient(token="")
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                client.upload_file_with_signed_url(
+                    file=mock.Mock(),
+                    signed_write_url=mock.Mock(),
+                )


### PR DESCRIPTION
Changes:
* No longer raise RuntimeError if upload failed but raise a requests error instead according to the response status
* Allow upload with session

The upload session was added to allow passing a session with retries/timeouts.