### PR TITLE
allow parallel downloading and some blingbling

### DIFF
--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -1,9 +1,14 @@
 from typing import Dict, List
 import io
+import warnings
 import os
 import tqdm
 from urllib.request import Request, urlopen
 from PIL import Image
+
+from torch.utils.hipify.hipify_python import bcolors
+
+from concurrent.futures.thread import ThreadPoolExecutor
 
 from lightly.api.bitmask import BitMask
 from lightly.openapi_generated.swagger_client.models.image_type import ImageType
@@ -40,6 +45,7 @@ class _DownloadDatasetMixin:
     def download_dataset(self,
                          output_dir: str,
                          tag_name: str = 'initial-tag',
+                         max_workers: int = 8,
                          verbose: bool = True):
         """Downloads images from the web-app and stores them in output_dir.
 
@@ -48,6 +54,8 @@ class _DownloadDatasetMixin:
                 Where to store the downloaded images.
             tag_name:
                 Name of the tag which should be downloaded.
+            max_workers:
+                Maximum number of workers downloading images in parallel.
             verbose:
                 Whether or not to show the progress bar.
 
@@ -64,7 +72,7 @@ class _DownloadDatasetMixin:
         if dataset.img_type != ImageType.FULL:
             # only thumbnails or metadata available
             raise ValueError(
-                f"Dataset with id {self.dataset_id} has no downloadable images!"
+                f"Dataset with id {self.dataset_id} has no downloadables images!"
             )
 
         # check if tag exists
@@ -84,26 +92,63 @@ class _DownloadDatasetMixin:
 
         indices = BitMask.from_hex(tag.bit_mask_data).to_indices()
         sample_ids = [sample_ids[i] for i in indices]
+
         filenames_on_server = self.get_filenames()
         filenames = [filenames_on_server[i] for i in indices]
 
+        downloadables = zip(sample_ids, filenames)
+
+        # handle the case where len(sample_ids) < max_workers
+        max_workers = min(len(sample_ids), max_workers)
+        max_workers = max(max_workers, 1)
+
         if verbose:
-            print(f'Downloading {len(sample_ids)} images:', flush=True)
-            pbar = tqdm.tqdm(unit='imgs', total=len(sample_ids))
-
-        # download images
-        for sample_id, filename in zip(sample_ids, filenames):
-            read_url = self._samples_api.get_sample_image_read_url_by_id(
-                self.dataset_id, 
-                sample_id,
-                type="full",
+            print(f'Downloading {bcolors.OKGREEN}{len(sample_ids)}{bcolors.ENDC} images (with {bcolors.OKGREEN}{max_workers}{bcolors.ENDC} workers):', flush=True)
+            pbar = tqdm.tqdm(
+                unit='imgs',
+                total=len(sample_ids)
             )
+            tqdm_lock = tqdm.tqdm.get_lock()
 
-            img = _get_image_from_read_url(read_url)
-            _make_dir_and_save_image(output_dir, filename, img)
+        # define lambda function for concurrent download
+        def lambda_(i):
+            sample_id, filename = i
+            # try to download image
+            try:
+                read_url = self._samples_api.get_sample_image_read_url_by_id(
+                    self.dataset_id, 
+                    sample_id,
+                    type="full",
+                )
+                img = _get_image_from_read_url(read_url)
+                _make_dir_and_save_image(output_dir, filename, img)
+                success = True
+            except Exception as e: # pylint: disable=broad-except
+                warnings.warn(
+                    f'Downloading of image {filename} failed with error {e}'
+                )
+                success = False
 
+            # update the progress bar
             if verbose:
+                tqdm_lock.acquire()
                 pbar.update(1)
+                tqdm_lock.release()
+            # return whether the download was successful
+            return success
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            results = list(executor.map(
+                lambda_, downloadables, chunksize=1))
+
+        if not all(results):
+            msg = 'Warning: Unsuccessful download! '
+            msg += 'Failed at image: {}'.format(results.index(False))
+            warnings.warn(msg)
+
+
+
+
 
     def export_label_studio_tasks_by_tag_id(
         self,

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -72,7 +72,7 @@ class _DownloadDatasetMixin:
         if dataset.img_type != ImageType.FULL:
             # only thumbnails or metadata available
             raise ValueError(
-                f"Dataset with id {self.dataset_id} has no downloadables images!"
+                f"Dataset with id {self.dataset_id} has no downloadable images!"
             )
 
         # check if tag exists

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -9,6 +9,8 @@ from concurrent.futures.thread import ThreadPoolExecutor
 import tqdm
 from lightly_utils import image_processing
 
+from torch.utils.hipify.hipify_python import bcolors
+
 from lightly.data.dataset import LightlyDataset
 from lightly.api.utils import check_filename
 from lightly.api.utils import MAXIMUM_FILENAME_LENGTH
@@ -67,7 +69,7 @@ class _UploadDatasetMixin:
         tags = self.get_all_tags()
         if len(tags) > 0:
             print(
-                f'Dataset with id {self.dataset_id} has {len(tags)} tags.',
+                f'Dataset with id {self.dataset_id} has {bcolors.OKGREEN}{len(tags)}{bcolors.ENDC} tags.',
                 flush=True
             )
 
@@ -88,7 +90,7 @@ class _UploadDatasetMixin:
 
         # upload the samples
         print(
-            f'Uploading images (with {max_workers} workers).',
+            f'Uploading {bcolors.OKGREEN}{len(dataset)}{bcolors.ENDC} images (with {bcolors.OKGREEN}{max_workers}{bcolors.ENDC} workers).',
             flush=True
         )
 
@@ -97,14 +99,15 @@ class _UploadDatasetMixin:
             lambda img: 0 # pylint: disable=protected-access
 
         # get the filenames of the samples already on the server
-        samples = self._samples_api.get_samples_by_dataset_id(
+        samples = retry(
+            self._samples_api.get_samples_by_dataset_id,
             dataset_id=self.dataset_id
         )
         filenames_on_server = [sample.file_name for sample in samples]
         filenames_on_server_set = set(filenames_on_server)
         if len(filenames_on_server) > 0:
             print(
-                f'Found {len(filenames_on_server)} images already on the server'
+                f'Found {bcolors.OKGREEN}{len(filenames_on_server)}{bcolors.ENDC} images already on the server'
                 ', they are skipped during the upload.'
             )
 
@@ -115,8 +118,8 @@ class _UploadDatasetMixin:
         max_dataset_size = \
             int(self._quota_api.get_quota_maximum_dataset_size())
         if len(total_filenames) > max_dataset_size:
-            msg = f'Your dataset has {len(dataset)} samples which'
-            msg += f' is more than the allowed maximum of {max_dataset_size}'
+            msg = f'Your dataset has {bcolors.OKGREEN}{len(dataset)}{bcolors.ENDC} samples which'
+            msg += f' is more than the allowed maximum of {bcolors.OKGREEN}{max_dataset_size}{bcolors.ENDC}'
             raise ValueError(msg)
 
         # index custom metadata by filename (only if it exists)

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -160,7 +160,11 @@ class _UploadCustomMetadataMixin:
             for image_info in custom_metadata[COCO_ANNOTATION_KEYS.images]
         }
 
-        samples = self._samples_api.get_samples_by_dataset_id(self.dataset_id)
+        samples = retry(
+            self._samples_api.get_samples_by_dataset_id,
+            dataset_id=self.dataset_id
+        )
+
         filename_to_sample_id = {
             sample.file_name: sample.id
             for sample in samples


### PR DESCRIPTION
closes lig-1294
- speedup `lightly-download` by using workers to download files in parallel