### PR TITLE
Igor lig 1609 allow users to share datasets from code

### DIFF
--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -530,6 +530,52 @@ It is also possible to directly download the actual files themselves as follows:
     )
 
 
+Sharing Datasets
+----------------
+
+Once a dataset has been created we can also make it accessible to other users by
+sharing it. Sharing works through e-mail addresses. 
+
+.. code-block:: python
+    :caption: Share a dataset
+
+    # we first need to have an api client (create a new or use an existing one)
+    client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+
+    # share a dataset with an user
+    client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=["user@something.com"])
+
+    # share dataset with a user while keep sharing it with previous users
+    user_emails = client.get_shared_users(dataset_id="MY_DATASET_ID")
+    user_emails.extend(["additional_user2@something.com"])
+    client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=user_emails)
+
+    # revoke access to all users
+    client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=[])
+
+
+If you want to get a list of users that have access to a given dataset we can do 
+this using the following code: 
+
+.. code-block:: python
+    :caption: Share a dataset
+
+    # we first need to have an api client (create a new or use an existing one)
+    client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+
+    # get a list of users that have access to a given dataset
+    client.get_shared_users(dataset_id="MY_DATASET_ID")
+    # ["user@something.com"]
+
+You find more details about the individual API requests in the docs for the
+Python client: :py:class:`lightly.api.api_workflow_client`
+
+
+.. note::
+
+    You can share a dataset immediately after creating the dataset. You don't have
+    to wait for a Lightly Worker run to complete!
+
 
 Reporting
 ---------

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -568,9 +568,6 @@ this using the following code:
     print(users)
     # ["user@something.com"]
 
-You find more details about the individual API requests in the docs for the
-Python client: :py:class:`lightly.api.api_workflow_client`
-
 
 .. note::
 

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -542,12 +542,12 @@ sharing it. Sharing works through e-mail addresses.
     # we first need to have an api client (create a new or use an existing one)
     client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
 
-    # share a dataset with an user
+    # share a dataset with a user
     client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=["user@something.com"])
 
     # share dataset with a user while keep sharing it with previous users
     user_emails = client.get_shared_users(dataset_id="MY_DATASET_ID")
-    user_emails.extend(["additional_user2@something.com"])
+    user_emails.append("additional_user2@something.com")
     client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=user_emails)
 
     # revoke access to all users
@@ -565,6 +565,7 @@ this using the following code:
 
     # get a list of users that have access to a given dataset
     client.get_shared_users(dataset_id="MY_DATASET_ID")
+    print(users)
     # ["user@something.com"]
 
 You find more details about the individual API requests in the docs for the

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -9,6 +9,7 @@ from lightly.api.api_workflow_tags import _TagsMixin
 from requests import Response
 
 from lightly.__init__ import __version__
+from lightly.api.api_workflow_collaboration import _CollaborationMixin
 from lightly.api.api_workflow_compute_worker import _ComputeWorkerMixin
 from lightly.api.api_workflow_datasets import _DatasetsMixin
 from lightly.api.api_workflow_datasources import _DatasourcesMixin
@@ -21,6 +22,7 @@ from lightly.api.bitmask import BitMask
 from lightly.api.utils import DatasourceType, get_signed_url_destination, getenv
 from lightly.api.version_checking import get_minimum_compatible_version, \
     version_compare
+from lightly.openapi_generated.swagger_client.api.collaboration_api import CollaborationApi
 from lightly.openapi_generated.swagger_client import ScoresApi, \
     QuotaApi, MetaDataConfigurationsApi
 from lightly.openapi_generated.swagger_client.api.datasets_api import \
@@ -56,6 +58,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
                         _TagsMixin,
                         _DatasourcesMixin,
                         _ComputeWorkerMixin,
+                        _CollaborationMixin,
                         ):
     """Provides a uniform interface to communicate with the api 
     
@@ -100,6 +103,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         if embedding_id is not None:
             self.embedding_id = embedding_id
 
+        self._collaboration_api = CollaborationApi(api_client=self.api_client)
         self._compute_worker_api = DockerApi(api_client=self.api_client)
         self._datasets_api = DatasetsApi(api_client=self.api_client)
         self._datasources_api = DatasourcesApi(api_client=self.api_client)

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -28,14 +28,14 @@ class _CollaborationMixin:
             List of email addresses of users to grant write permission
 
         Examples:
-          >>> # share a dataset with an user
+          >>> # share a dataset with a user
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
           >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=["user@something.com"])
           >>>
           >>> # share dataset with a user while keep sharing it with previous users
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
           >>> user_emails = client.get_shared_users(dataset_id="MY_DATASET_ID")
-          >>> user_emails.extend(["additional_user2@something.com"])
+          >>> user_emails.append("additional_user2@something.com")
           >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=user_emails)
           >>>
           >>> # revoke access to all users

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -1,0 +1,76 @@
+from os import access
+from typing import List
+
+from lightly.openapi_generated.swagger_client.models.create_entity_response import CreateEntityResponse
+from lightly.openapi_generated.swagger_client.models.dataset_create_request import DatasetCreateRequest
+
+from lightly.openapi_generated.swagger_client.models.shared_access_config_create_request import SharedAccessConfigCreateRequest
+from lightly.openapi_generated.swagger_client.models.shared_access_config_data import SharedAccessConfigData
+from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
+
+from lightly.openapi_generated.swagger_client.models.dataset_data import DatasetData
+from lightly.openapi_generated.swagger_client.rest import ApiException
+from lightly.openapi_generated.swagger_client.models.dataset_type import DatasetType
+
+class _CollaborationMixin:
+
+    def share_dataset(self, dataset_id: str, user_emails: List[str]):
+        """Shares dataset with a list of users
+
+        This method overwrites the list of users that have had access to the dataset
+        before. If you want to add someone new to the list make sure you get the
+        list of users with access beforehand and add them as well.
+
+        Args:
+          dataset_id:
+            Identifier of dataset
+          user_emails:  
+            List of email addresses of users to grant write permission
+
+        Examples:
+          >>> # share a dataset with an user
+          >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+          >>> client.share_dataset(dataset_id="MY_DATASET_ID", user_emails=["user@something.com"])
+          >>>
+          >>> # share dataset with a user while keep sharing it with previous users
+          >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+          >>> user_emails = client.get_shared_users(dataset_id="MY_DATASET_ID")
+          >>> user_emails.extend(["additional_user2@something.com"])
+          >>> client.share_dataset(dataset_id="MY_DATASET_ID", user_emails=user_emails)
+        """
+        body = SharedAccessConfigCreateRequest(access_type=SharedAccessType.WRITE, users=user_emails)
+        self._collaboration_api.create_or_update_shared_access_config_by_dataset_id(body=body, dataset_id=dataset_id)
+
+
+    def get_shared_users(self, dataset_id: str) -> List[str]:
+      """Get list of users that have access to the dataset
+      
+      Args:
+        dataset_id:
+          Identifier of dataset
+      
+      Returns:
+        List of email addresses of users that have write access to the dataset
+
+      Examples:
+          >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+          >>> client.get_shared_users(dataset_id="MY_DATASET_ID")
+          >>> ["user@something.com"]
+      """
+
+      access_configs: List[SharedAccessConfigData] = self._collaboration_api.get_shared_access_configs_by_dataset_id(dataset_id=dataset_id)
+
+      user_emails = []
+
+      # iterate through configs and find first WRITE config
+      # we use the same hard rule in the frontend to communicate with the API
+      # as we currently only support WRITE access
+
+      print(access_configs)
+
+      for access_config in access_configs:
+        if access_config.access_type == SharedAccessType.WRITE:
+          user_emails.extend(access_config.users)
+          break
+
+      return user_emails

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -30,17 +30,17 @@ class _CollaborationMixin:
         Examples:
           >>> # share a dataset with an user
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-          >>> client.share_dataset(dataset_id="MY_DATASET_ID", user_emails=["user@something.com"])
+          >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=["user@something.com"])
           >>>
           >>> # share dataset with a user while keep sharing it with previous users
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
           >>> user_emails = client.get_shared_users(dataset_id="MY_DATASET_ID")
           >>> user_emails.extend(["additional_user2@something.com"])
-          >>> client.share_dataset(dataset_id="MY_DATASET_ID", user_emails=user_emails)
+          >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=user_emails)
           >>>
           >>> # revoke access to all users
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-          >>> user_emails = client.share_dataset(dataset_id="MY_DATASET_ID", user_emails=[])
+          >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=[])
         """
         body = SharedAccessConfigCreateRequest(access_type=SharedAccessType.WRITE, users=user_emails)
         self._collaboration_api.create_or_update_shared_access_config_by_dataset_id(body=body, dataset_id=dataset_id)

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -14,7 +14,7 @@ from lightly.openapi_generated.swagger_client.models.dataset_type import Dataset
 
 class _CollaborationMixin:
 
-    def share_dataset(self, dataset_id: str, user_emails: List[str]):
+    def share_dataset_only_with(self, dataset_id: str, user_emails: List[str]):
         """Shares dataset with a list of users
 
         This method overwrites the list of users that have had access to the dataset

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -37,6 +37,10 @@ class _CollaborationMixin:
           >>> user_emails = client.get_shared_users(dataset_id="MY_DATASET_ID")
           >>> user_emails.extend(["additional_user2@something.com"])
           >>> client.share_dataset(dataset_id="MY_DATASET_ID", user_emails=user_emails)
+          >>>
+          >>> # revoke access to all users
+          >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+          >>> user_emails = client.share_dataset(dataset_id="MY_DATASET_ID", user_emails=[])
         """
         body = SharedAccessConfigCreateRequest(access_type=SharedAccessType.WRITE, users=user_emails)
         self._collaboration_api.create_or_update_shared_access_config_by_dataset_id(body=body, dataset_id=dataset_id)
@@ -59,15 +63,11 @@ class _CollaborationMixin:
       """
 
       access_configs: List[SharedAccessConfigData] = self._collaboration_api.get_shared_access_configs_by_dataset_id(dataset_id=dataset_id)
-
       user_emails = []
 
       # iterate through configs and find first WRITE config
       # we use the same hard rule in the frontend to communicate with the API
       # as we currently only support WRITE access
-
-      print(access_configs)
-
       for access_config in access_configs:
         if access_config.access_type == SharedAccessType.WRITE:
           user_emails.extend(access_config.users)

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -1,16 +1,9 @@
-from os import access
 from typing import List
-
-from lightly.openapi_generated.swagger_client.models.create_entity_response import CreateEntityResponse
-from lightly.openapi_generated.swagger_client.models.dataset_create_request import DatasetCreateRequest
 
 from lightly.openapi_generated.swagger_client.models.shared_access_config_create_request import SharedAccessConfigCreateRequest
 from lightly.openapi_generated.swagger_client.models.shared_access_config_data import SharedAccessConfigData
 from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
 
-from lightly.openapi_generated.swagger_client.models.dataset_data import DatasetData
-from lightly.openapi_generated.swagger_client.rest import ApiException
-from lightly.openapi_generated.swagger_client.models.dataset_type import DatasetType
 
 class _CollaborationMixin:
 

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -1,7 +1,13 @@
+from os import access
 from typing import List
 
 from lightly.openapi_generated.swagger_client.models.create_entity_response import CreateEntityResponse
 from lightly.openapi_generated.swagger_client.models.dataset_create_request import DatasetCreateRequest
+
+from lightly.openapi_generated.swagger_client.models.shared_access_config_create_request import SharedAccessConfigCreateRequest
+from lightly.openapi_generated.swagger_client.models.shared_access_config_data import SharedAccessConfigData
+from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
+
 from lightly.openapi_generated.swagger_client.models.dataset_data import DatasetData
 from lightly.openapi_generated.swagger_client.rest import ApiException
 from lightly.openapi_generated.swagger_client.models.dataset_type import DatasetType

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -1,16 +1,10 @@
-from os import access
 from typing import List
 
 from lightly.openapi_generated.swagger_client.models.create_entity_response import CreateEntityResponse
 from lightly.openapi_generated.swagger_client.models.dataset_create_request import DatasetCreateRequest
 
-from lightly.openapi_generated.swagger_client.models.shared_access_config_create_request import SharedAccessConfigCreateRequest
-from lightly.openapi_generated.swagger_client.models.shared_access_config_data import SharedAccessConfigData
-from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
-
 from lightly.openapi_generated.swagger_client.models.dataset_data import DatasetData
 from lightly.openapi_generated.swagger_client.rest import ApiException
-from lightly.openapi_generated.swagger_client.models.dataset_type import DatasetType
 
 class _DatasetsMixin:
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -672,7 +672,6 @@ class MockedApiClient(ApiClient):
 
 class MockedAPICollaboration(CollaborationApi):
     def create_or_update_shared_access_config_by_dataset_id(self, body, dataset_id, **kwargs):
-    #def share_dataset(self, dataset_id: str, user_emails: List[str]):
         assert isinstance(body, SharedAccessConfigCreateRequest)
         return CreateEntityResponse(id='access-share-config')
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -1,5 +1,6 @@
 import csv
 import io
+from os import access
 import tempfile
 import unittest
 from io import IOBase
@@ -43,6 +44,7 @@ from lightly.openapi_generated.swagger_client import ScoresApi, \
     InitialTagCreateRequest, ApiClient, VersioningApi, QuotaApi, \
     TagArithmeticsRequest, TagBitMaskResponse, SampleWriteUrls, SampleData, SampleDataModes, DatasourceRawSamplesMetadataData, Trigger2dEmbeddingJobRequest, SampleUpdateRequest
 from lightly.openapi_generated.swagger_client.api.embeddings_api import EmbeddingsApi
+from lightly.openapi_generated.swagger_client.api.collaboration_api import CollaborationApi
 from lightly.openapi_generated.swagger_client.api.jobs_api import JobsApi
 from lightly.openapi_generated.swagger_client.api.mappings_api import MappingsApi
 from lightly.openapi_generated.swagger_client.api.samplings_api import SamplingsApi
@@ -62,7 +64,9 @@ from lightly.openapi_generated.swagger_client.models.datasource_processed_until_
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data import DatasourceRawSamplesData
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data_row import DatasourceRawSamplesDataRow
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_predictions_data import DatasourceRawSamplesPredictionsData
-
+from lightly.openapi_generated.swagger_client.models.shared_access_config_create_request import SharedAccessConfigCreateRequest
+from lightly.openapi_generated.swagger_client.models.shared_access_config_data import SharedAccessConfigData
+from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
 
 def _check_dataset_id(dataset_id: str):
     assert isinstance(dataset_id, str)
@@ -666,6 +670,23 @@ class MockedApiClient(ApiClient):
         raise ValueError("ERROR: calling ApiClient.call_api(), but this should be mocked.")
 
 
+class MockedAPICollaboration(CollaborationApi):
+    def create_or_update_shared_access_config_by_dataset_id(self, body, dataset_id, **kwargs):
+    #def share_dataset(self, dataset_id: str, user_emails: List[str]):
+        assert isinstance(body, SharedAccessConfigCreateRequest)
+        return CreateEntityResponse(id='access-share-config')
+
+    def get_shared_access_configs_by_dataset_id(self, dataset_id, **kwargs):
+        write_config = SharedAccessConfigData(
+            id='some-id', 
+            owner='owner-id',
+            users=["user1@gmail.com", "user2@something.com"], 
+            organizations=['some-id'],
+            created_at=Timestamp(0),
+            last_modified_at=Timestamp(0),
+            access_type=SharedAccessType.WRITE)
+        return [write_config]
+
 class MockedApiWorkflowClient(ApiWorkflowClient):
 
     embeddings_filename_base = 'img'
@@ -688,6 +709,7 @@ class MockedApiWorkflowClient(ApiWorkflowClient):
         self._datasources_api = MockedDatasourcesApi(api_client=self.api_client)
         self._quota_api = MockedQuotaApi(api_client=self.api_client)
         self._compute_worker_api = MockedComputeWorkerApi(api_client=self.api_client)
+        self._collaboration_api = MockedAPICollaboration(api_client=self.api_client)
 
         lightly.api.api_workflow_client.requests.put = mocked_request_put
 
@@ -730,3 +752,5 @@ class MockedApiWorkflowSetup(unittest.TestCase):
 
     def setUp(self, token="token_xyz",  dataset_id="dataset_id_xyz") -> None:
         self.api_workflow_client = MockedApiWorkflowClient(token=token, dataset_id=dataset_id)
+
+

--- a/tests/api_workflow/test_api_workflow_collaboration.py
+++ b/tests/api_workflow/test_api_workflow_collaboration.py
@@ -7,10 +7,10 @@ class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
         self.api_workflow_client = MockedApiWorkflowClient(token="token_xyz")
 
     def test_share_empty_dataset(self):
-        self.api_workflow_client.share_dataset(dataset_id="some-dataset-id", user_emails=[])
+        self.api_workflow_client.share_dataset_only_with(dataset_id="some-dataset-id", user_emails=[])
 
     def test_share_dataset(self):
-        self.api_workflow_client.share_dataset(dataset_id="some-dataset-id", user_emails=["someone@something.com"])
+        self.api_workflow_client.share_dataset_only_with(dataset_id="some-dataset-id", user_emails=["someone@something.com"])
 
     def test_get_shared_users(self):
         user_emails = self.api_workflow_client.get_shared_users(dataset_id="some-dataset-id")

--- a/tests/api_workflow/test_api_workflow_collaboration.py
+++ b/tests/api_workflow/test_api_workflow_collaboration.py
@@ -1,0 +1,17 @@
+from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup, MockedApiWorkflowClient
+
+
+class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
+
+    def setUp(self) -> None:
+        self.api_workflow_client = MockedApiWorkflowClient(token="token_xyz")
+
+    def test_share_empty_dataset(self):
+        self.api_workflow_client.share_dataset(dataset_id="some-dataset-id", user_emails=[])
+
+    def test_share_dataset(self):
+        self.api_workflow_client.share_dataset(dataset_id="some-dataset-id", user_emails=["someone@something.com"])
+
+    def test_get_shared_users(self):
+        user_emails = self.api_workflow_client.get_shared_users(dataset_id="some-dataset-id")
+        assert user_emails == ["user1@gmail.com", "user2@something.com"]


### PR DESCRIPTION
## Changes

- users can now share datasets using the Python API
- add `share_dataset` method to share datasets with other users
- add `get_shared_users` method to get list of users that have access to a dataset
- add unit tests

I tested the whole setup also manually using a code similar to this:

Example
```Python
import lightly

api_client = lightly.api.ApiWorkflowClient(token='MY_TOKEN')

# share a dataset from Python client api
api_client.share_dataset(dataset_id="DATASET_ID", user_emails=['someone@something.com'])

# get list of shared users for a dataset
api_client.get_shared_users(dataset_id='630f7f90f17b7808bfebec51')
# Out: ['someone@something.com']
```