### PR TITLE
Jeremy lig 1447 delegated access use lightly urls by

### DIFF
--- a/docs/source/docker/configuration/configuration.rst
+++ b/docs/source/docker/configuration/configuration.rst
@@ -160,6 +160,9 @@ The following are parameters which can be passed to the container:
     # This feature is always enabled when a S3 datasource with delegated access
     # is configured. 
     use_redirected_read_url: False
+    # Bypass the verification of read/write access to the datasource
+    bypass_verify: False
+
 
   # active learning
   active_learning:

--- a/docs/source/docker/configuration/configuration.rst
+++ b/docs/source/docker/configuration/configuration.rst
@@ -150,6 +150,16 @@ The following are parameters which can be passed to the container:
     # Use video metadata to determine the number of frames in each video. Set to
     # True for faster processing. Set to False if you get video related errors.
     use_frame_count_metadata: False
+    # This feature flag enables runs which take longer than 7 days by bypassing
+    # the limitation of signed read URLs of S3, GCS and Azure.
+    # The tradeoff is that it will take longer to fully read and process all the
+    # data which is stored in the bucket configured as your datasource resulting
+    # in a longer total duration.
+    # Only enable this if you are certain that your run will take longer than
+    # 7 days to complete.
+    # This feature is always enabled when a S3 datasource with delegated access
+    # is configured. 
+    use_redirected_read_url: False
 
   # active learning
   active_learning:

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -23,7 +23,7 @@ class _DatasourcesMixin:
             from_: int = 0,
             to: Optional[int] = None,
             relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: bool = False,
+            use_redirected_read_url: Optional[bool] = False,
             progress_bar: Optional[tqdm.tqdm] = None,
             **kwargs
     ):
@@ -65,7 +65,7 @@ class _DatasourcesMixin:
             from_: int = 0,
             to: Optional[int] = None,
             relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: bool = False,
+            use_redirected_read_url: Optional[bool] = False,
             progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
         """Downloads all filenames and read urls from the datasource between `from_` and `to`.
@@ -109,7 +109,7 @@ class _DatasourcesMixin:
             from_: int = 0,
             to: Optional[int] = None,
             relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: bool = False,
+            use_redirected_read_url: Optional[bool] = False,
             progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
         """Downloads all prediction filenames and read urls from the datasource between `from_` and `to`.
@@ -155,7 +155,7 @@ class _DatasourcesMixin:
             from_: int = 0,
             to: Optional[int] = None,
             relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: bool = False,
+            use_redirected_read_url: Optional[bool] = False,
             progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
         """Downloads all metadata filenames and read urls from the datasource between `from_` and `to`.
@@ -195,7 +195,7 @@ class _DatasourcesMixin:
 
     def download_new_raw_samples(
         self,
-        use_redirected_read_url: bool = False,
+        use_redirected_read_url: Optional[bool] = False,
     ) -> List[Tuple[str, str]]:
         """Downloads filenames and read urls of unprocessed samples from the datasource.
 
@@ -226,6 +226,7 @@ class _DatasourcesMixin:
         data = self.download_raw_samples(
             from_=from_,
             to=to,
+            relevant_filenames_file_name=None,
             use_redirected_read_url=use_redirected_read_url
         )
         self.update_processed_until_timestamp(timestamp=to)

--- a/lightly/openapi_generated/swagger_client/api/datasources_api.py
+++ b/lightly/openapi_generated/swagger_client/api/datasources_api.py
@@ -336,6 +336,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesData
                  If the method is called asynchronously,
@@ -362,13 +363,14 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesData
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['dataset_id', '_from', 'to', 'cursor', 'relevant_filenames_file_name']  # noqa: E501
+        all_params = ['dataset_id', '_from', 'to', 'cursor', 'use_redirected_read_url', 'relevant_filenames_file_name']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -401,6 +403,8 @@ class DatasourcesApi(object):
             query_params.append(('to', params['to']))  # noqa: E501
         if 'cursor' in params:
             query_params.append(('cursor', params['cursor']))  # noqa: E501
+        if 'use_redirected_read_url' in params:
+            query_params.append(('useRedirectedReadUrl', params['use_redirected_read_url']))  # noqa: E501
         if 'relevant_filenames_file_name' in params:
             query_params.append(('relevantFilenamesFileName', params['relevant_filenames_file_name']))  # noqa: E501
 
@@ -447,6 +451,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesMetadataData
                  If the method is called asynchronously,
@@ -473,13 +478,14 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesMetadataData
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['dataset_id', '_from', 'to', 'cursor', 'relevant_filenames_file_name']  # noqa: E501
+        all_params = ['dataset_id', '_from', 'to', 'cursor', 'use_redirected_read_url', 'relevant_filenames_file_name']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -512,6 +518,8 @@ class DatasourcesApi(object):
             query_params.append(('to', params['to']))  # noqa: E501
         if 'cursor' in params:
             query_params.append(('cursor', params['cursor']))  # noqa: E501
+        if 'use_redirected_read_url' in params:
+            query_params.append(('useRedirectedReadUrl', params['use_redirected_read_url']))  # noqa: E501
         if 'relevant_filenames_file_name' in params:
             query_params.append(('relevantFilenamesFileName', params['relevant_filenames_file_name']))  # noqa: E501
 
@@ -559,6 +567,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesPredictionsData
                  If the method is called asynchronously,
@@ -586,13 +595,14 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesPredictionsData
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['dataset_id', 'task_name', '_from', 'to', 'cursor', 'relevant_filenames_file_name']  # noqa: E501
+        all_params = ['dataset_id', 'task_name', '_from', 'to', 'cursor', 'use_redirected_read_url', 'relevant_filenames_file_name']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -631,6 +641,8 @@ class DatasourcesApi(object):
             query_params.append(('to', params['to']))  # noqa: E501
         if 'cursor' in params:
             query_params.append(('cursor', params['cursor']))  # noqa: E501
+        if 'use_redirected_read_url' in params:
+            query_params.append(('useRedirectedReadUrl', params['use_redirected_read_url']))  # noqa: E501
         if 'relevant_filenames_file_name' in params:
             query_params.append(('relevantFilenamesFileName', params['relevant_filenames_file_name']))  # noqa: E501
 
@@ -965,6 +977,109 @@ class DatasourcesApi(object):
             post_params=form_params,
             files=local_var_files,
             response_type='str',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=params.get('async_req'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
+    def get_resource_read_url_redirect(self, dataset_id, path, **kwargs):  # noqa: E501
+        """get_resource_read_url_redirect  # noqa: E501
+
+        This endpoint enables anyone given the correct credentials to access the actual image directly via a redirect. By creating a readURL for the resource and redirecting to that URL, the client can use this endpoint to always have a way to access the resource as there is no expiration   # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_resource_read_url_redirect(dataset_id, path, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param MongoObjectID dataset_id: ObjectId of the dataset (required)
+        :param str path: the resource path (required)
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.get_resource_read_url_redirect_with_http_info(dataset_id, path, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_resource_read_url_redirect_with_http_info(dataset_id, path, **kwargs)  # noqa: E501
+            return data
+
+    def get_resource_read_url_redirect_with_http_info(self, dataset_id, path, **kwargs):  # noqa: E501
+        """get_resource_read_url_redirect  # noqa: E501
+
+        This endpoint enables anyone given the correct credentials to access the actual image directly via a redirect. By creating a readURL for the resource and redirecting to that URL, the client can use this endpoint to always have a way to access the resource as there is no expiration   # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_resource_read_url_redirect_with_http_info(dataset_id, path, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param MongoObjectID dataset_id: ObjectId of the dataset (required)
+        :param str path: the resource path (required)
+        :return: None
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['dataset_id', 'path']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_resource_read_url_redirect" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'dataset_id' is set
+        if self.api_client.client_side_validation and ('dataset_id' not in params or
+                                                       params['dataset_id'] is None):  # noqa: E501
+            raise ValueError("Missing the required parameter `dataset_id` when calling `get_resource_read_url_redirect`")  # noqa: E501
+        # verify the required parameter 'path' is set
+        if self.api_client.client_side_validation and ('path' not in params or
+                                                       params['path'] is None):  # noqa: E501
+            raise ValueError("Missing the required parameter `path` when calling `get_resource_read_url_redirect`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'dataset_id' in params:
+            path_params['datasetId'] = params['dataset_id']  # noqa: E501
+
+        query_params = []
+        if 'path' in params:
+            query_params.append(('path', params['path']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = ['ApiPublicJWTAuth']  # noqa: E501
+
+        return self.api_client.call_api(
+            '/v1/datasets/{datasetId}/datasource/readurlRedirect', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type=None,  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),

--- a/lightly/openapi_generated/swagger_client/api/datasources_api.py
+++ b/lightly/openapi_generated/swagger_client/api/datasources_api.py
@@ -336,7 +336,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
-        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true and this param has no effect. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesData
                  If the method is called asynchronously,
@@ -363,7 +363,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
-        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true and this param has no effect. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesData
                  If the method is called asynchronously,
@@ -451,7 +451,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
-        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true and this param has no effect. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesMetadataData
                  If the method is called asynchronously,
@@ -478,7 +478,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
-        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true and this param has no effect. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesMetadataData
                  If the method is called asynchronously,
@@ -567,7 +567,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
-        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true and this param has no effect. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesPredictionsData
                  If the method is called asynchronously,
@@ -595,7 +595,7 @@ class DatasourcesApi(object):
         :param Timestamp _from: Unix timestamp, only samples with a creation date after `from` will be returned. This parameter is ignored if `cursor` is specified. 
         :param Timestamp to: Unix timestamp, only samples with a creation date before `to` will be returned. This parameter is ignored if `cursor` is specified. 
         :param str cursor: Cursor from previous request, encodes `from` and `to` parameters. Specify to continue reading samples from the list. 
-        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
+        :param bool use_redirected_read_url: By default this is set to false unless a S3DelegatedAccess is configured in which case its always true and this param has no effect. When true this will return RedirectedReadUrls instead of ReadUrls meaning that  returned URLs allow for unlimited access to the file 
         :param str relevant_filenames_file_name: The name of the file within your datasource which contains a list of relevant filenames to list. See https://docs.lightly.ai/docker/getting_started/first_steps.html#specify-relevant-files for more details  
         :return: DatasourceRawSamplesPredictionsData
                  If the method is called asynchronously,

--- a/lightly/openapi_generated/swagger_client/api/samples_api.py
+++ b/lightly/openapi_generated/swagger_client/api/samples_api.py
@@ -363,7 +363,7 @@ class SamplesApi(object):
         :param MongoObjectID dataset_id: ObjectId of the dataset (required)
         :param MongoObjectID sample_id: ObjectId of the sample (required)
         :param str type: if we want to get the full image or just the thumbnail (required)
-        :return: str
+        :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -387,7 +387,7 @@ class SamplesApi(object):
         :param MongoObjectID dataset_id: ObjectId of the dataset (required)
         :param MongoObjectID sample_id: ObjectId of the sample (required)
         :param str type: if we want to get the full image or just the thumbnail (required)
-        :return: str
+        :return: None
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -453,7 +453,7 @@ class SamplesApi(object):
             body=body_params,
             post_params=form_params,
             files=local_var_files,
-            response_type='str',  # noqa: E501
+            response_type=None,  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),
@@ -688,6 +688,8 @@ class SamplesApi(object):
         :param MongoObjectID dataset_id: ObjectId of the dataset (required)
         :param str mode: if we want everything (full) or just the ObjectIds
         :param str file_name: filter the samples by filename
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[SampleData]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -712,12 +714,14 @@ class SamplesApi(object):
         :param MongoObjectID dataset_id: ObjectId of the dataset (required)
         :param str mode: if we want everything (full) or just the ObjectIds
         :param str file_name: filter the samples by filename
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[SampleData]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['dataset_id', 'mode', 'file_name']  # noqa: E501
+        all_params = ['dataset_id', 'mode', 'file_name', 'page_size', 'page_offset']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -748,6 +752,10 @@ class SamplesApi(object):
             query_params.append(('mode', params['mode']))  # noqa: E501
         if 'file_name' in params:
             query_params.append(('fileName', params['file_name']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page_offset' in params:
+            query_params.append(('pageOffset', params['page_offset']))  # noqa: E501
 
         header_params = {}
 

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config.py
@@ -86,7 +86,7 @@ class DockerWorkerConfig(object):
     def docker(self):
         """Gets the docker of this DockerWorkerConfig.  # noqa: E501
 
-        docker run configurations, keys should match the structure of https://github.com/lightly-ai/lightly-core/blob/develop/onprem-docker/resources/docker/docker.yaml   # noqa: E501
+        docker run configurations, keys should match the structure of https://github.com/lightly-ai/lightly-core/blob/develop/onprem-docker/lightly_worker/src/lightly_worker/resources/docker/docker.yaml   # noqa: E501
 
         :return: The docker of this DockerWorkerConfig.  # noqa: E501
         :rtype: dict(str, object)
@@ -97,7 +97,7 @@ class DockerWorkerConfig(object):
     def docker(self, docker):
         """Sets the docker of this DockerWorkerConfig.
 
-        docker run configurations, keys should match the structure of https://github.com/lightly-ai/lightly-core/blob/develop/onprem-docker/resources/docker/docker.yaml   # noqa: E501
+        docker run configurations, keys should match the structure of https://github.com/lightly-ai/lightly-core/blob/develop/onprem-docker/lightly_worker/src/lightly_worker/resources/docker/docker.yaml   # noqa: E501
 
         :param docker: The docker of this DockerWorkerConfig.  # noqa: E501
         :type: dict(str, object)

--- a/lightly/openapi_generated/swagger_client/models/sama_task_data.py
+++ b/lightly/openapi_generated/swagger_client/models/sama_task_data.py
@@ -35,6 +35,7 @@ class SamaTaskData(object):
     swagger_types = {
         'id': 'int',
         'url': 'RedirectedReadUrl',
+        'image': 'RedirectedReadUrl',
         'lightly_file_name': 'str',
         'lightly_meta_info': 'str'
     }
@@ -42,11 +43,12 @@ class SamaTaskData(object):
     attribute_map = {
         'id': 'id',
         'url': 'url',
+        'image': 'image',
         'lightly_file_name': 'lightlyFileName',
         'lightly_meta_info': 'lightlyMetaInfo'
     }
 
-    def __init__(self, id=None, url=None, lightly_file_name=None, lightly_meta_info=None, _configuration=None):  # noqa: E501
+    def __init__(self, id=None, url=None, image=None, lightly_file_name=None, lightly_meta_info=None, _configuration=None):  # noqa: E501
         """SamaTaskData - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -54,12 +56,15 @@ class SamaTaskData(object):
 
         self._id = None
         self._url = None
+        self._image = None
         self._lightly_file_name = None
         self._lightly_meta_info = None
         self.discriminator = None
 
         self.id = id
         self.url = url
+        if image is not None:
+            self.image = image
         if lightly_file_name is not None:
             self.lightly_file_name = lightly_file_name
         if lightly_meta_info is not None:
@@ -110,6 +115,27 @@ class SamaTaskData(object):
             raise ValueError("Invalid value for `url`, must not be `None`")  # noqa: E501
 
         self._url = url
+
+    @property
+    def image(self):
+        """Gets the image of this SamaTaskData.  # noqa: E501
+
+
+        :return: The image of this SamaTaskData.  # noqa: E501
+        :rtype: RedirectedReadUrl
+        """
+        return self._image
+
+    @image.setter
+    def image(self, image):
+        """Sets the image of this SamaTaskData.
+
+
+        :param image: The image of this SamaTaskData.  # noqa: E501
+        :type: RedirectedReadUrl
+        """
+
+        self._image = image
 
     @property
     def lightly_file_name(self):

--- a/lightly/openapi_generated/swagger_client/models/sama_tasks.py
+++ b/lightly/openapi_generated/swagger_client/models/sama_tasks.py
@@ -33,98 +33,17 @@ class SamaTasks(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'notification_email': 'str',
-        'tasks_file_name': 'str',
-        'tasks': 'list[SamaTask]'
     }
 
     attribute_map = {
-        'notification_email': 'notification_email',
-        'tasks_file_name': 'tasks_file_name',
-        'tasks': 'tasks'
     }
 
-    def __init__(self, notification_email=None, tasks_file_name=None, tasks=None, _configuration=None):  # noqa: E501
+    def __init__(self, _configuration=None):  # noqa: E501
         """SamaTasks - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
         self._configuration = _configuration
-
-        self._notification_email = None
-        self._tasks_file_name = None
-        self._tasks = None
         self.discriminator = None
-
-        if notification_email is not None:
-            self.notification_email = notification_email
-        if tasks_file_name is not None:
-            self.tasks_file_name = tasks_file_name
-        self.tasks = tasks
-
-    @property
-    def notification_email(self):
-        """Gets the notification_email of this SamaTasks.  # noqa: E501
-
-
-        :return: The notification_email of this SamaTasks.  # noqa: E501
-        :rtype: str
-        """
-        return self._notification_email
-
-    @notification_email.setter
-    def notification_email(self, notification_email):
-        """Sets the notification_email of this SamaTasks.
-
-
-        :param notification_email: The notification_email of this SamaTasks.  # noqa: E501
-        :type: str
-        """
-
-        self._notification_email = notification_email
-
-    @property
-    def tasks_file_name(self):
-        """Gets the tasks_file_name of this SamaTasks.  # noqa: E501
-
-
-        :return: The tasks_file_name of this SamaTasks.  # noqa: E501
-        :rtype: str
-        """
-        return self._tasks_file_name
-
-    @tasks_file_name.setter
-    def tasks_file_name(self, tasks_file_name):
-        """Sets the tasks_file_name of this SamaTasks.
-
-
-        :param tasks_file_name: The tasks_file_name of this SamaTasks.  # noqa: E501
-        :type: str
-        """
-
-        self._tasks_file_name = tasks_file_name
-
-    @property
-    def tasks(self):
-        """Gets the tasks of this SamaTasks.  # noqa: E501
-
-
-        :return: The tasks of this SamaTasks.  # noqa: E501
-        :rtype: list[SamaTask]
-        """
-        return self._tasks
-
-    @tasks.setter
-    def tasks(self, tasks):
-        """Sets the tasks of this SamaTasks.
-
-
-        :param tasks: The tasks of this SamaTasks.  # noqa: E501
-        :type: list[SamaTask]
-        """
-        if self._configuration.client_side_validation and tasks is None:
-            raise ValueError("Invalid value for `tasks`, must not be `None`")  # noqa: E501
-
-        self._tasks = tasks
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -417,7 +417,8 @@ class MockedDatasourcesApi(DatasourcesApi):
             cursor: str = None,
             _from: int = None,
             to: int = None,
-            relevant_filenames_file_name: str = -1
+            relevant_filenames_file_name: str = -1,
+            use_redirected_read_url: bool = False,
     ) -> DatasourceRawSamplesData:
         if relevant_filenames_file_name == -1:
             samples = self._samples[dataset_id]
@@ -451,8 +452,13 @@ class MockedDatasourcesApi(DatasourcesApi):
         )
 
     def get_list_of_raw_samples_predictions_from_datasource_by_dataset_id(
-        self, dataset_id: str, task_name: str,
-        cursor: str = None, _from: int = None, to: int = None, **kwargs,
+        self, dataset_id: str,
+        task_name: str,
+        cursor: str = None,
+        _from: int = None,
+        to: int = None,
+        use_redirected_read_url: bool = False,
+        **kwargs,
     ) -> DatasourceRawSamplesPredictionsData:
         if cursor is None:
             # initial request
@@ -479,8 +485,13 @@ class MockedDatasourcesApi(DatasourcesApi):
         )
 
     def get_list_of_raw_samples_metadata_from_datasource_by_dataset_id(
-        self, dataset_id: str,
-        cursor: str = None, _from: int = None, to: int = None, **kwargs,
+        self,
+        dataset_id: str,
+        cursor: str = None,
+        _from: int = None,
+        to: int = None,
+        use_redirected_read_url: bool = False,
+        **kwargs,
     ) -> DatasourceRawSamplesMetadataData:
         if cursor is None:
             # initial request


### PR DESCRIPTION
pip side of lig-1447
- regenerate API specs
- allow to pass `use_redirected_read_url` to all datasource list helper methods