### PR TITLE
closes lig-1258 Lightly failing pip tests

### DIFF
--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -194,6 +194,7 @@ class TestVideoDataset(unittest.TestCase):
             # https://github.com/pytorch/vision/blob/5985504cc32011fbd4312600b4492d8ae0dd13b4/torchvision/io/video.py#L397
             # We cannot count warnings, since these are emitted only from torchvision version 0.11 onwards
             # with warnings.catch_warnings(record=True) as caught_warning:
+            #     dataset = LightlyDataset(self.input_dir)
             # expected_warning = "Caught error: [Errno 13] Permission denied:"
             # has_warning = [True for warning in caught_warning if expected_warning in str(warning)]
             # self.assertEqual(len(has_warning), n_videos)

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -192,11 +192,13 @@ class TestVideoDataset(unittest.TestCase):
                     os.chmod(filepath, 0o000)
             # This will not raise any Permissions error, as they are caught by torchvision:
             # https://github.com/pytorch/vision/blob/5985504cc32011fbd4312600b4492d8ae0dd13b4/torchvision/io/video.py#L397
-            with warnings.catch_warnings(record=True) as caught_warning:
-                dataset = LightlyDataset(self.input_dir)
-            expected_warning = "Caught error: [Errno 13] Permission denied:"
-            has_warning = [True for warning in caught_warning if expected_warning in str(warning)]
-            self.assertEqual(len(has_warning), n_videos)
+
+            # We cannot count warnings, since these are emitted only from torchvision version 0.11 onwards
+            # with warnings.catch_warnings(record=True) as caught_warning:
+            #     dataset = LightlyDataset(self.input_dir)
+            # expected_warning = "Caught error: [Errno 13] Permission denied:"
+            # has_warning = [True for warning in caught_warning if expected_warning in str(warning)]
+            # self.assertEqual(len(has_warning), n_videos)
             self.assertEqual(len(dataset), 0)
 
         with self.subTest("no read rights subdirs"):

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -192,12 +192,6 @@ class TestVideoDataset(unittest.TestCase):
                     os.chmod(filepath, 0o000)
             # This will not raise any Permissions error, as they are caught by torchvision:
             # https://github.com/pytorch/vision/blob/5985504cc32011fbd4312600b4492d8ae0dd13b4/torchvision/io/video.py#L397
-            # We cannot count warnings, since these are emitted only from torchvision version 0.11 onwards
-            # with warnings.catch_warnings(record=True) as caught_warning:
-            #     dataset = LightlyDataset(self.input_dir)
-            # expected_warning = "Caught error: [Errno 13] Permission denied:"
-            # has_warning = [True for warning in caught_warning if expected_warning in str(warning)]
-            # self.assertEqual(len(has_warning), n_videos)
             dataset = LightlyDataset(self.input_dir)
             self.assertEqual(len(dataset), 0)
 

--- a/tests/data/test_VideoDataset.py
+++ b/tests/data/test_VideoDataset.py
@@ -192,13 +192,12 @@ class TestVideoDataset(unittest.TestCase):
                     os.chmod(filepath, 0o000)
             # This will not raise any Permissions error, as they are caught by torchvision:
             # https://github.com/pytorch/vision/blob/5985504cc32011fbd4312600b4492d8ae0dd13b4/torchvision/io/video.py#L397
-
             # We cannot count warnings, since these are emitted only from torchvision version 0.11 onwards
             # with warnings.catch_warnings(record=True) as caught_warning:
-            #     dataset = LightlyDataset(self.input_dir)
             # expected_warning = "Caught error: [Errno 13] Permission denied:"
             # has_warning = [True for warning in caught_warning if expected_warning in str(warning)]
             # self.assertEqual(len(has_warning), n_videos)
+            dataset = LightlyDataset(self.input_dir)
             self.assertEqual(len(dataset), 0)
 
         with self.subTest("no read rights subdirs"):


### PR DESCRIPTION
- allows tests to pass for torchvision <= 0.10
- remove warnings assertion

See https://linear.app/lightly/issue/LIG-1258/lightly-failing-pip-tests for motivation & reasoning.