### PR TITLE
closes lig-1071 lightly test write file not removed

### DIFF
--- a/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_azure_storage.rst
@@ -16,8 +16,6 @@ However, the thumbnails will be stored in your container and thus need storage.
   
     If you want to use thumbnails you need to give
     Lightly write access to your container to create the thumbnails there for you.
-    The write access can be configured not to allow overwriting and
-    deleting, thus existing data cannot get lost.
 
 Setting up Azure
 ------------------
@@ -64,9 +62,9 @@ Uploading your data
 4. Enter the storage account name and SAS token from the previous step.
 5. Toggle the **"Generate thumbnail"** switch if you want Lightly to generate thumbnails for you.
 6. If you want to store outputs from Lightly (like thumbnails or extracted frames) in a different directory, you can toggle **"Use a different output datasource"** and enter a different path in your bucket. This allows you to keep your input directory clean as nothing gets ever written there.
-  .. note:: 
 
-    Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
+    .. note:: 
+        Lightly requires list, read, write and delete access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
 7. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
 
 

--- a/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_gcloud_bucket.rst
@@ -18,8 +18,6 @@ However, the thumbnails will be stored in your bucket and thus need storage.
   
     If you want to use thumbnails you need to give
     Lightly write access to your bucket to create the thumbnails there for you.
-    The write access can be configured not to allow overwriting and
-    deleting, thus existing data cannot get lost.
 
 
 Setting up Google Cloud Storage
@@ -61,9 +59,9 @@ If it is not, change it to uniform.
 - Create a new role, with the same title and ID.
   E.g. call it `LIGHTLY_DATASET_ACCESS`.
 - Click on **"Add Permissions"**, search for `storage.objects`
-- Add the permissions `storage.objects.get`, `storage.objects.list`, and `storage.objects.create`.
-  The create permissions are needed if you want Lightly to create thumbnails
-  in your bucket . Otherwise you can leave them away.
+- Add the permissions `storage.objects.get`, `storage.objects.list`, `storage.objects.create` 
+  and `storage.objects.delete`. The create and delete permissions are needed only if you want 
+  Lightly to create thumbnails in your bucket. Otherwise you can leave them out.
 - After adding the permissions, create the role.
 
 .. figure:: ./images_gcloud_bucket/screenshot_gcloud_storage_role.jpg
@@ -159,9 +157,9 @@ Create and configure a dataset
 5. Click on **"Select Credentials File"** to add the key file you downloaded in the previous step.
 6. Toggle the **"Generate thumbnail"** switch if you want Lightly to generate thumbnails for you.
 7. If you want to store outputs from Lightly (like thumbnails or extracted frames) in a different directory, you can toggle **"Use a different output datasource"** and enter a different path in your bucket. This allows you to keep your input directory clean as nothing gets ever written there.
-  .. note:: 
 
-    Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
+.. note::
+    Lightly requires list, read, write and delete access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
 8. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
 
 


### PR DESCRIPTION

- the most direct way of ensuring that lightly-test-write-file.txt is removed is to include delete permissions in gcloud and azure
- this also makes IAM user instructions consistent across aws, gcloud and azure

The background investigation is covered in https://linear.app/lightly/issue/LIG-1071/lightly-test-write-file-not-removed

![Screenshot from 2022-07-28 23-44-28](https://user-images.githubusercontent.com/1595173/181644072-62b90b7e-3cab-49e3-9f84-c98378aa1322.png)
![Screenshot from 2022-07-28 23-45-09](https://user-images.githubusercontent.com/1595173/181644083-2d62c6fb-748c-48c8-88ca-fbfe5406cfc8.png)
