### PR TITLE
Add proportion_samples to generated api client

### DIFF
--- a/lightly/openapi_generated/swagger_client/models/selection_config.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config.py
@@ -34,25 +34,31 @@ class SelectionConfig(object):
     """
     swagger_types = {
         'n_samples': 'int',
+        'proportion_samples': 'float',
         'strategies': 'list[SelectionConfigEntry]'
     }
 
     attribute_map = {
         'n_samples': 'nSamples',
+        'proportion_samples': 'proportionSamples',
         'strategies': 'strategies'
     }
 
-    def __init__(self, n_samples=None, strategies=None, _configuration=None):  # noqa: E501
+    def __init__(self, n_samples=None, proportion_samples=None, strategies=None, _configuration=None):  # noqa: E501
         """SelectionConfig - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
         self._configuration = _configuration
 
         self._n_samples = None
+        self._proportion_samples = None
         self._strategies = None
         self.discriminator = None
 
-        self.n_samples = n_samples
+        if n_samples is not None:
+            self.n_samples = n_samples
+        if proportion_samples is not None:
+            self.proportion_samples = proportion_samples
         self.strategies = strategies
 
     @property
@@ -73,10 +79,29 @@ class SelectionConfig(object):
         :param n_samples: The n_samples of this SelectionConfig.  # noqa: E501
         :type: int
         """
-        if self._configuration.client_side_validation and n_samples is None:
-            raise ValueError("Invalid value for `n_samples`, must not be `None`")  # noqa: E501
 
         self._n_samples = n_samples
+
+    @property
+    def proportion_samples(self):
+        """Gets the proportion_samples of this SelectionConfig.  # noqa: E501
+
+
+        :return: The proportion_samples of this SelectionConfig.  # noqa: E501
+        :rtype: float
+        """
+        return self._proportion_samples
+
+    @proportion_samples.setter
+    def proportion_samples(self, proportion_samples):
+        """Sets the proportion_samples of this SelectionConfig.
+
+
+        :param proportion_samples: The proportion_samples of this SelectionConfig.  # noqa: E501
+        :type: float
+        """
+
+        self._proportion_samples = proportion_samples
 
     @property
     def strategies(self):

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -128,6 +128,7 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
 def test__selection_config_from_dict() -> None:
     cfg = {
         "n_samples": 10,
+        "proportion_samples": 0.1,
         "strategies": [
             {
                 "input": {"type": "EMBEDDINGS", "dataset_id": "some-dataset-id", "tag_name": "some-tag-name"},
@@ -148,6 +149,7 @@ def test__selection_config_from_dict() -> None:
     }
     selection_cfg = api_workflow_compute_worker._selection_config_from_dict(cfg)
     assert selection_cfg.n_samples == 10
+    assert selection_cfg.proportion_samples == 0.1
     assert selection_cfg.strategies is not None
     assert len(selection_cfg.strategies) == 2
     assert selection_cfg.strategies[0].input.type == "EMBEDDINGS"
@@ -163,32 +165,20 @@ def test__selection_config_from_dict() -> None:
     assert isinstance(cfg['strategies'][0]['input'], dict)
 
 
-def test__selection_config_from_dict__missing_n_samples() -> None:
-    cfg = {
-        "strategies": [
-            {"input": {"type": "EMBEDDINGS"}, "strategy": {"type": "DIVERSIFY"}},
-        ]
-    }
-    with pytest.raises(ValueError, match="Invalid value for `n_samples`, must not be `None`"):
-        api_workflow_compute_worker._selection_config_from_dict(cfg)
-
-
 def test__selection_config_from_dict__missing_strategies() -> None:
-    cfg = {"n_samples": 10}
+    cfg = {}
     selection_cfg = api_workflow_compute_worker._selection_config_from_dict(cfg)
-    assert selection_cfg.n_samples == 10
     assert selection_cfg.strategies == []
 
 
 def test__selection_config_from_dict__extra_key() -> None:
-    cfg = {"n_samples": 10, "strategies": [], "invalid-key": 0}
+    cfg = {"strategies": [], "invalid-key": 0}
     with pytest.raises(TypeError, match="got an unexpected keyword argument 'invalid-key'"):
         api_workflow_compute_worker._selection_config_from_dict(cfg)
 
 
 def test__selection_config_from_dict__extra_stratey_key() -> None:
     cfg = {
-        "n_samples": 10, 
         "strategies": [
             {
                 "input": {"type": "EMBEDDINGS"}, 
@@ -202,7 +192,6 @@ def test__selection_config_from_dict__extra_stratey_key() -> None:
 
 def test__selection_config_from_dict__extra_input_key() -> None:
     cfg = {
-        "n_samples": 10, 
         "strategies": [
             {
                 "input": {"type": "EMBEDDINGS", "datasetId": ""},
@@ -216,7 +205,6 @@ def test__selection_config_from_dict__extra_input_key() -> None:
 
 def test__selection_config_from_dict__extra_strategy_strategy_key() -> None:
     cfg = {
-        "n_samples": 10, 
         "strategies": [
             {
                 "input": {"type": "EMBEDDINGS"},


### PR DESCRIPTION
Adds api generated code for `proportion_samples` option.

## TODO
* ~~Wait until https://github.com/lightly-ai/lightly/pull/913 is merged and rebase~~
* Add docs --> This should actually be done in https://github.com/lightly-ai/lightly/pull/900