### PR TITLE
Shaun lig 1464 duplicate relevant filenames crashes

### DIFF
--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -452,7 +452,7 @@ you are only interested in `image_1.png` and `subdir/image_3.png`
             L image_3.png
 
 
-Then you can add a file called `relevant_filenames.txt` to your output bucket with the following content (note: only file paths relative to the bucket are supported!)
+Then you can add a file called `relevant_filenames.txt` to your output bucket with the following content (note: only file paths relative to the bucket are supported! Paths containing dots e.g. `./` or `../` are not supported)
 
 .. code-block:: text
     :caption: relevant_filenames.txt

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -452,7 +452,7 @@ you are only interested in `image_1.png` and `subdir/image_3.png`
             L image_3.png
 
 
-Then you can add a file called `relevant_filenames.txt` to your output bucket with the following content
+Then you can add a file called `relevant_filenames.txt` to your output bucket with the following content (note: only file paths relative to the bucket are supported!)
 
 .. code-block:: text
     :caption: relevant_filenames.txt

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -452,7 +452,7 @@ you are only interested in `image_1.png` and `subdir/image_3.png`
             L image_3.png
 
 
-Then you can add a file called `relevant_filenames.txt` to your output bucket with the following content (note: only file paths relative to the bucket are supported! Paths containing dots e.g. `./` or `../` are not supported)
+Then you can add a file called `relevant_filenames.txt` to your output bucket with the following content (note: only file paths relative to the bucket are supported! And relative paths cannot include dot notations `./` or `../`)
 
 .. code-block:: text
     :caption: relevant_filenames.txt

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -94,8 +94,7 @@ class _DatasourcesMixin:
             else:
                 sample_map[s.file_name] = s.read_url
         samples = [(file_name, read_url) for file_name, read_url in sample_map.items()]
-        sorted_samples = sorted(samples, key=lambda x: x[0])
-        return sorted_samples
+        return samples
 
     def download_raw_samples(
         self,

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -74,22 +74,28 @@ class _DatasourcesMixin:
                 progress_bar.update(len(response.data))
         sample_map = {}
         for s in samples:
-            if re.match("^\.*/", s.file_name):
+            if s.file_name.startswith("/"):
                 raise ValueError(
-                    f"Absolute file paths like {s.file_name} are not supported"
-                    " in relevant filenames file {relevant_filenames_file_name}"
+                        f"Absolute file paths like {s.file_name} are not supported"
+                        f" in relevant filenames file {relevant_filenames_file_name}"
                 )
-            if s.file_name in sample_map:
+            elif s.file_name.startswith(("./", "../")):
+                raise ValueError(
+                        f"Using dot notation ('./', '../') like in {s.file_name} is not supported"
+                        f" in relevant filenames file {relevant_filenames_file_name}"
+                )
+            elif s.file_name in sample_map:
                 warnings.warn(
                     UserWarning(
                         f"Duplicate filename {s.file_name} in relevant"
-                        " filenames file {relevant_filenames_file_name}"
+                        f" filenames file {relevant_filenames_file_name}"
                     )
                 )
             else:
                 sample_map[s.file_name] = s.read_url
         samples = [(file_name, read_url) for file_name, read_url in sample_map.items()]
-        return samples
+        sorted_samples = sorted(samples, key=lambda x: x[0])
+        return sorted_samples
 
     def download_raw_samples(
         self,

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -39,7 +39,7 @@ class _DatasourcesMixin:
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
         **kwargs,
-    ):
+    ) -> List[Tuple[str, str]]:
         if to is None:
             to = int(time.time())
         relevant_filenames_kwargs = (

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -75,14 +75,18 @@ class _DatasourcesMixin:
         sample_map = {}
         for idx, s in enumerate(samples):
             if s.file_name.startswith("/"):
-                raise ValueError(
-                    f"Absolute file paths like {s.file_name} are not supported"
-                    f" in relevant filenames file {relevant_filenames_file_name}"
+                warnings.warn(
+                    UserWarning(
+                        f"Absolute file paths like {s.file_name} are not supported"
+                        f" in relevant filenames file {relevant_filenames_file_name}"
+                    )
                 )
             elif s.file_name.startswith(("./", "../")):
-                raise ValueError(
-                    f"Using dot notation ('./', '../') like in {s.file_name} is not supported"
-                    f" in relevant filenames file {relevant_filenames_file_name}"
+                warnings.warn(
+                    UserWarning(
+                        f"Using dot notation ('./', '../') like in {s.file_name} is not supported"
+                        f" in relevant filenames file {relevant_filenames_file_name}"
+                    )
                 )
             elif s.file_name in sample_map:
                 warnings.warn(

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -72,17 +72,19 @@ class _DatasourcesMixin:
             samples.extend(response.data)
             if progress_bar is not None:
                 progress_bar.update(len(response.data))
+        samples_out = [None] * len(samples)
         sample_map = {}
-        for s in samples:
+        duplicates = 0
+        for idx, s in enumerate(samples):
             if s.file_name.startswith("/"):
                 raise ValueError(
-                        f"Absolute file paths like {s.file_name} are not supported"
-                        f" in relevant filenames file {relevant_filenames_file_name}"
+                    f"Absolute file paths like {s.file_name} are not supported"
+                    f" in relevant filenames file {relevant_filenames_file_name}"
                 )
             elif s.file_name.startswith(("./", "../")):
                 raise ValueError(
-                        f"Using dot notation ('./', '../') like in {s.file_name} is not supported"
-                        f" in relevant filenames file {relevant_filenames_file_name}"
+                    f"Using dot notation ('./', '../') like in {s.file_name} is not supported"
+                    f" in relevant filenames file {relevant_filenames_file_name}"
                 )
             elif s.file_name in sample_map:
                 warnings.warn(
@@ -91,10 +93,12 @@ class _DatasourcesMixin:
                         f" filenames file {relevant_filenames_file_name}"
                     )
                 )
+                duplicates += 1
             else:
                 sample_map[s.file_name] = s.read_url
-        samples = [(file_name, read_url) for file_name, read_url in sample_map.items()]
-        return samples
+                samples_out[idx] = (s.file_name, s.read_url)
+        return samples_out[0 : len(samples) - duplicates]
+        # return [(file_name, read_url) for file_name, read_url in sample_map.items()]
 
     def download_raw_samples(
         self,

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -88,9 +88,7 @@ class _DatasourcesMixin:
                 )
             else:
                 sample_map[s.file_name] = s.read_url
-        # sample_map = {s.file_name: s.read_url for s in samples}
         samples = [(file_name, read_url) for file_name, read_url in sample_map.items()]
-        # samples = [(s.file_name, s.read_url) for s in samples]
         return samples
 
     def download_raw_samples(

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -2,36 +2,51 @@ import time
 from typing import Dict, List, Optional, Tuple, Union
 
 import tqdm
+import warnings
+import re
 
-from lightly.openapi_generated.swagger_client.models.datasource_config import DatasourceConfig
-from lightly.openapi_generated.swagger_client.models.datasource_purpose import DatasourcePurpose
-from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_request import DatasourceProcessedUntilTimestampRequest
-from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_response import DatasourceProcessedUntilTimestampResponse
-from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data import DatasourceRawSamplesData
-from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_predictions_data import DatasourceRawSamplesPredictionsData
+from lightly.openapi_generated.swagger_client.models.datasource_config import (
+    DatasourceConfig,
+)
+from lightly.openapi_generated.swagger_client.models.datasource_purpose import (
+    DatasourcePurpose,
+)
+from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_request import (
+    DatasourceProcessedUntilTimestampRequest,
+)
+from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_response import (
+    DatasourceProcessedUntilTimestampResponse,
+)
+from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data import (
+    DatasourceRawSamplesData,
+)
+from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_predictions_data import (
+    DatasourceRawSamplesPredictionsData,
+)
 
 
 class _DatasourcesMixin:
-
     def _download_raw_files(
-            self,
-            download_function: Union[
-                "DatasourcesApi.get_list_of_raw_samples_from_datasource_by_dataset_id",
-                "DatasourcesApi.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id",
-                "DatasourcesApi.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id"
-            ],
-            from_: int = 0,
-            to: Optional[int] = None,
-            relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: Optional[bool] = False,
-            progress_bar: Optional[tqdm.tqdm] = None,
-            **kwargs
+        self,
+        download_function: Union[
+            "DatasourcesApi.get_list_of_raw_samples_from_datasource_by_dataset_id",
+            "DatasourcesApi.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id",
+            "DatasourcesApi.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id",
+        ],
+        from_: int = 0,
+        to: Optional[int] = None,
+        relevant_filenames_file_name: Optional[str] = None,
+        use_redirected_read_url: Optional[bool] = False,
+        progress_bar: Optional[tqdm.tqdm] = None,
+        **kwargs,
     ):
         if to is None:
             to = int(time.time())
-        relevant_filenames_kwargs = {
-            "relevant_filenames_file_name": relevant_filenames_file_name
-        } if relevant_filenames_file_name else dict()
+        relevant_filenames_kwargs = (
+            {"relevant_filenames_file_name": relevant_filenames_file_name}
+            if relevant_filenames_file_name
+            else dict()
+        )
 
         response: DatasourceRawSamplesData = download_function(
             dataset_id=self.dataset_id,
@@ -39,7 +54,7 @@ class _DatasourcesMixin:
             to=to,
             use_redirected_read_url=use_redirected_read_url,
             **relevant_filenames_kwargs,
-            **kwargs
+            **kwargs,
         )
         cursor = response.cursor
         samples = response.data
@@ -51,31 +66,49 @@ class _DatasourcesMixin:
                 cursor=cursor,
                 use_redirected_read_url=use_redirected_read_url,
                 **relevant_filenames_kwargs,
-                **kwargs
+                **kwargs,
             )
             cursor = response.cursor
             samples.extend(response.data)
             if progress_bar is not None:
                 progress_bar.update(len(response.data))
-        samples = [(s.file_name, s.read_url) for s in samples]
+        sample_map = {}
+        for s in samples:
+            if re.match("^\.*/", s.file_name):
+                raise ValueError(
+                    f"Absolute file paths like {s.file_name} are not supported"
+                    " in relevant filenames file {relevant_filenames_file_name}"
+                )
+            if s.file_name in sample_map:
+                warnings.warn(
+                    UserWarning(
+                        f"Duplicate filename {s.file_name} in relevant"
+                        " filenames file {relevant_filenames_file_name}"
+                    )
+                )
+            else:
+                sample_map[s.file_name] = s.read_url
+        # sample_map = {s.file_name: s.read_url for s in samples}
+        samples = [(file_name, read_url) for file_name, read_url in sample_map.items()]
+        # samples = [(s.file_name, s.read_url) for s in samples]
         return samples
 
     def download_raw_samples(
-            self,
-            from_: int = 0,
-            to: Optional[int] = None,
-            relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: Optional[bool] = False,
-            progress_bar: Optional[tqdm.tqdm] = None,
+        self,
+        from_: int = 0,
+        to: Optional[int] = None,
+        relevant_filenames_file_name: Optional[str] = None,
+        use_redirected_read_url: Optional[bool] = False,
+        progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
         """Downloads all filenames and read urls from the datasource between `from_` and `to`.
 
         Samples which have timestamp == `from_` or timestamp == `to` will also be included.
-        
+
         Args:
-            from_: 
+            from_:
                 Unix timestamp from which on samples are downloaded.
-            to: 
+            to:
                 Unix timestamp up to and including which samples are downloaded.
             relevant_filenames_file_name:
                 The path to the relevant filenames text file in the cloud bucket.
@@ -83,12 +116,12 @@ class _DatasourcesMixin:
             use_redirected_read_url:
                 By default this is set to false unless a S3DelegatedAccess is configured in which
                 case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that 
+                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
                 returned URLs allow for unlimited access to the file
             progress_bar:
                 Tqdm progress bar to show how many samples have already been
                 retrieved.
-        
+
         Returns:
            A list of (filename, url) tuples, where each tuple represents a sample
 
@@ -104,13 +137,13 @@ class _DatasourcesMixin:
         return samples
 
     def download_raw_predictions(
-            self,
-            task_name: str,
-            from_: int = 0,
-            to: Optional[int] = None,
-            relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: Optional[bool] = False,
-            progress_bar: Optional[tqdm.tqdm] = None,
+        self,
+        task_name: str,
+        from_: int = 0,
+        to: Optional[int] = None,
+        relevant_filenames_file_name: Optional[str] = None,
+        use_redirected_read_url: Optional[bool] = False,
+        progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
         """Downloads all prediction filenames and read urls from the datasource between `from_` and `to`.
 
@@ -129,7 +162,7 @@ class _DatasourcesMixin:
             use_redirected_read_url:
                 By default this is set to false unless a S3DelegatedAccess is configured in which
                 case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that 
+                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
                 returned URLs allow for unlimited access to the file
             progress_bar:
                 Tqdm progress bar to show how many prediction files have already been
@@ -151,12 +184,12 @@ class _DatasourcesMixin:
         return samples
 
     def download_raw_metadata(
-            self,
-            from_: int = 0,
-            to: Optional[int] = None,
-            relevant_filenames_file_name: Optional[str] = None,
-            use_redirected_read_url: Optional[bool] = False,
-            progress_bar: Optional[tqdm.tqdm] = None,
+        self,
+        from_: int = 0,
+        to: Optional[int] = None,
+        relevant_filenames_file_name: Optional[str] = None,
+        use_redirected_read_url: Optional[bool] = False,
+        progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
         """Downloads all metadata filenames and read urls from the datasource between `from_` and `to`.
 
@@ -173,7 +206,7 @@ class _DatasourcesMixin:
             use_redirected_read_url:
                 By default this is set to false unless a S3DelegatedAccess is configured in which
                 case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that 
+                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
                 returned URLs allow for unlimited access to the file
             progress_bar:
                 Tqdm progress bar to show how many metadata files have already been
@@ -199,7 +232,7 @@ class _DatasourcesMixin:
     ) -> List[Tuple[str, str]]:
         """Downloads filenames and read urls of unprocessed samples from the datasource.
 
-        All samples after the timestamp of `ApiWorkflowClient.get_processed_until_timestamp()` are 
+        All samples after the timestamp of `ApiWorkflowClient.get_processed_until_timestamp()` are
         fetched. After downloading the samples the timestamp is updated to the current time.
         This function can be repeatedly called to retrieve new samples from the datasource.
 
@@ -207,15 +240,15 @@ class _DatasourcesMixin:
             use_redirected_read_url:
                 By default this is set to false unless a S3DelegatedAccess is configured in which
                 case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that 
+                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
                 returned URLs allow for unlimited access to the file
-        
+
         Returns:
             A list of (filename, url) tuples, where each tuple represents a sample
 
         """
         from_ = self.get_processed_until_timestamp()
-        
+
         if from_ != 0:
             # We already processed samples at some point.
             # Add 1 because the samples with timestamp == from_
@@ -227,30 +260,28 @@ class _DatasourcesMixin:
             from_=from_,
             to=to,
             relevant_filenames_file_name=None,
-            use_redirected_read_url=use_redirected_read_url
+            use_redirected_read_url=use_redirected_read_url,
         )
         self.update_processed_until_timestamp(timestamp=to)
         return data
 
     def get_processed_until_timestamp(self) -> int:
         """Returns the timestamp until which samples have been processed.
-        
+
         Returns:
             Unix timestamp of last processed sample
         """
-        response: DatasourceProcessedUntilTimestampResponse = (
-            self._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id(
-                dataset_id=self.dataset_id
-            )
+        response: DatasourceProcessedUntilTimestampResponse = self._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id(
+            dataset_id=self.dataset_id
         )
         timestamp = int(response.processed_until_timestamp)
         return timestamp
 
     def update_processed_until_timestamp(self, timestamp: int) -> None:
         """Sets the timestamp until which samples have been processed.
-        
+
         Args:
-            timestamp: 
+            timestamp:
                 Unix timestamp of last processed sample
         """
         body = DatasourceProcessedUntilTimestampRequest(
@@ -270,21 +301,21 @@ class _DatasourcesMixin:
             ApiException if no datasource was configured.
 
         """
-        return self._datasources_api.get_datasource_by_dataset_id(
-            self.dataset_id
-        )
+        return self._datasources_api.get_datasource_by_dataset_id(self.dataset_id)
 
     def set_azure_config(
         self,
         container_name: str,
         account_name: str,
         sas_token: str,
-        thumbnail_suffix: Optional[str] = ".lightly/thumbnails/[filename]_thumb.[extension]",
+        thumbnail_suffix: Optional[
+            str
+        ] = ".lightly/thumbnails/[filename]_thumb.[extension]",
         purpose: str = DatasourcePurpose.INPUT_OUTPUT,
     ) -> None:
         """Sets the Azure configuration for the datasource of the current dataset.
-        
-        Find a detailed explanation on how to setup Lightly with 
+
+        Find a detailed explanation on how to setup Lightly with
         Azure Blob Storage in our docs: https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_azure_storage.html#
 
         Args:
@@ -296,8 +327,8 @@ class _DatasourcesMixin:
                 Secure Access Signature token.
             thumbnail_suffix:
                 Where to save thumbnails of the images in the dataset, for
-                example ".lightly/thumbnails/[filename]_thumb.[extension]". 
-                Set to None to disable thumbnails and use the full images from the 
+                example ".lightly/thumbnails/[filename]_thumb.[extension]".
+                Set to None to disable thumbnails and use the full images from the
                 datasource instead.
             purpose:
                 Datasource purpose, determines if datasource is read only (INPUT)
@@ -305,15 +336,15 @@ class _DatasourcesMixin:
                 The latter is required when Lightly extracts frames from input videos.
 
         """
-        # TODO: Use DatasourceConfigAzure once we switch/update the api generator.
+        # TODO: Use DatasourceConfigAzure once we switch/update the api generator.
         self._datasources_api.update_datasource_by_dataset_id(
             body={
-                'type': 'AZURE',
-                'fullPath': container_name,
-                'thumbSuffix': thumbnail_suffix,
-                'accountName': account_name,
-                'accountKey': sas_token,
-                'purpose': purpose,
+                "type": "AZURE",
+                "fullPath": container_name,
+                "thumbSuffix": thumbnail_suffix,
+                "accountName": account_name,
+                "accountKey": sas_token,
+                "purpose": purpose,
             },
             dataset_id=self.dataset_id,
         )
@@ -323,27 +354,29 @@ class _DatasourcesMixin:
         resource_path: str,
         project_id: str,
         credentials: str,
-        thumbnail_suffix: Optional[str] = ".lightly/thumbnails/[filename]_thumb.[extension]",
+        thumbnail_suffix: Optional[
+            str
+        ] = ".lightly/thumbnails/[filename]_thumb.[extension]",
         purpose: str = DatasourcePurpose.INPUT_OUTPUT,
     ) -> None:
         """Sets the Google Cloud Storage configuration for the datasource of the
         current dataset.
 
-        Find a detailed explanation on how to setup Lightly with 
+        Find a detailed explanation on how to setup Lightly with
         Google Cloud Storage in our docs: https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_gcloud_bucket.html
-        
+
         Args:
             resource_path:
                 GCS url of your dataset, for example: "gs://my_bucket/path/to/my/data"
             project_id:
                 GCS project id.
             credentials:
-                Content of the credentials JSON file stringified which you 
+                Content of the credentials JSON file stringified which you
                 download from Google Cloud Platform.
             thumbnail_suffix:
                 Where to save thumbnails of the images in the dataset, for
-                example ".lightly/thumbnails/[filename]_thumb.[extension]". 
-                Set to None to disable thumbnails and use the full images from the 
+                example ".lightly/thumbnails/[filename]_thumb.[extension]".
+                Set to None to disable thumbnails and use the full images from the
                 datasource instead.
             purpose:
                 Datasource purpose, determines if datasource is read only (INPUT)
@@ -351,15 +384,15 @@ class _DatasourcesMixin:
                 The latter is required when Lightly extracts frames from input videos.
 
         """
-        # TODO: Use DatasourceConfigGCS once we switch/update the api generator.
+        # TODO: Use DatasourceConfigGCS once we switch/update the api generator.
         self._datasources_api.update_datasource_by_dataset_id(
             body={
-                'type': 'GCS',
-                'fullPath': resource_path,
-                'thumbSuffix': thumbnail_suffix,
-                'gcsProjectId': project_id,
-                'gcsCredentials': credentials,
-                'purpose': purpose,
+                "type": "GCS",
+                "fullPath": resource_path,
+                "thumbSuffix": thumbnail_suffix,
+                "gcsProjectId": project_id,
+                "gcsCredentials": credentials,
+                "purpose": purpose,
             },
             dataset_id=self.dataset_id,
         )
@@ -367,29 +400,31 @@ class _DatasourcesMixin:
     def set_local_config(
         self,
         resource_path: str,
-        thumbnail_suffix: Optional[str] = ".lightly/thumbnails/[filename]_thumb.[extension]",
+        thumbnail_suffix: Optional[
+            str
+        ] = ".lightly/thumbnails/[filename]_thumb.[extension]",
     ) -> None:
         """Sets the local configuration for the datasource of the current dataset.
 
         Find a detailed explanation on how to setup Lightly with a local file
         server in our docs: https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_local_server.html
-        
+
         Args:
             resource_path:
                 Url to your local file server, for example: "http://localhost:1234/path/to/my/data".
             thumbnail_suffix:
                 Where to save thumbnails of the images in the dataset, for
-                example ".lightly/thumbnails/[filename]_thumb.[extension]". 
-                Set to None to disable thumbnails and use the full images from the 
+                example ".lightly/thumbnails/[filename]_thumb.[extension]".
+                Set to None to disable thumbnails and use the full images from the
                 datasource instead.
         """
-        # TODO: Use DatasourceConfigLocal once we switch/update the api generator.
+        # TODO: Use DatasourceConfigLocal once we switch/update the api generator.
         self._datasources_api.update_datasource_by_dataset_id(
             body={
-                'type': 'LOCAL',
-                'fullPath': resource_path,
-                'thumbSuffix': thumbnail_suffix,
-                'purpose': DatasourcePurpose.INPUT_OUTPUT,
+                "type": "LOCAL",
+                "fullPath": resource_path,
+                "thumbSuffix": thumbnail_suffix,
+                "purpose": DatasourcePurpose.INPUT_OUTPUT,
             },
             dataset_id=self.dataset_id,
         )
@@ -400,11 +435,13 @@ class _DatasourcesMixin:
         region: str,
         access_key: str,
         secret_access_key: str,
-        thumbnail_suffix: Optional[str] = ".lightly/thumbnails/[filename]_thumb.[extension]",
+        thumbnail_suffix: Optional[
+            str
+        ] = ".lightly/thumbnails/[filename]_thumb.[extension]",
         purpose: str = DatasourcePurpose.INPUT_OUTPUT,
     ) -> None:
         """Sets the S3 configuration for the datasource of the current dataset.
-        
+
         Args:
             resource_path:
                 S3 url of your dataset, for example "s3://my_bucket/path/to/my/data".
@@ -416,8 +453,8 @@ class _DatasourcesMixin:
                 Secret for the S3 access key.
             thumbnail_suffix:
                 Where to save thumbnails of the images in the dataset, for
-                example ".lightly/thumbnails/[filename]_thumb.[extension]". 
-                Set to None to disable thumbnails and use the full images from the 
+                example ".lightly/thumbnails/[filename]_thumb.[extension]".
+                Set to None to disable thumbnails and use the full images from the
                 datasource instead.
             purpose:
                 Datasource purpose, determines if datasource is read only (INPUT)
@@ -425,16 +462,16 @@ class _DatasourcesMixin:
                 The latter is required when Lightly extracts frames from input videos.
 
         """
-        # TODO: Use DatasourceConfigS3 once we switch/update the api generator.
+        # TODO: Use DatasourceConfigS3 once we switch/update the api generator.
         self._datasources_api.update_datasource_by_dataset_id(
             body={
-                'type': 'S3',
-                'fullPath': resource_path,
-                'thumbSuffix': thumbnail_suffix,
-                's3Region': region,
-                's3AccessKeyId': access_key,
-                's3SecretAccessKey': secret_access_key,
-                'purpose': purpose,
+                "type": "S3",
+                "fullPath": resource_path,
+                "thumbSuffix": thumbnail_suffix,
+                "s3Region": region,
+                "s3AccessKeyId": access_key,
+                "s3SecretAccessKey": secret_access_key,
+                "purpose": purpose,
             },
             dataset_id=self.dataset_id,
         )
@@ -445,11 +482,13 @@ class _DatasourcesMixin:
         region: str,
         role_arn: str,
         external_id: str,
-        thumbnail_suffix: Optional[str] = ".lightly/thumbnails/[filename]_thumb.[extension]",
+        thumbnail_suffix: Optional[
+            str
+        ] = ".lightly/thumbnails/[filename]_thumb.[extension]",
         purpose: str = DatasourcePurpose.INPUT_OUTPUT,
     ) -> None:
         """Sets the S3 configuration for the datasource of the current dataset.
-        
+
         Args:
             resource_path:
                 S3 url of your dataset, for example "s3://my_bucket/path/to/my/data".
@@ -461,8 +500,8 @@ class _DatasourcesMixin:
                 External ID of the role.
             thumbnail_suffix:
                 Where to save thumbnails of the images in the dataset, for
-                example ".lightly/thumbnails/[filename]_thumb.[extension]". 
-                Set to None to disable thumbnails and use the full images from the 
+                example ".lightly/thumbnails/[filename]_thumb.[extension]".
+                Set to None to disable thumbnails and use the full images from the
                 datasource instead.
             purpose:
                 Datasource purpose, determines if datasource is read only (INPUT)
@@ -470,34 +509,33 @@ class _DatasourcesMixin:
                 The latter is required when Lightly extracts frames from input videos.
 
         """
-        # TODO: Use DatasourceConfigS3 once we switch/update the api generator.
+        # TODO: Use DatasourceConfigS3 once we switch/update the api generator.
         self._datasources_api.update_datasource_by_dataset_id(
             body={
-                'type': 'S3DelegatedAccess',
-                'fullPath': resource_path,
-                'thumbSuffix': thumbnail_suffix,
-                's3Region': region,
-                's3ARN': role_arn,
-                's3ExternalId': external_id,
-                'purpose': purpose,
+                "type": "S3DelegatedAccess",
+                "fullPath": resource_path,
+                "thumbSuffix": thumbnail_suffix,
+                "s3Region": region,
+                "s3ARN": role_arn,
+                "s3ExternalId": external_id,
+                "purpose": purpose,
             },
             dataset_id=self.dataset_id,
         )
-
 
     def get_prediction_read_url(
         self,
         filename: str,
     ):
         """Returns a read-url for .lightly/predictions/{filename}.
-    
+
         Args:
             filename:
                 Filename for which to get the read-url.
 
         Returns the read-url. If the file does not exist, a read-url is returned
         anyways.
-        
+
         """
         return self._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id(
             self.dataset_id,
@@ -509,14 +547,14 @@ class _DatasourcesMixin:
         filename: str,
     ):
         """Returns a read-url for .lightly/metadata/{filename}.
-    
+
         Args:
             filename:
                 Filename for which to get the read-url.
 
         Returns the read-url. If the file does not exist, a read-url is returned
         anyways.
-        
+
         """
         return self._datasources_api.get_metadata_file_read_url_from_datasource_by_dataset_id(
             self.dataset_id,

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -78,14 +78,14 @@ class _DatasourcesMixin:
                 warnings.warn(
                     UserWarning(
                         f"Absolute file paths like {s.file_name} are not supported"
-                        f" in relevant filenames file {relevant_filenames_file_name}"
+                        f" in relevant filenames file {relevant_filenames_file_name} due to blob storage"
                     )
                 )
             elif s.file_name.startswith(("./", "../")):
                 warnings.warn(
                     UserWarning(
                         f"Using dot notation ('./', '../') like in {s.file_name} is not supported"
-                        f" in relevant filenames file {relevant_filenames_file_name}"
+                        f" in relevant filenames file {relevant_filenames_file_name} due to blob storage"
                     )
                 )
             elif s.file_name in sample_map:

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -72,9 +72,7 @@ class _DatasourcesMixin:
             samples.extend(response.data)
             if progress_bar is not None:
                 progress_bar.update(len(response.data))
-        samples_out = [None] * len(samples)
         sample_map = {}
-        duplicates = 0
         for idx, s in enumerate(samples):
             if s.file_name.startswith("/"):
                 raise ValueError(
@@ -93,12 +91,9 @@ class _DatasourcesMixin:
                         f" filenames file {relevant_filenames_file_name}"
                     )
                 )
-                duplicates += 1
             else:
                 sample_map[s.file_name] = s.read_url
-                samples_out[idx] = (s.file_name, s.read_url)
-        return samples_out[0 : len(samples) - duplicates]
-        # return [(file_name, read_url) for file_name, read_url in sample_map.items()]
+        return [(file_name, read_url) for file_name, read_url in sample_map.items()]
 
     def download_raw_samples(
         self,

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import tqdm
+import pytest
 
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data_row import (
@@ -178,12 +179,8 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with self.assertWarns(UserWarning) as context:
+        with pytest.warns(UserWarning, match="Duplicate filename file_0 in relevant filenames file"):
             samples = self.api_workflow_client.download_raw_samples()
-        self.assertTrue(
-            "Duplicate filename file_0 in relevant filenames file"
-            in str(context.warning)
-        )
 
         assert len(samples) == 5
         # expect a warning
@@ -199,12 +196,8 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError, match="Absolute file paths like /file_0 are not supported in relevant filenames file"):
             samples = self.api_workflow_client.download_raw_samples()
-        self.assertTrue(
-            "Absolute file paths like /file_0 are not supported in relevant filenames file"
-            in str(context.exception)
-        )
 
     def test__download_raw_files_dot_slash(self):
         self.api_workflow_client._datasources_api.reset
@@ -217,11 +210,8 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError, match="Using dot notation \('\./', '\.\./'\) like in \./file_0 is not supported.*"):
             samples = self.api_workflow_client.download_raw_samples()
-        self.assertTrue(
-            "Using dot notation ('./', '../') like in ./file_0" in str(context.exception)
-        )
 
     def test__download_raw_files_dot_dot_slash(self):
         self.api_workflow_client._datasources_api.reset
@@ -234,8 +224,5 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError, match="Using dot notation \('\./', '\.\./'\) like in \.\./file_0 is not supported.*"):
             samples = self.api_workflow_client.download_raw_samples()
-        self.assertTrue(
-            "Using dot notation ('./', '../') like in ../file_0" in str(context.exception)
-        )

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -166,7 +166,7 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
         read_url = self.api_workflow_client.get_prediction_read_url("test.json")
         self.assertIsNotNone(read_url)
 
-    def test_duplicate_filenames(self):
+    def test__download_raw_files_duplicate_filenames(self):
         self.api_workflow_client._datasources_api.reset()
         self.api_workflow_client._datasources_api._samples = defaultdict(
             lambda: [
@@ -188,7 +188,7 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
         assert len(samples) == 5
         # expect a warning
 
-    def test_absolute_filenames(self):
+    def test__download_raw_files_absolute_filenames(self):
         self.api_workflow_client._datasources_api.reset
         self.api_workflow_client._datasources_api._samples = defaultdict(
             lambda: [
@@ -206,7 +206,7 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             in str(context.exception)
         )
 
-    def test_dot_slash(self):
+    def test__download_raw_files_dot_slash(self):
         self.api_workflow_client._datasources_api.reset
         self.api_workflow_client._datasources_api._samples = defaultdict(
             lambda: [
@@ -223,7 +223,7 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             "Using dot notation ('./', '../') like in ./file_0" in str(context.exception)
         )
 
-    def test_dot_dot_slash(self):
+    def test__download_raw_files_dot_dot_slash(self):
         self.api_workflow_client._datasources_api.reset
         self.api_workflow_client._datasources_api._samples = defaultdict(
             lambda: [

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -179,7 +179,9 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with pytest.warns(UserWarning, match="Duplicate filename file_0 in relevant filenames file"):
+        with pytest.warns(
+            UserWarning, match="Duplicate filename file_0 in relevant filenames file"
+        ):
             samples = self.api_workflow_client.download_raw_samples()
 
         assert len(samples) == 5
@@ -196,7 +198,10 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with pytest.raises(ValueError, match="Absolute file paths like /file_0 are not supported in relevant filenames file"):
+        with pytest.warns(
+            UserWarning,
+            match="Absolute file paths like /file_0 are not supported in relevant filenames file",
+        ):
             samples = self.api_workflow_client.download_raw_samples()
 
     def test__download_raw_files_dot_slash(self):
@@ -210,7 +215,10 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with pytest.raises(ValueError, match="Using dot notation \('\./', '\.\./'\) like in \./file_0 is not supported.*"):
+        with pytest.warns(
+            UserWarning,
+            match="Using dot notation \('\./', '\.\./'\) like in \./file_0 is not supported.*",
+        ):
             samples = self.api_workflow_client.download_raw_samples()
 
     def test__download_raw_files_dot_dot_slash(self):
@@ -224,5 +232,8 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
             ]
         )
-        with pytest.raises(ValueError, match="Using dot notation \('\./', '\.\./'\) like in \.\./file_0 is not supported.*"):
+        with pytest.warns(
+            UserWarning,
+            match="Using dot notation \('\./', '\.\./'\) like in \.\./file_0 is not supported.*",
+        ):
             samples = self.api_workflow_client.download_raw_samples()

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -183,8 +183,7 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             samples = self.api_workflow_client.download_raw_samples()
 
         assert len(samples) == 5
-        for sample in samples:
-            assert sample is not None
+        assert samples == [(f"file_{i}", f"url_{i}") for i in range(5)]
 
     def test__download_raw_files_absolute_filenames(self):
         self.api_workflow_client._datasources_api.reset

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -3,8 +3,11 @@ from unittest import mock
 import tqdm
 
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
-from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data_row import DatasourceRawSamplesDataRow
+from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data_row import (
+    DatasourceRawSamplesDataRow,
+)
 from collections import defaultdict
+
 
 class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
     def test_get_processed_until_timestamp(self):
@@ -24,7 +27,7 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
 
     def test_download_raw_samples_progress_bar(self):
         self.api_workflow_client._datasources_api.reset()
-        pbar = mock.Mock(wraps=tqdm.tqdm(unit='file'))
+        pbar = mock.Mock(wraps=tqdm.tqdm(unit="file"))
         samples = self.api_workflow_client.download_raw_samples(progress_bar=pbar)
         num_samples = self.api_workflow_client._datasources_api._num_samples
         assert len(samples) == num_samples
@@ -67,12 +70,11 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
         self.api_workflow_client._datasources_api.reset()
         for method in [
             self.api_workflow_client.download_raw_samples,
-            self.api_workflow_client.download_raw_metadata
+            self.api_workflow_client.download_raw_metadata,
         ]:
             for relevant_filenames_path in [None, "", "relevant_filenames.txt"]:
                 with self.subTest(
-                        relevant_filenames_path=relevant_filenames_path,
-                        method=method
+                    relevant_filenames_path=relevant_filenames_path, method=method
                 ):
                     samples = method(
                         relevant_filenames_file_name=relevant_filenames_path
@@ -117,20 +119,22 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
             region="eu-central-1",
             role_arn="my-role-arn",
-            external_id="my-external-id"
+            external_id="my-external-id",
         )
 
     def test_download_raw_samples_predictions(self):
         self.api_workflow_client._datasources_api.reset()
 
-        predictions = self.api_workflow_client.download_raw_predictions('test')
+        predictions = self.api_workflow_client.download_raw_predictions("test")
         num_samples = self.api_workflow_client._datasources_api._num_samples
         assert len(predictions) == num_samples
 
     def test_download_raw_samples_predictions_progress_bar(self):
         self.api_workflow_client._datasources_api.reset()
-        pbar = mock.Mock(wraps=tqdm.tqdm(unit='file'))
-        predictions = self.api_workflow_client.download_raw_predictions('test', progress_bar=pbar)
+        pbar = mock.Mock(wraps=tqdm.tqdm(unit="file"))
+        predictions = self.api_workflow_client.download_raw_predictions(
+            "test", progress_bar=pbar
+        )
         num_samples = self.api_workflow_client._datasources_api._num_samples
         assert len(predictions) == num_samples
         pbar.update.assert_called()
@@ -143,7 +147,7 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
 
     def test_download_raw_sample_metadata_progress_bar(self):
         self.api_workflow_client._datasources_api.reset()
-        pbar = mock.Mock(wraps=tqdm.tqdm(unit='file'))
+        pbar = mock.Mock(wraps=tqdm.tqdm(unit="file"))
         predictions = self.api_workflow_client.download_raw_metadata(progress_bar=pbar)
         num_samples = self.api_workflow_client._datasources_api._num_samples
         assert len(predictions) == num_samples
@@ -151,39 +155,87 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
 
     def test_download_raw_samples_predictions_relevant_filenames(self):
         self.api_workflow_client._datasources_api.reset()
-        predictions = self.api_workflow_client.download_raw_predictions('test', relevant_filenames_file_name="test")
+        predictions = self.api_workflow_client.download_raw_predictions(
+            "test", relevant_filenames_file_name="test"
+        )
         num_samples = self.api_workflow_client._datasources_api._num_samples
         assert len(predictions) == num_samples
 
     def test_get_prediction_read_url(self):
         self.api_workflow_client._datasources_api.reset()
-        read_url = self.api_workflow_client.get_prediction_read_url('test.json')
+        read_url = self.api_workflow_client.get_prediction_read_url("test.json")
         self.assertIsNotNone(read_url)
 
     def test_duplicate_filenames(self):
         self.api_workflow_client._datasources_api.reset()
-        self.api_workflow_client._datasources_api._samples = defaultdict(lambda: [
+        self.api_workflow_client._datasources_api._samples = defaultdict(
+            lambda: [
                 DatasourceRawSamplesDataRow(file_name="file_0", read_url="url_0"),
                 DatasourceRawSamplesDataRow(file_name="file_0", read_url="url_0"),
                 DatasourceRawSamplesDataRow(file_name="file_1", read_url="url_1"),
                 DatasourceRawSamplesDataRow(file_name="file_2", read_url="url_2"),
                 DatasourceRawSamplesDataRow(file_name="file_3", read_url="url_3"),
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
-                ])
-        with self.assertWarns(UserWarning):
+            ]
+        )
+        with self.assertWarns(UserWarning) as context:
             samples = self.api_workflow_client.download_raw_samples()
+        self.assertTrue(
+            "Duplicate filename file_0 in relevant filenames file"
+            in str(context.warning)
+        )
+
         assert len(samples) == 5
         # expect a warning
 
     def test_absolute_filenames(self):
         self.api_workflow_client._datasources_api.reset
-        self.api_workflow_client._datasources_api._samples = defaultdict(lambda: [
+        self.api_workflow_client._datasources_api._samples = defaultdict(
+            lambda: [
                 DatasourceRawSamplesDataRow(file_name="/file_0", read_url="url_0"),
                 DatasourceRawSamplesDataRow(file_name="file_1", read_url="url_1"),
                 DatasourceRawSamplesDataRow(file_name="file_2", read_url="url_2"),
                 DatasourceRawSamplesDataRow(file_name="file_3", read_url="url_3"),
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
-                ])
-        with self.assertRaises(ValueError):
+            ]
+        )
+        with self.assertRaises(ValueError) as context:
             samples = self.api_workflow_client.download_raw_samples()
+        self.assertTrue(
+            "Absolute file paths like /file_0 are not supported in relevant filenames file"
+            in str(context.exception)
+        )
 
+    def test_dot_slash(self):
+        self.api_workflow_client._datasources_api.reset
+        self.api_workflow_client._datasources_api._samples = defaultdict(
+            lambda: [
+                DatasourceRawSamplesDataRow(file_name="./file_0", read_url="url_0"),
+                DatasourceRawSamplesDataRow(file_name="file_1", read_url="url_1"),
+                DatasourceRawSamplesDataRow(file_name="file_2", read_url="url_2"),
+                DatasourceRawSamplesDataRow(file_name="file_3", read_url="url_3"),
+                DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
+            ]
+        )
+        with self.assertRaises(ValueError) as context:
+            samples = self.api_workflow_client.download_raw_samples()
+        self.assertTrue(
+            "Using dot notation ('./', '../') like in ./file_0" in str(context.exception)
+        )
+
+    def test_dot_dot_slash(self):
+        self.api_workflow_client._datasources_api.reset
+        self.api_workflow_client._datasources_api._samples = defaultdict(
+            lambda: [
+                DatasourceRawSamplesDataRow(file_name="../file_0", read_url="url_0"),
+                DatasourceRawSamplesDataRow(file_name="file_1", read_url="url_1"),
+                DatasourceRawSamplesDataRow(file_name="file_2", read_url="url_2"),
+                DatasourceRawSamplesDataRow(file_name="file_3", read_url="url_3"),
+                DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
+            ]
+        )
+        with self.assertRaises(ValueError) as context:
+            samples = self.api_workflow_client.download_raw_samples()
+        self.assertTrue(
+            "Using dot notation ('./', '../') like in ../file_0" in str(context.exception)
+        )

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -172,8 +172,8 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
         self.api_workflow_client._datasources_api._samples = defaultdict(
             lambda: [
                 DatasourceRawSamplesDataRow(file_name="file_0", read_url="url_0"),
-                DatasourceRawSamplesDataRow(file_name="file_0", read_url="url_0"),
                 DatasourceRawSamplesDataRow(file_name="file_1", read_url="url_1"),
+                DatasourceRawSamplesDataRow(file_name="file_0", read_url="url_0"),
                 DatasourceRawSamplesDataRow(file_name="file_2", read_url="url_2"),
                 DatasourceRawSamplesDataRow(file_name="file_3", read_url="url_3"),
                 DatasourceRawSamplesDataRow(file_name="file_4", read_url="url_4"),
@@ -183,7 +183,8 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             samples = self.api_workflow_client.download_raw_samples()
 
         assert len(samples) == 5
-        # expect a warning
+        for sample in samples:
+            assert sample is not None
 
     def test__download_raw_files_absolute_filenames(self):
         self.api_workflow_client._datasources_api.reset


### PR DESCRIPTION
- deduplicates duplicate relevant filenames with a user warning
- unit test verifies deduplication and emission of user warning for a case of duplicates
- raises error where absolute filepaths or other paths matching ^\.* are in relevant filenames
- unit test verifies the raising of an error in one case of an absolute path
- doc update to emphasize that only relative paths are supported


![Screenshot from 2022-08-25 16-20-32](https://user-images.githubusercontent.com/1595173/186690411-11220eea-c385-4d4f-9314-23d91ee37972.png)




closes LIG-1718