### PR TITLE
Minor docs updates

### DIFF
--- a/docs/source/getting_started/command_line_tool.rst
+++ b/docs/source/getting_started/command_line_tool.rst
@@ -249,7 +249,7 @@ You can use a custom name for the embeddings using the *embedding_name* paramete
 
     # you can upload the latest embeddings you created to the latest dataset you created
     lightly-upload embeddings=$LIGHTLY_LAST_EMBEDDING_PATH token=your_token \
-                       dataset_id=$LIGHTLY_LAST_DATASET_ID embedding_name=default
+                   dataset_id=$LIGHTLY_LAST_DATASET_ID embedding_name=default
 
 The dataset_id of the latest dataset you used in the `lightly-upload` command
 will always be saved under an environment variable named LIGHTLY_LAST_DATASET_ID.
@@ -277,7 +277,8 @@ Alternatively, you can upload custom metadata to an already existing dataset lik
 .. code-block:: bash
     
     # be aware that this overrides existing custom metadata uploaded to the same dataset
-    lightly-upload token=yourToken dataset_id=yourDatasetId custom_metadata=yourCustomMetadata.json
+    lightly-upload token=yourToken dataset_id=yourDatasetId \
+                   custom_metadata=yourCustomMetadata.json
 
 .. note::
 
@@ -334,7 +335,7 @@ you can use the following:
     lightly-upload input_dir=data_dir token=yourToken new_dataset_name=myNewDataset
     # upload the embeddings to the dataset just created
     lightly-upload embeddings=$LIGHTLY_LAST_EMBEDDING_PATH token=yourToken \
-    dataset_id=$LIGHTLY_LAST_DATASET_ID embedding_name=embedding_1
+        dataset_id=$LIGHTLY_LAST_DATASET_ID embedding_name=embedding_1
 
 
 

--- a/docs/source/getting_started/command_line_tool.rst
+++ b/docs/source/getting_started/command_line_tool.rst
@@ -275,7 +275,8 @@ To upload custom metadata, simply pass it to the `lightly-magic` command:
 Alternatively, you can upload custom metadata to an already existing dataset like this:
 
 .. code-block:: bash
-
+    
+    # be aware that this overrides existing custom metadata uploaded to the same dataset
     lightly-upload token=yourToken dataset_id=yourDatasetId custom_metadata=yourCustomMetadata.json
 
 .. note::

--- a/docs/source/getting_started/command_line_tool.rst
+++ b/docs/source/getting_started/command_line_tool.rst
@@ -238,21 +238,18 @@ You can use a custom name for the embeddings using the *embedding_name* paramete
 
 .. code-block:: bash
 
-    # upload only the embeddings
+    # upload the embeddings
     lightly-upload embeddings=your_embedding.csv token=your_token \
-                   dataset_id=your_dataset_id
+                   dataset_id=your_dataset_id embedding_name=default
 
     # you can upload the dataset together with the embeddings
     lightly-upload input_dir=cat embeddings=your_embedding.csv \
-                   token=your_token new_dataset_name=your_dataset_name
-
-    # you can upload the embeddings under a specific name
-    lightly-upload embeddings=your_embedding.csv token=your_token \
-                   new_dataset_name=your_dataset_name embedding_name=embedding_1
+                   token=your_token new_dataset_name=your_dataset_name \
+                   embedding_name=default
 
     # you can upload the latest embeddings you created to the latest dataset you created
     lightly-upload embeddings=$LIGHTLY_LAST_EMBEDDING_PATH token=your_token \
-                       dataset_id=$LIGHTLY_LAST_DATASET_ID
+                       dataset_id=$LIGHTLY_LAST_DATASET_ID embedding_name=default
 
 The dataset_id of the latest dataset you used in the `lightly-upload` command
 will always be saved under an environment variable named LIGHTLY_LAST_DATASET_ID.


### PR DESCRIPTION
## Changes

- In the CLI section add more clear information about
  - how to upload embeddings (always include embedding_name)
  - that metadata always gets overwritten