### PR TITLE
Guarin lig 1248 fix tox tests for pip package

### DIFF
--- a/tests/data/test_LightlySubset.py
+++ b/tests/data/test_LightlySubset.py
@@ -1,15 +1,20 @@
-import os
 import tempfile
 import random
 from typing import Tuple, List
-
-import torchvision
+import unittest
 
 from lightly.data.dataset import LightlyDataset
 from lightly.data.lightly_subset import LightlySubset
 
 from tests.data.test_LightlyDataset import TestLightlyDataset
 
+try:
+    from lightly.data._video import VideoDataset    
+    import av
+    import cv2
+    VIDEO_DATASET_AVAILABLE = True
+except ModuleNotFoundError:
+    VIDEO_DATASET_AVAILABLE = False
 
 class TestLightlySubset(TestLightlyDataset):
     def setUp(self) -> None:
@@ -27,6 +32,7 @@ class TestLightlySubset(TestLightlyDataset):
         subset = LightlySubset(base_dataset=base_dataset, filenames_subset=filenames_subset)
         return subset, filenames_subset
 
+    @unittest.skipUnless(VIDEO_DATASET_AVAILABLE, "PyAV and CV2 are both installed")
     def create_video_subset(self, seed=0) -> Tuple[LightlySubset, List[str]]:
         random.seed(seed)
         self.create_video_dataset(n_videos=5, n_frames_per_video=10)
@@ -47,6 +53,7 @@ class TestLightlySubset(TestLightlyDataset):
             sample, target, fname = subset.__getitem__(index_subset)
             assert filename_subset == fname
 
+    @unittest.skipUnless(VIDEO_DATASET_AVAILABLE, "PyAV and CV2 are both installed")
     def test_create_lightly_video_subset(self):
         subset, filenames_subset = self.create_video_subset()
         
@@ -68,4 +75,3 @@ class TestLightlySubset(TestLightlyDataset):
 
         files_output_dir = LightlyDataset(input_dir=out_dir).get_filenames()
         assert set(files_output_dir) == set(dataset.get_filenames())
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
-# Make sure you have both python 3.7 and 3.6 installed for the tox tests
+# Make sure you have python 3.7 installed for the tox tests
 # If not, you can install for example python 3.6 using the following commands
 # 1. Install build dependencies 
 #    `sudo apt-get install make build-essential libssl-dev zlib1g-dev libbz2-dev libsqlite3-dev`
 # 2. Download python version
-#    `wget https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz`
+#    `wget https://www.python.org/ftp/python/3.7.13/Python-3.7.13.tgz`
 # 3. Unpack archive
-#    `tar xzf Python-3.6.12.tgz`
+#    `tar xzf Python-3.7.13.tgz`
 # 4. Go to new folder
-#    `cd Python-3.6.12`
+#    `cd Python-3.7.13`
 # 5. Configure installation
 #    `sudo ./configure --enable-optimizations`
 # 6. Install Python
@@ -15,8 +15,8 @@
 # 7. Install pip
 #    `python3.6 -m ensurepip --default-pip`
 # you should get the following message:
-#    Requirement already satisfied: setuptools in /usr/local/lib/python3.6/site-packages (40.6.2)
-#    Requirement already satisfied: pip in /usr/local/lib/python3.6/site-packages (18.1)
+#    Requirement already satisfied: setuptools in /usr/local/lib/python3.7/site-packages (40.6.2)
+#    Requirement already satisfied: pip in /usr/local/lib/python3.7/site-packages (18.1)
 [tox]
 envlist = cuda, cpu, cpu-minimal, video
 
@@ -62,7 +62,7 @@ commands =
 
 [testenv:cpu-minimal]
 # test the full package on the cpu with minimal configuration
-basepython = python3.6
+basepython = python3.7
 
 # suppress warnings              
 whitelist_externals = make
@@ -75,8 +75,8 @@ setenv = LIGHTLY_SERVER_LOCATION = https://api-dev.lightly.ai
 
 commands = 
            pip install pillow==7.0.0
-           pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-           pip install pytorch-lightning==1.0.4
+           pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+           pip install pytorch-lightning==1.5
            pip install hydra-core==1.0.0
            pip install numpy==1.18.1
            pip install urllib3==1.15.1


### PR DESCRIPTION
* Updated minimal python version to 3.7
* Updated minimal pytorch lightning version to 1.5 (this is necessary because we use the `strategy` trainer option in `train_cli.py` which was only introduced in PL 1.5)
* Added skip flags for video tests if av/cv2 are not available