### PR TITLE
Hotfix: Lightly temporarily does not support pytorch_lightning 1.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 
 hydra-core>=1.0.0
 numpy>=1.18.1
-pytorch_lightning>=1.0.4
+pytorch_lightning>=1.0.4,<1.7  # TODO: Hotfix, remove upper bound
 requests>=2.23.0
 torchvision
 tqdm>=4.44


### PR DESCRIPTION
### What has changed

A new release of pytorch_lightning deprecates `weights_summary` parameter for Trainer ([docs](https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#weights-summary)). This leads to an error when running lightly with pytorch_lightning 1.7:
```
TypeError: Trainer.__init__() got an unexpected keyword argument 'weights_summary'
```

Temporarily mark lightly incompatible with this version until it is supported.

### How is it tested

Because there was a change in the requirements folder, CI reinstalls all the dependencies and runs tests in this environment.