### PR TITLE
S3 datasource: make methods clearer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Unit Tests
 
 on: [push, workflow_dispatch, pull_request]
+  paths-ignore:
+    - 'docs/**'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,15 @@
 name: Unit Tests
 
-on: [push, workflow_dispatch, pull_request]
-  paths-ignore:
-    - 'docs/**'
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+  workflow_dispatch:
+
+
 
 jobs:
   test:

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -1,8 +1,13 @@
 name: check setup.py
 
-on: [push, workflow_dispatch]
-  paths-ignore:
-    - 'docs/**'
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -1,5 +1,8 @@
 name: check setup.py
+
 on: [push, workflow_dispatch]
+  paths-ignore:
+    - 'docs/**'
 
 jobs:
   test:

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -7,30 +7,17 @@ Create a dataset from an AWS S3 bucket
 Lightly allows you to configure a remote datasource like Amazon S3 (Amazon Simple Storage Service).
 In this guide, we will show you how to setup your S3 bucket, configure your dataset to use said bucket, and only upload metadata to Lightly.
 
-List, Read and Write permissions
+List, read and write permissions
 --------------------------------
 
-Lightly needs at minimum to have read and list permissions (s3:GetObject and s3:ListBucket) on your bucket. It needs them to provide the Lightly Worker access to your dataset,
+Lightly needs at minimum to have read and list permissions (`s3:GetObject` and `s3:ListBucket`) on your bucket. It needs them to provide the Lightly Worker access to your dataset,
 so that it can process it. Furthermore, the Lightly platform needs access to show you your images in the webapp.
 
-There are 3 reasons which make also write permissions (s3:PutObject) necessary:
+There are different scenarios which also require write permissions (`s3:PutObject`):
 
 - You process videos.
-- You run Lightly on object level.
-- You want Lightly to create thumbnails for you to increase the performance of the WebApp.
-
-Input and output datasources
-----------------------------
-
-Furthermore, you can decide to use one bucket/subdirectory for both the input to Lightly and for saving the output or have two different buckets/subdirectories for it.
-We recommend setting up separate input and output datasources (see :ref:`rst-docker-first-steps`).
-This setup is only done in later steps, not now.
-
-Only if you decide to use two different buckets, you have the option to use two different permissions for the two different buckets.
-E.g. you can have
-
-- Only List and Read permissions for the input bucket.
-- List, Read and Write permissions for the output bucket.
+- You use the Lightly with the object level workflow. (See :ref:`ref-docker-object-level`)
+- You want Lightly to create thumbnails for you to increase the performance of the Lightly Platform.
 
 User Access and Delegated Access
 --------------------------------
@@ -88,7 +75,7 @@ Create and configure a dataset
 5. Toggle the **"Generate thumbnail"** switch if you want Lightly to generate thumbnails for you.
 6. If you want to store outputs from Lightly (like thumbnails or extracted frames) in a different directory, you can toggle **"Use a different output datasource"** and enter a different path in your bucket. This allows you to keep your input directory clean as nothing gets ever written there.
 
-    .. note:: Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
+    .. note:: Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before. You can also use two different permissions to only allow listing and reading for the input datasource and additionally writing for the output datasource.
 7. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
 
 Next steps

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -11,13 +11,13 @@ List, read and write permissions
 --------------------------------
 
 Lightly needs at minimum to have read and list permissions (`s3:GetObject` and `s3:ListBucket`) on your bucket. It needs them to provide the Lightly Worker access to your dataset,
-so that it can process it. Furthermore, the Lightly platform needs access to show you your images in the webapp.
+so that it can process it. Furthermore, the Lightly Platform needs access to show you your images in the webapp.
 
 There are different scenarios which also require write permissions (`s3:PutObject`):
 
 - You process videos.
-- You use the Lightly with the object level workflow. (See :ref:`ref-docker-object-level`)
-- You want Lightly to create thumbnails for you to increase the performance of the Lightly Platform.
+- You use the Lightly Worker with the object level workflow. (See :ref:`ref-docker-object-level`)
+- You want the Lightly Worker to create thumbnails for you to increase the performance of the Lightly Platform.
 
 User Access and Delegated Access
 --------------------------------

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -7,19 +7,42 @@ Create a dataset from an AWS S3 bucket
 Lightly allows you to configure a remote datasource like Amazon S3 (Amazon Simple Storage Service).
 In this guide, we will show you how to setup your S3 bucket, configure your dataset to use said bucket, and only upload metadata to Lightly.
 
-Lightly needs at minimum to be able to read and list permissions on your bucket. It needs them to provide the Lightly Compute Worker access to your dataset,
+List, Read and Write permissions
+--------------------------------
+
+Lightly needs at minimum to have read and list permissions (s3:GetObject and s3:ListBucket) on your bucket. It needs them to provide the Lightly Worker access to your dataset,
 so that it can process it. Furthermore, the Lightly platform needs access to show you your images in the webapp.
 
-If you want Lightly to create thumbnails for you while uploading the metadata of your images or to write, write permissions are also needed.
+There are 3 reasons which make also write permissions (s3:PutObject) necessary:
 
-There are two ways to set up these Permissions:
+- You process videos.
+- You run Lightly on object level.
+- You want Lightly to create thumbnails for you to increase the performance of the WebApp.
+
+Input and output datasources
+----------------------------
+
+Furthermore, you can decide to use one bucket/subdirectory for both the input to Lightly and for saving the output or have two different buckets/subdirectories for it.
+We recommend setting up separate input and output datasources (see :ref:`rst-docker-first-steps`).
+This setup is only done in later steps, not now.
+
+Only if you decide to use two different buckets, you have the option to use two different permissions for the two different buckets.
+E.g. you can have
+
+- Only List and Read permissions for the input bucket.
+- List, Read and Write permissions for the output bucket.
+
+User Access and Delegated Access
+--------------------------------
+
+There are two ways to set up these permissions:
 
 1. User Access
 
 This method will create a user with permissions to access your bucket. An Access ID and secret key allow to authenticate as this user.
 We recommend this method as it is easy to set up and provides optimal performance.
 
-2. Delegated access
+2. Delegated Access
 
 To access your data in your S3 bucket on AWS, Lightly `can assume a role <https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html>`_ in your account which has the necessary permissions to access your data.
 Use this method if internal or external policies of your organization require it or disallow the other method.

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket.rst
@@ -7,176 +7,40 @@ Create a dataset from an AWS S3 bucket
 Lightly allows you to configure a remote datasource like Amazon S3 (Amazon Simple Storage Service).
 In this guide, we will show you how to setup your S3 bucket, configure your dataset to use said bucket, and only upload metadata to Lightly.
 
+Lightly needs at minimum to be able to read and list permissions on your bucket. It needs them to provide the Lightly Compute Worker access to your dataset,
+so that it can process it. Furthermore, the Lightly platform needs access to show you your images in the webapp.
 
-Setting up Amazon S3
-----------------------
+If you want Lightly to create thumbnails for you while uploading the metadata of your images or to write, write permissions are also needed.
 
-For Lightly to be able to create so-called `presigned URLs/read URLs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html>`_ to be used for displaying your data in your browser, Lightly needs at minimum to be able to read and list permissions on your bucket. If you want Lightly to create optimal thumbnails for you while uploading the metadata of your images, write permissions are also needed.
+There are two ways to set up these Permissions:
 
-Let us assume your bucket is called `datalake`. And let us assume the folder you want to use with Lightly is located at projects/farm-animals/
+1. User Access
 
-**Setting up IAM**
+This method will create a user with permissions to access your bucket. An Access ID and secret key allow to authenticate as this user.
+We recommend this method as it is easy to set up and provides optimal performance.
 
-1. Go to the `Identity and Access Management IAM page <https://console.aws.amazon.com/iamv2/home?#/users>`_ and create a new user for Lightly.
-2. Choose a unique name of your choice and select **"Programmatic access"** as **"Access type"**. Click next
-    
-    .. figure:: ../resources/AWSCreateUser2.png
-        :align: center
-        :alt: Create AWS User
-
-        Create AWS User
-
-3. We will want to create very restrictive permissions for this new user so that it can't access other resources of your company. Click on **"Attach existing policies directly"** and then on **"Create policy"**. This will bring you to a new page
-    
-    .. figure:: ../resources/AWSCreateUser3.png
-        :align: center
-        :alt: Setting user permission in AWS
-
-        Setting user permission in AWS
-
-4. As our policy is very simple, we will use the JSON option and enter the following while substituting `datalake` with your bucket and `projects/farm-animals/` with the folder you want to share.
-    
-    .. code-block:: json
-
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "VisualEditor0",
-                    "Effect": "Allow",
-                    "Action": "s3:ListBucket",
-                    "Resource": [
-                        "arn:aws:s3:::datalake",
-                        "arn:aws:s3:::datalake/projects/farm-animals/*"
-                    ]
-                },
-                {
-                    "Sid": "VisualEditor1",
-                    "Effect": "Allow",
-                    "Action": "s3:*",
-                    "Resource": [
-                        "arn:aws:s3:::datalake/projects/farm-animals/*"
-                    ]
-                }
-            ]
-        }
-    .. figure:: ../resources/AWSCreateUser4.png
-        :align: center
-        :alt: Permission policy in AWS
-
-        Permission policy in AWS
-5. Go to the next page and create tags as you see fit (e.g `external` or `lightly`) and give a name to your new policy before creating it.
-
-    .. figure:: ../resources/AWSCreateUser5.png
-        :align: center
-        :alt: Review and name permission policy in AWS
-
-        Review and name permission policy in AWS
-6. Return to the previous page as shown in the screenshot below and reload. Now when filtering policies, your newly created policy will show up. Select it and continue setting up your new user.
-    
-    .. figure:: ../resources/AWSCreateUser6.png
-        :align: center
-        :alt: Attach permission policy to user in AWS
-
-        Attach permission policy to user in AWS
-7. Write down the `Access key ID` and the `Secret access key` in a secure location (such as a password manager) as you will not be able to access this information again (you can generate new keys and revoke old keys under `Security credentials` of a users detail page)
-    
-    .. figure:: ../resources/AWSCreateUser7.png
-        :align: center
-        :alt: Get security credentials (access key id, secret access key) from AWS
-
-        Get security credentials (access key id, secret access key) from AWS
-
-
-
-
-**S3 IAM Delegated Access**
+2. Delegated access
 
 To access your data in your S3 bucket on AWS, Lightly `can assume a role <https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html>`_ in your account which has the necessary permissions to access your data.
-This is `considered best practice <https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#delegate-using-roles>`_ by AWS.
+Use this method if internal or external policies of your organization require it or disallow the other method.
+It comes with a small overhead for each access to a file in your bucket by Lightly.
+The overhead is negligible for larger files (e.g. videos or large images), but may become significant for many small files.
 
-To set up IAM Delegated Access
+To set up one of the access methods:
 
-1. Go to the `AWS IAM Console <https://console.aws.amazon.com/iam/home?#/roles>`_
+.. tabs::
 
-2. Click `Create role`
-   
-3. Select `AWS Account` as the trusted entity type
+    .. tab:: User Access
 
-    a. Select `Another AWS account` and specify the AWS Account ID of Lightly: `916419735646`
+        .. include:: dataset_creation_aws_bucket_user_access.rst
 
-    b. Check `Require external ID`, and choose an external ID. The external ID should be treated like a passphrase
+    .. tab:: Delegated Access
 
-    c. Do not check `Require MFA`.
-    
-    d. Click next
-
-4. Select a policy which grants access to your S3 bucket. If no policy has previously been created, here is an example of how the policy should look like:
+        .. include:: dataset_creation_aws_bucket_delegated_access.rst
 
 
-
-    .. code-block:: json
-            
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "lightlyS3Access",
-                    "Action": [
-                        "s3:GetObject",
-                        "s3:DeleteObject",
-                        "s3:PutObject",
-                        "s3:ListBucket"
-                    ],
-                    "Effect": "Allow",
-                    "Resource": [
-                        "arn:aws:s3:::{YOUR_BUCKET}/*",
-                        "arn:aws:s3:::{YOUR_BUCKET}"
-                    ]
-                }
-            ]
-        }
-
-5. Name the role `Lightly-S3-Integration` and create the role.
-6. Edit your new `Lightly-S3-Integration` role: set the `Maximum session duration` to 12 hours. 
-
-    .. warning:: If you don't set the maximum duration to 12 hours, Lightly will not be able to access your data. Please make sure to se the `Maximum session duration` to 12 hours.
-
-
-7. Remember the external ID and the ARN of the newly created role (`arn:aws:iam::123456789012:role/Lightly-S3-Integration`)
-
-
-
-.. note:: We recommend setting up separate input and output datasources (see :ref:`rst-docker-first-steps`). For this either use two different roles with narrow scope or one role with broader access.
-
-
-
-Preparing your data
-^^^^^^^^^^^^^^^^^^^^^
-
-For the :ref:`lightly-command-line-tool` to be able to create embeddings and extract metadata from your data, `lightly-magic` needs to be able to access your data. You can either download/sync your data from S3 or you can mount S3 as a drive. We recommend downloading your data from S3 as it makes the overall process faster.
-
-Prepare data by downloading from S3 (recommended)
-""""""""""""""""""""""""""""""""""""""""""""""""""
-
-1. Install AWS cli by following the `guide of Amazon <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`_
-2. Run `aws configure` and set the credentials
-3. Download/synchronize the folder located on S3 to your current directory
-
-    .. code-block:: console
-
-        aws s3 sync s3://datalake/projects/farm-animals ./farm
-
-
-Prepare data by mounting S3 as a drive
-"""""""""""""""""""""""""""""""""""""""
-
-For Linux and MacOS we recommend using `s3fs-fuse <https://github.com/s3fs-fuse/s3fs-fuse>`_ to mount S3 buckets to a local file storage. 
-You can have a look at our step-by-step guide: :ref:`ref-docker-integration-s3fs-fuse`. 
-
-
-Uploading your data
----------------------
+Create and configure a dataset
+------------------------------
 
 Create and configure a dataset
 
@@ -204,8 +68,8 @@ Create and configure a dataset
     .. note:: Lightly requires list, read, and write access to the `output datasource`. Make sure you have configured it accordingly in the steps before.
 7. Press save and ensure that at least the lights for List and Read turn green. If you added permissions for writing, this light should also turn green.
 
-Use `lightly-magic` and `lightly-upload` just as you always would with the following considerations;
+Next steps
+----------
 
-- Use `input_dir=datalake/farm-animals`
-- If you chose the option to generate thumbnails in your bucket, use the argument `upload=thumbnails`
-- Otherwise, use `upload=metadata` instead.
+Use the Lightly Worker. (see :ref:`ref-docker-setup`).
+If you have already set up the Worker, create a dataset with your S3 bucket as datasource. (see :ref:`ref-docker-with-datasource`)

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket_delegated_access.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket_delegated_access.rst
@@ -1,0 +1,56 @@
+.. _dataset-creation-aws-bucket-delegated-access:
+
+**S3 IAM Delegated Access**
+
+1. Go to the `AWS IAM Console <https://console.aws.amazon.com/iam/home?#/roles>`_
+
+2. Click `Create role`
+
+3. Select `AWS Account` as the trusted entity type
+
+    a. Select `Another AWS account` and specify the AWS Account ID of Lightly: `916419735646`
+
+    b. Check `Require external ID`, and choose an external ID. The external ID should be treated like a passphrase
+
+    c. Do not check `Require MFA`.
+
+    d. Click next
+
+4. Select a policy which grants access to your S3 bucket. If no policy has previously been created, here is an example of how the policy should look like:
+Please substitute `YOUR_BUCKET` with the name of your bucket.
+
+
+    .. code-block:: json
+
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "lightlyS3Access",
+                    "Action": [
+                        "s3:GetObject",
+                        "s3:DeleteObject",
+                        "s3:PutObject",
+                        "s3:ListBucket"
+                    ],
+                    "Effect": "Allow",
+                    "Resource": [
+                        "arn:aws:s3:::{YOUR_BUCKET}/*",
+                        "arn:aws:s3:::{YOUR_BUCKET}"
+                    ]
+                }
+            ]
+        }
+
+5. Name the role `Lightly-S3-Integration` and create the role.
+6. Edit your new `Lightly-S3-Integration` role: set the `Maximum session duration` to 12 hours.
+
+    .. warning:: If you don't set the maximum duration to 12 hours, Lightly will not be able to access your data. Please make sure to se the `Maximum session duration` to 12 hours.
+
+
+7. Remember the external ID and the ARN of the newly created role (`arn:aws:iam::123456789012:role/Lightly-S3-Integration`)
+
+
+
+.. note:: We recommend setting up separate input and output datasources (see :ref:`rst-docker-first-steps`). For this either use two different roles with narrow scope or one role with broader access.
+

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket_delegated_access.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket_delegated_access.rst
@@ -50,7 +50,3 @@ Please substitute `YOUR_BUCKET` with the name of your bucket.
 
 7. Remember the external ID and the ARN of the newly created role (`arn:aws:iam::123456789012:role/Lightly-S3-Integration`)
 
-
-
-.. note:: We recommend setting up separate input and output datasources (see :ref:`rst-docker-first-steps`). For this either use two different roles with narrow scope or one role with broader access.
-

--- a/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket_user_access.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_aws_bucket_user_access.rst
@@ -1,0 +1,75 @@
+.. _dataset-creation-aws-bucket-user-access:
+
+**S3 IAM User Access**
+
+1. Go to the `Identity and Access Management IAM page <https://console.aws.amazon.com/iamv2/home?#/users>`_ and create a new user for Lightly.
+2. Choose a unique name of your choice and select **"Programmatic access"** as **"Access type"**. Click next
+
+    .. figure:: ../resources/AWSCreateUser2.png
+        :align: center
+        :alt: Create AWS User
+
+        Create AWS User
+
+3. We will want to create very restrictive permissions for this new user so that it can't access other resources of your company. Click on **"Attach existing policies directly"** and then on **"Create policy"**. This will bring you to a new page
+
+    .. figure:: ../resources/AWSCreateUser3.png
+        :align: center
+        :alt: Setting user permission in AWS
+
+        Setting user permission in AWS
+
+4. As our policy is very simple, we will use the JSON option and enter the following.
+Please substitute `datalake` with the name of your bucket and `projects/farm-animals/` with the folder you want to share.
+
+    .. code-block:: json
+
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "VisualEditor0",
+                    "Effect": "Allow",
+                    "Action": "s3:ListBucket",
+                    "Resource": [
+                        "arn:aws:s3:::datalake",
+                        "arn:aws:s3:::datalake/projects/farm-animals/*"
+                    ]
+                },
+                {
+                    "Sid": "VisualEditor1",
+                    "Effect": "Allow",
+                    "Action": "s3:*",
+                    "Resource": [
+                        "arn:aws:s3:::datalake/projects/farm-animals/*"
+                    ]
+                }
+            ]
+        }
+    .. figure:: ../resources/AWSCreateUser4.png
+        :align: center
+        :alt: Permission policy in AWS
+
+        Permission policy in AWS
+5. Go to the next page and create tags as you see fit (e.g `external` or `lightly`) and give a name to your new policy before creating it.
+
+    .. figure:: ../resources/AWSCreateUser5.png
+        :align: center
+        :alt: Review and name permission policy in AWS
+
+        Review and name permission policy in AWS
+6. Return to the previous page as shown in the screenshot below and reload. Now when filtering policies, your newly created policy will show up. Select it and continue setting up your new user.
+
+    .. figure:: ../resources/AWSCreateUser6.png
+        :align: center
+        :alt: Attach permission policy to user in AWS
+
+        Attach permission policy to user in AWS
+7. Write down the `Access key ID` and the `Secret access key` in a secure location (such as a password manager) as you will not be able to access this information again (you can generate new keys and revoke old keys under `Security credentials` of a users detail page)
+
+    .. figure:: ../resources/AWSCreateUser7.png
+        :align: center
+        :alt: Get security credentials (access key id, secret access key) from AWS
+
+        Get security credentials (access key id, secret access key) from AWS
+


### PR DESCRIPTION
## Changes
- explain the two methods (User Access and Delegated Access) and recommend when to use which one
- put them in separate tabs in the document
- have the source code of the two methods in separate tabs and inline it
- after setting up the access: link to docker docs instead of recommending to use lightly-magic
 
[Create a dataset from an AWS S3 bucket — lightly 1.2.25 documentation.pdf](https://github.com/lightly-ai/lightly/files/9251180/Create.a.dataset.from.an.AWS.S3.bucket.lightly.1.2.25.documentation.pdf)


## The issue:
https://github.com/lightly-ai/lightly/pull/884#issue-1322116255

