### PR TITLE
fix typo in docs

### DIFF
--- a/docs/source/docker/advanced/datasource_metadata.rst
+++ b/docs/source/docker/advanced/datasource_metadata.rst
@@ -200,7 +200,7 @@ For our example from above, a metadata file corresponding to a image/video/frame
     .. tab:: Image
     
         .. code-block:: javascript
-            :caption: .lightly/metadata/my_image.png
+            :caption: .lightly/metadata/my_image.json
 
             {
                 "file_name": "my_image.png",

--- a/docs/source/docker_archive/advanced/datasource_metadata.rst
+++ b/docs/source/docker_archive/advanced/datasource_metadata.rst
@@ -200,7 +200,7 @@ For our example from above, a metadata file corresponding to a image/video/frame
     .. tab:: Image
     
         .. code-block:: javascript
-            :caption: .lightly/metadata/my_image.png
+            :caption: .lightly/metadata/my_image.json
 
             {
                 "file_name": "my_image.png",


### PR DESCRIPTION
## Description
Fixed a typo calling the metadata file `my_image.png` instead of `my_image.json`.
See the 8 changed characters and the issue.

![image](https://user-images.githubusercontent.com/20324507/186148156-b2d3bf71-bfd8-4def-a1c8-069cb6c3fed9.jpeg)
