### PR TITLE
allow passing headers for server side encryption

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -221,7 +221,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             if headers is None:
                 headers = {}
             # don't override previously set SSE
-            if headers['x-amz-server-side-encryption'] == '':
+            if 'x-amz-server-side-encryption' not in headers:
                 if lightly_s3_sse_kms_key.lower() == 'true':
                     headers['x-amz-server-side-encryption'] = 'AES256'
                 else:

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 import requests
+import os
 
 from lightly.api import ApiWorkflowClient
 
@@ -29,6 +30,42 @@ class TestApiWorkflowClient(unittest.TestCase):
             session=session
         )
         session.put.assert_called_with(signed_write_url, data=file)
+    
+    def test_upload_file_with_signed_url_session_sse(self):
+        session = mock.Mock()
+        file = mock.Mock()
+        signed_write_url = mock.Mock()
+        client = ApiWorkflowClient(token="")
+        # set the environment var to enable SSE 
+        os.environ['LIGHTLY_S3_SSE_KMS_KEY'] = 'True'
+        client.upload_file_with_signed_url(
+            file=file,
+            signed_write_url=signed_write_url,
+            session=session
+        )
+        session.put.assert_called_with(signed_write_url, data=file, headers={'x-amz-server-side-encryption': 'AES256'})
+    
+    def test_upload_file_with_signed_url_session_sse_kms(self):
+        session = mock.Mock()
+        file = mock.Mock()
+        signed_write_url = mock.Mock()
+        client = ApiWorkflowClient(token="")
+        # set the environment var to enable SSE with KMS 
+        sseKMSKey = "arn:aws:kms:us-west-2:123456789000:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+        os.environ['LIGHTLY_S3_SSE_KMS_KEY'] = sseKMSKey
+        client.upload_file_with_signed_url(
+            file=file,
+            signed_write_url=signed_write_url,
+            session=session
+        )
+        session.put.assert_called_with(
+            signed_write_url,
+            data=file,
+            headers={
+                'x-amz-server-side-encryption': 'aws:kms',
+                'x-amz-server-side-encryption-aws-kms-key-id': sseKMSKey,
+            }
+        )
 
     def test_upload_file_with_signed_url_raise_status(self):
         def raise_connection_error(*args, **kwargs):


### PR DESCRIPTION
closes lig-1593
- when setting the `LIGHTLY_S3_SSE_KMS_KEY` env variable, the assets lightly creates (thumbnails, crops, frames, etc) will be server side encrypted in S3. Setting it to `true` will enable `AES256` encryption. Setting it to anything other will pass that as the kms key id for `aws:kms` as outlined in https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html