### PR TITLE
Igor lig 1232 add io speedup information from old docs

### DIFF
--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -230,14 +230,15 @@ Now that everything is in place, let's configure and run a simple job.
 
 The command schedules a job with the following configurations:
 
-- **enable_corruptness_check=True** Checks your dataset for corrupt images 
+- :code:`enable_corruptness_check` Checks your dataset for corrupt images if **True**.
 
-- **remove_exact_duplicates=True** Removes exact duplicates
+- :code:`remove_exact_duplicates` Removes exact duplicates if **True**.
 
-- **stopping_condition.n_samples=0.1** Selects 10% of the images using the
+- :code:`stopping_condition.n_samples` **0.1** selects 10% of the images using the
   default method (coreset). Selecting 10% means that the remaining dataset
-  will be 10% of the initial dataset size. You can also specify the exact 
-  number of remaining images by setting **n_samples** to an integer.
+  will be 10% of the initial dataset size. 
+  You can also specify the exact number of remaining images 
+  by setting the value to an integer.
 
 
 The worker should pick up the job after a few seconds and start working on it. The
@@ -249,10 +250,10 @@ report can be accessed from the compute worker runs page mentioned just above.
 
 There's an alternative stopping condition to `n_samples`, the `min_distance`
 
-- **stopping_condition.min_distance=0.2** would remove all samples which are
+- :code:`stopping_condition.min_distance` **0.2** would remove all samples which are
   closer to each other than 0.2. This allows you to specify the minimum allowed distance between two image 
   embeddings in the output dataset. After normalizing the input embeddings 
-  to unit length, this value should be between 0 and 2. This is often a more 
+  to unit length, this value should be between 0 and 2.0. This is often a more 
   convenient method when working with different data sources and trying to 
   combine them in a balanced way.
 
@@ -292,8 +293,16 @@ You may not always want to train for exactly 100 epochs with the default setting
 The Lightly worker is a wrapper around the lightly Python package.
 Hence, for training and embedding the user can access all the settings from the lightly command-line tool.
 
+Here are some of the most common parameters for the **lightly_config**
+you might want to change:
+
+- :code:`trainer.max_epochs` determines the number of epochs your SSL model should be trained for.
+- :code:`loader.num_workers` specifies the number of background workers for data processing.
+  -1 uses the number of available CPU cores. 
+
 
 .. code-block:: python
+    :emphasize-lines: 18, 29
     :caption: Accessing the lightly parameters from Python
 
     client.schedule_compute_worker_run(

--- a/docs/source/docker/known_issues_faq.rst
+++ b/docs/source/docker/known_issues_faq.rst
@@ -42,7 +42,7 @@ Shared Memory Error when running Lightly Worker
 
 The following error message appears when the docker runtime has not enough
 shared memory. By default Docker uses 64 MBytes. However, when using multiple 
-workers for data fetching `lightly.loader.num_workers` there might be not enough.
+workers for data fetching :code:`lightly.loader.num_workers` there might be not enough.
 
 .. code-block:: console
 
@@ -56,15 +56,37 @@ workers for data fetching `lightly.loader.num_workers` there might be not enough
         fd, size = storage._share_fd_()                                                                                                                                                                         
     RuntimeError: unable to write to file </torch_31_1030151126> 
 
-To solve this problem we need to increase the shared memory for the docker runtime.
+To solve this problem we need to reduce the number of workers or 
+increase the shared memory for the docker runtime. 
 
-You can change the shared memory to 512 MBytes by adding `--shm-size="512m"` to 
-the docker run command:
+Lightly determines the number of CPU cores available and sets the number
+of workers to the same number. If you have a machine with many cores but not so much
+memory (e.g. less than 2 GB of memory per core) it can happen that you run out 
+of memory and you rather want to reduce
+the number of workers intead of increasing the shared memory. 
+
+You can set the number of workers using
+
+.. code-block:: console
+
+    # you can manually override the config to only use 4 workers
+    docker run --gpus all --rm -it \
+        -v {OUTPUT_DIR}:/home/output_dir \
+        lightly/worker:latest \
+        token=MY_AWESOME_TOKEN \
+        worker.worker_id=MY_WORKER_ID \
+        lightly.loader.num_workers=4
+
+You can change the shared memory from 64 MBytes to 512 MBytes by 
+adding `--shm-size="512m"` to the docker run command:
 
 .. code-block:: console
 
     # example of docker run with setting shared memory to 512 MBytes
     docker run --shm-size="512m" --gpus all
+
+    # you can also increase it to 2 Gigabytes using
+    docker run --shm-size="2G" --gpus all
 
 
 Lightly Worker crashes because of too many open files

--- a/docs/source/docker/known_issues_faq.rst
+++ b/docs/source/docker/known_issues_faq.rst
@@ -65,18 +65,6 @@ memory (e.g. less than 2 GB of memory per core) it can happen that you run out
 of memory and you rather want to reduce
 the number of workers intead of increasing the shared memory. 
 
-You can set the number of workers using
-
-.. code-block:: console
-
-    # you can manually override the config to only use 4 workers
-    docker run --gpus all --rm -it \
-        -v {OUTPUT_DIR}:/home/output_dir \
-        lightly/worker:latest \
-        token=MY_AWESOME_TOKEN \
-        worker.worker_id=MY_WORKER_ID \
-        lightly.loader.num_workers=4
-
 You can change the shared memory from 64 MBytes to 512 MBytes by 
 adding `--shm-size="512m"` to the docker run command:
 


### PR DESCRIPTION
## Changes

 - Add information about how decreasing `num_workers` can reduce risk of OOM issues with shared memory
 - Add some more clarity on how to set `num_workers` and what the default parameter `-1` does do getting started guide

[Known Issues and FAQ — lightly 1.2.23 documentation.pdf](https://github.com/lightly-ai/lightly/files/9140866/Known.Issues.and.FAQ.lightly.1.2.23.documentation.pdf)
[First Steps — lightly 1.2.23 documentation.pdf](https://github.com/lightly-ai/lightly/files/9140867/First.Steps.lightly.1.2.23.documentation.pdf)
 