### PR TITLE
Automation for seeing compute worker state

### DIFF
--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -257,23 +257,12 @@ Now that everything is in place, let's configure and run a simple job.
         }
     )
 
-    """Optionally, You can use this code to track the state of the compute worker and only continue if it has finished."""
-    last_run_info = None
-    while True:
-        run_info = client.get_compute_worker_run_info(scheduled_run_id=scheduled_run_id)
-
-        # Print the state and message if either is new. You can adapt this log as you like, e.g. also print the time.
-        if run_info != last_run_info:
-            print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
-
-        # Break if the scheduled run is in one of the end states.
-        if run_info.in_end_state():
-            break
-
-        # Wait before polling the state again
-        time.sleep(30)  # Keep this at 30s or larger to prevent rate limiting.
-
-        last_run_info = run_info
+    """
+    Optionally, You can use this code to track and print the state of the compute worker.
+    The loop will end once the compute worker run has finished, was canceled or aborted.
+    """
+    for run_info in client.compute_worker_run_info_generator(scheduled_run_id=scheduled_run_id):
+        print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
 
 The command schedules a job with the following configurations:
 

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -271,12 +271,12 @@ The command schedules a job with the following configurations:
 For more details and options regarding the worker config, head to :ref:`docker-configuration`.
 For more details and options regarding the selection config, head to :ref:`worker-selection`.
 
-Monitoring the compute worker run
+Monitoring the Compute Worker Run
 ---------------------------------
 
 The worker should pick up the job after a few seconds and start working on it. The
 status of the current run and scheduled jobs can be seen under https://app.lightly.ai/compute/runs.
-Alternatively, you can also monitor it from python.
+Alternatively, you can also monitor it from Python.
 
 .. code-block:: python
     :caption: Monitoring the compute worker run from Python

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -257,24 +257,23 @@ Now that everything is in place, let's configure and run a simple job.
         }
     )
 
-     """Optionally, You can use this code to track the state of the compute worker and only continue if it has finished."""
-    last_log = ("", "")
+    """Optionally, You can use this code to track the state of the compute worker and only continue if it has finished."""
+    last_run_info = None
     while True:
-        state, message = client.get_compute_worker_state_and_message(scheduled_run_id=scheduled_run_id)
+        run_info = client.get_compute_worker_run_info(scheduled_run_id=scheduled_run_id)
 
         # Print the state and message if either is new. You can adapt this log as you like, e.g. also print the time.
-        if (state, message) != last_log:
-            print(f"Compute worker run is now in {state=} with {message=}")
+        if run_info != last_run_info:
+            print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
 
         # Break if the scheduled run is in one of the end states.
-        if state in [DockerRunScheduledState.CANCELED, DockerRunState.ABORTED, DockerRunState.COMPLETED, DockerRunState.FAILED]:
+        if run_info.in_end_state():
             break
 
         # Wait before polling the state again
         time.sleep(30)  # Keep this at 30s or larger to prevent rate limiting.
 
-        last_log = (state, message)
-
+        last_run_info = run_info
 
 The command schedules a job with the following configurations:
 

--- a/docs/source/docker/getting_started/first_steps.rst
+++ b/docs/source/docker/getting_started/first_steps.rst
@@ -257,12 +257,6 @@ Now that everything is in place, let's configure and run a simple job.
         }
     )
 
-    """
-    Optionally, You can use this code to track and print the state of the compute worker.
-    The loop will end once the compute worker run has finished, was canceled or aborted.
-    """
-    for run_info in client.compute_worker_run_info_generator(scheduled_run_id=scheduled_run_id):
-        print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
 
 The command schedules a job with the following configurations:
 
@@ -277,8 +271,27 @@ The command schedules a job with the following configurations:
 For more details and options regarding the worker config, head to :ref:`docker-configuration`.
 For more details and options regarding the selection config, head to :ref:`worker-selection`.
 
+Monitoring the compute worker run
+---------------------------------
+
 The worker should pick up the job after a few seconds and start working on it. The
-status of the current run and scheduled jobs can be seen under https://app.lightly.ai/compute/runs
+status of the current run and scheduled jobs can be seen under https://app.lightly.ai/compute/runs.
+Alternatively, you can also monitor it from python.
+
+.. code-block:: python
+    :caption: Monitoring the compute worker run from Python
+
+    """
+    You can use this code to track and print the state of the compute worker.
+    The loop will end once the compute worker run has finished, was canceled or aborted/failed.
+    """
+    for run_info in client.compute_worker_run_info_generator(scheduled_run_id=scheduled_run_id):
+        print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
+
+    if run_info.ended_successfully():
+        print("SUCCESS")
+    else:
+        print("FAILURE")
 
 After the job was processed, the selected data will be accessible in the configured dataset. The
 report can be accessed from the compute worker runs page mentioned just above.

--- a/docs/source/docker/integration/examples/trigger_job.py
+++ b/docs/source/docker/integration/examples/trigger_job.py
@@ -74,19 +74,19 @@ scheduled_run_id = client.schedule_compute_worker_run(
 )
 
 """Optionally, You can use this code to track the state of the compute worker and only continue if it has finished."""
-last_log = ("", "")
+last_run_info = None
 while True:
-    state, message = client.get_compute_worker_state_and_message(scheduled_run_id=scheduled_run_id)
+    run_info = client.get_compute_worker_run_info(scheduled_run_id=scheduled_run_id)
 
     # Print the state and message if either is new. You can adapt this log as you like, e.g. also print the time.
-    if (state, message) != last_log:
-        print(f"Compute worker run is now in {state=} with {message=}")
+    if run_info != last_run_info:
+        print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
 
     # Break if the scheduled run is in one of the end states.
-    if state in [DockerRunScheduledState.CANCELED, DockerRunState.ABORTED, DockerRunState.COMPLETED, DockerRunState.FAILED]:
+    if run_info.in_end_state():
         break
 
     # Wait before polling the state again
     time.sleep(30)  # Keep this at 30s or larger to prevent rate limiting.
 
-    last_log = (state, message)
+    last_run_info = run_info

--- a/docs/source/docker/integration/examples/trigger_job.py
+++ b/docs/source/docker/integration/examples/trigger_job.py
@@ -73,20 +73,9 @@ scheduled_run_id = client.schedule_compute_worker_run(
     }
 )
 
-"""Optionally, You can use this code to track the state of the compute worker and only continue if it has finished."""
-last_run_info = None
-while True:
-    run_info = client.get_compute_worker_run_info(scheduled_run_id=scheduled_run_id)
-
-    # Print the state and message if either is new. You can adapt this log as you like, e.g. also print the time.
-    if run_info != last_run_info:
-        print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
-
-    # Break if the scheduled run is in one of the end states.
-    if run_info.in_end_state():
-        break
-
-    # Wait before polling the state again
-    time.sleep(30)  # Keep this at 30s or larger to prevent rate limiting.
-
-    last_run_info = run_info
+"""
+Optionally, You can use this code to track and print the state of the compute worker.
+The loop will end once the compute worker run has finished, was canceled or aborted.
+"""
+for run_info in client.compute_worker_run_info_generator(scheduled_run_id=scheduled_run_id):
+    print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")

--- a/docs/source/docker/integration/examples/trigger_job.py
+++ b/docs/source/docker/integration/examples/trigger_job.py
@@ -75,7 +75,12 @@ scheduled_run_id = client.schedule_compute_worker_run(
 
 """
 Optionally, You can use this code to track and print the state of the compute worker.
-The loop will end once the compute worker run has finished, was canceled or aborted.
+The loop will end once the compute worker run has finished, was canceled or aborted/failed.
 """
 for run_info in client.compute_worker_run_info_generator(scheduled_run_id=scheduled_run_id):
     print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
+
+if run_info.ended_successfully():
+    print("SUCCESS")
+else:
+    print("FAILURE")

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -286,7 +286,7 @@ class _ComputeWorkerMixin:
 
         Polls the compute worker status every 30s.
         If the status changed, it will yield a new ComputeWorkerRunInfo.
-        If the compute worker run finished, the generator stops
+        If the compute worker run finished, the generator stops.
 
         Args:
             scheduled_run_id:

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -1,13 +1,18 @@
 import copy
 import dataclasses
 import time
-from typing import Any, Dict, List, Optional, Union, Tuple, Literal, Iterator
+from typing import Any, Dict, List, Optional, Union, Iterator
 
 from lightly.api.utils import retry
 from lightly.openapi_generated.swagger_client import (
-    SelectionConfig,
     DockerRunScheduledState,
     DockerRunState,
+)
+from lightly.openapi_generated.swagger_client import (
+    SelectionConfig,
+    SelectionConfigEntryInput,
+    SelectionConfigEntryStrategy,
+    SelectionConfigEntry,
 )
 from lightly.openapi_generated.swagger_client.models.create_docker_worker_registry_entry_request import (
     CreateDockerWorkerRegistryEntryRequest,
@@ -24,42 +29,54 @@ from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_data i
 from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_priority import (
     DockerRunScheduledPriority,
 )
-from lightly.openapi_generated.swagger_client.models.docker_worker_type import (
-    DockerWorkerType,
-)
 from lightly.openapi_generated.swagger_client.models.docker_worker_config import (
     DockerWorkerConfig,
 )
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_create_request import (
     DockerWorkerConfigCreateRequest,
 )
-from lightly.openapi_generated.swagger_client import (
-    SelectionConfig,
-    SelectionConfigEntryInput,
-    SelectionConfigEntryStrategy,
-    SelectionConfigEntry,
+from lightly.openapi_generated.swagger_client.models.docker_worker_type import (
+    DockerWorkerType,
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
-
 
 STATE_SCHEDULED_ID_NOT_FOUND = "CANCELED_OR_NOT_EXISTING"
 
 
 @dataclasses.dataclass
 class ComputeWorkerRunInfo:
+    """
+    Contains information about a compute worker run that is useful for monitoring it.
+
+    Attributes:
+        state:
+            The state of the compute worker run.
+        message:
+            The last message of the compute worker run.
+    """
 
     state: Union[
         DockerRunState, DockerRunScheduledState.OPEN, STATE_SCHEDULED_ID_NOT_FOUND
     ]
     message: str
 
-    def in_end_state(self):
+    def in_end_state(self) -> bool:
+        """Returns wether the compute worker has ended"""
         return self.state in [
-            DockerRunState.ABORTED,
             DockerRunState.COMPLETED,
+            DockerRunState.ABORTED,
             DockerRunState.FAILED,
             STATE_SCHEDULED_ID_NOT_FOUND,
         ]
+
+    def ended_successfully(self) -> bool:
+        """
+        Returns wether the compute worker ended successfully or failed.
+        Raises a ValueError if the compute worker is still running.
+        """
+        if not self.in_end_state():
+            raise ValueError("Compute worker is still running")
+        return self.state == DockerRunState.COMPLETED
 
 
 class _ComputeWorkerMixin:
@@ -184,10 +201,17 @@ class _ComputeWorkerMixin:
             dataset_id=self.dataset_id
         )
 
-    def get_scheduled_run_by_id(self, scheduled_run_id: str) -> DockerRunScheduledData:
+    def _get_scheduled_run_by_id(self, scheduled_run_id: str) -> DockerRunScheduledData:
         """Returns the schedule run data given the id of the scheduled run.
 
         TODO (MALTE, 09/2022): Have a proper API endpoint for doing this.
+        Args:
+            scheduled_run_id:
+                The id with which the run was scheduled.
+
+        Returns:
+            Data about the scheduled run.
+
         """
         try:
             run: DockerRunScheduledData = next(
@@ -214,8 +238,22 @@ class _ComputeWorkerMixin:
             scheduled_run_id:
                 The id with which the run was scheduled.
 
+        Returns:
+            Data about the compute worker run.
+
+        Examples:
+            >>> # Scheduled a compute worker run and get its state
+            >>> scheduled_run_id = client.schedule_compute_worker_run(...)
+            >>> run_info = client.get_compute_worker_run_info(scheduled_run_id)
+            >>> print(run_info)
+
+        """
+        """
+        Because we currently (09/2022) have different Database entries for a ScheduledRun and DockerRun,
+        the logic is more complicated and covers three cases.
         """
         try:
+            # Case 1: DockerRun exists.
             docker_run: DockerRunData = (
                 self._compute_worker_api.get_docker_run_by_scheduled_id(
                     scheduled_id=scheduled_run_id
@@ -226,12 +264,14 @@ class _ComputeWorkerMixin:
             )
         except ApiException:
             try:
-                _ = self.get_scheduled_run_by_id(scheduled_run_id)
+                # Case 2: DockerRun does NOT exist, but ScheduledRun exists.
+                _ = self._get_scheduled_run_by_id(scheduled_run_id)
                 info = ComputeWorkerRunInfo(
                     state=DockerRunScheduledState.OPEN,
                     message="Waiting for pickup by compute worker.",
                 )
             except ApiException:
+                # Case 3: NEITHER the DockerRun NOR the ScheduledRun exist.
                 info = ComputeWorkerRunInfo(
                     state=STATE_SCHEDULED_ID_NOT_FOUND,
                     message="The scheduled run was either canceled or does not exist.",
@@ -253,7 +293,14 @@ class _ComputeWorkerMixin:
                 The id with which the run was scheduled.
 
         Returns:
-            Generator of information about the compute worker run status
+            Generator of information about the compute worker run status.
+
+        Examples:
+            >>> # Scheduled a compute worker run and monitor its state
+            >>> scheduled_run_id = client.schedule_compute_worker_run(...)
+            >>> for run_info in client.compute_worker_run_info_generator(scheduled_run_id):
+            >>>     print(f"Compute worker run is now in state='{run_info.state}' with message='{run_info.message}'")
+            >>>
 
         """
         last_run_info = None

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -2,7 +2,11 @@ import copy
 from typing import Any, Dict, List, Optional, Union, Tuple
 
 from lightly.api.utils import retry
-from lightly.openapi_generated.swagger_client import SelectionConfig, DockerRunScheduledState, DockerRunState
+from lightly.openapi_generated.swagger_client import (
+    SelectionConfig,
+    DockerRunScheduledState,
+    DockerRunState,
+)
 from lightly.openapi_generated.swagger_client.models.create_docker_worker_registry_entry_request import (
     CreateDockerWorkerRegistryEntryRequest,
 )
@@ -33,6 +37,7 @@ from lightly.openapi_generated.swagger_client import (
     SelectionConfigEntryStrategy,
     SelectionConfigEntry,
 )
+
 
 class ScheduledRunUnknown(ValueError):
     pass
@@ -168,16 +173,29 @@ class _ComputeWorkerMixin:
         try:
             run: DockerRunScheduledData = next(
                 run
-                for run in retry(lambda: self._compute_worker_api.get_docker_runs_scheduled_by_dataset_id(
-                    self.dataset_id
-                ))
+                for run in retry(
+                    lambda: self._compute_worker_api.get_docker_runs_scheduled_by_dataset_id(
+                        self.dataset_id
+                    )
+                )
                 if run.id == scheduled_run_id
             )
             return run
         except StopIteration:
-            raise ScheduledRunUnknown(f"No scheduled run found for {scheduled_run_id=}.")
+            raise ScheduledRunUnknown(
+                f"No scheduled run found for {scheduled_run_id=}."
+            )
 
-    def get_compute_worker_state_and_message(self, scheduled_run_id: str) -> Tuple[Union[DockerRunState, DockerRunScheduledState.OPEN, DockerRunScheduledState.CANCELED], str]:
+    def get_compute_worker_state_and_message(
+        self, scheduled_run_id: str
+    ) -> Tuple[
+        Union[
+            DockerRunState,
+            DockerRunScheduledState.OPEN,
+            DockerRunScheduledState.CANCELED,
+        ],
+        str,
+    ]:
         """Returns information about the compute worker run.
 
         Args:
@@ -206,7 +224,11 @@ class _ComputeWorkerMixin:
             state = scheduled_run.state
             message = scheduled_run_state_to_message[scheduled_run.state]
         else:
-            docker_run: DockerRunData = retry(lambda: self._compute_worker_api.get_docker_run_by_scheduled_id(scheduled_id=scheduled_run_id))
+            docker_run: DockerRunData = retry(
+                lambda: self._compute_worker_api.get_docker_run_by_scheduled_id(
+                    scheduled_id=scheduled_run_id
+                )
+            )
             state = docker_run.state
             message = docker_run.message
         return state, message

--- a/lightly/openapi_generated/swagger_client/api/docker_api.py
+++ b/lightly/openapi_generated/swagger_client/api/docker_api.py
@@ -718,6 +718,101 @@ class DockerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_docker_run_by_scheduled_id(self, scheduled_id, **kwargs):  # noqa: E501
+        """get_docker_run_by_scheduled_id  # noqa: E501
+
+        Retrieves the associated docker run of a scheduled run; returns the docker run by the id of the scheduled run which caused this docker run. If a scheduled docker run has not yet started being processed by a worker, a 404 will be returned.    # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_docker_run_by_scheduled_id(scheduled_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param MongoObjectID scheduled_id: ObjectId of the docker worker run (required)
+        :return: DockerRunData
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.get_docker_run_by_scheduled_id_with_http_info(scheduled_id, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_docker_run_by_scheduled_id_with_http_info(scheduled_id, **kwargs)  # noqa: E501
+            return data
+
+    def get_docker_run_by_scheduled_id_with_http_info(self, scheduled_id, **kwargs):  # noqa: E501
+        """get_docker_run_by_scheduled_id  # noqa: E501
+
+        Retrieves the associated docker run of a scheduled run; returns the docker run by the id of the scheduled run which caused this docker run. If a scheduled docker run has not yet started being processed by a worker, a 404 will be returned.    # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_docker_run_by_scheduled_id_with_http_info(scheduled_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param MongoObjectID scheduled_id: ObjectId of the docker worker run (required)
+        :return: DockerRunData
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['scheduled_id']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_docker_run_by_scheduled_id" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'scheduled_id' is set
+        if self.api_client.client_side_validation and ('scheduled_id' not in params or
+                                                       params['scheduled_id'] is None):  # noqa: E501
+            raise ValueError("Missing the required parameter `scheduled_id` when calling `get_docker_run_by_scheduled_id`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'scheduled_id' in params:
+            path_params['scheduledId'] = params['scheduled_id']  # noqa: E501
+
+        query_params = []
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = ['ApiKeyAuth', 'auth0Bearer']  # noqa: E501
+
+        return self.api_client.call_api(
+            '/v1/docker/runs/schedule/{scheduledId}', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='DockerRunData',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=params.get('async_req'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_docker_run_report_read_url_by_id(self, run_id, **kwargs):  # noqa: E501
         """get_docker_run_report_read_url_by_id  # noqa: E501
 

--- a/lightly/openapi_generated/swagger_client/models/docker_run_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_data.py
@@ -35,8 +35,10 @@ class DockerRunData(object):
     swagger_types = {
         'id': 'MongoObjectID',
         'docker_version': 'str',
-        'dataset_id': 'MongoObjectID',
         'state': 'DockerRunState',
+        'dataset_id': 'MongoObjectID',
+        'config_id': 'MongoObjectID',
+        'scheduled_id': 'MongoObjectID',
         'created_at': 'Timestamp',
         'last_modified_at': 'Timestamp',
         'message': 'str',
@@ -47,8 +49,10 @@ class DockerRunData(object):
     attribute_map = {
         'id': 'id',
         'docker_version': 'dockerVersion',
-        'dataset_id': 'datasetId',
         'state': 'state',
+        'dataset_id': 'datasetId',
+        'config_id': 'configId',
+        'scheduled_id': 'scheduledId',
         'created_at': 'createdAt',
         'last_modified_at': 'lastModifiedAt',
         'message': 'message',
@@ -56,7 +60,7 @@ class DockerRunData(object):
         'report_available': 'reportAvailable'
     }
 
-    def __init__(self, id=None, docker_version=None, dataset_id=None, state=None, created_at=None, last_modified_at=None, message=None, messages=None, report_available=None, _configuration=None):  # noqa: E501
+    def __init__(self, id=None, docker_version=None, state=None, dataset_id=None, config_id=None, scheduled_id=None, created_at=None, last_modified_at=None, message=None, messages=None, report_available=None, _configuration=None):  # noqa: E501
         """DockerRunData - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -64,8 +68,10 @@ class DockerRunData(object):
 
         self._id = None
         self._docker_version = None
-        self._dataset_id = None
         self._state = None
+        self._dataset_id = None
+        self._config_id = None
+        self._scheduled_id = None
         self._created_at = None
         self._last_modified_at = None
         self._message = None
@@ -75,9 +81,13 @@ class DockerRunData(object):
 
         self.id = id
         self.docker_version = docker_version
+        self.state = state
         if dataset_id is not None:
             self.dataset_id = dataset_id
-        self.state = state
+        if config_id is not None:
+            self.config_id = config_id
+        if scheduled_id is not None:
+            self.scheduled_id = scheduled_id
         self.created_at = created_at
         self.last_modified_at = last_modified_at
         if message is not None:
@@ -134,27 +144,6 @@ class DockerRunData(object):
         self._docker_version = docker_version
 
     @property
-    def dataset_id(self):
-        """Gets the dataset_id of this DockerRunData.  # noqa: E501
-
-
-        :return: The dataset_id of this DockerRunData.  # noqa: E501
-        :rtype: MongoObjectID
-        """
-        return self._dataset_id
-
-    @dataset_id.setter
-    def dataset_id(self, dataset_id):
-        """Sets the dataset_id of this DockerRunData.
-
-
-        :param dataset_id: The dataset_id of this DockerRunData.  # noqa: E501
-        :type: MongoObjectID
-        """
-
-        self._dataset_id = dataset_id
-
-    @property
     def state(self):
         """Gets the state of this DockerRunData.  # noqa: E501
 
@@ -176,6 +165,69 @@ class DockerRunData(object):
             raise ValueError("Invalid value for `state`, must not be `None`")  # noqa: E501
 
         self._state = state
+
+    @property
+    def dataset_id(self):
+        """Gets the dataset_id of this DockerRunData.  # noqa: E501
+
+
+        :return: The dataset_id of this DockerRunData.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._dataset_id
+
+    @dataset_id.setter
+    def dataset_id(self, dataset_id):
+        """Sets the dataset_id of this DockerRunData.
+
+
+        :param dataset_id: The dataset_id of this DockerRunData.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._dataset_id = dataset_id
+
+    @property
+    def config_id(self):
+        """Gets the config_id of this DockerRunData.  # noqa: E501
+
+
+        :return: The config_id of this DockerRunData.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._config_id
+
+    @config_id.setter
+    def config_id(self, config_id):
+        """Sets the config_id of this DockerRunData.
+
+
+        :param config_id: The config_id of this DockerRunData.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._config_id = config_id
+
+    @property
+    def scheduled_id(self):
+        """Gets the scheduled_id of this DockerRunData.  # noqa: E501
+
+
+        :return: The scheduled_id of this DockerRunData.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._scheduled_id
+
+    @scheduled_id.setter
+    def scheduled_id(self, scheduled_id):
+        """Sets the scheduled_id of this DockerRunData.
+
+
+        :param scheduled_id: The scheduled_id of this DockerRunData.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._scheduled_id = scheduled_id
 
     @property
     def created_at(self):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@ sphinx
 pytest
 pytest-forked
 pytest-xdist
+pytest-mock
 responses
 sphinx-copybutton
 sphinx-design

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -1,17 +1,37 @@
 import json
+from unittest.mock import MagicMock
+
 import pytest
-from typing import Dict, Any
+from typing import Any
 from unittest import mock
 
-from omegaconf import DictConfig, OmegaConf
-
-from lightly.openapi_generated.swagger_client import SelectionConfig, SelectionConfigEntry, SelectionInputType, \
-    SelectionStrategyType, ApiClient, DockerApi, SelectionConfigEntryInput, SelectionStrategyThresholdOperation, \
-    SelectionInputPredictionsName, SelectionConfigEntryStrategy, DockerWorkerConfig, DockerWorkerType
-from lightly.openapi_generated.swagger_client.models.docker_run_data import DockerRunData
-from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_data import DockerRunScheduledData
+from lightly.api.api_workflow_compute_worker import ScheduledRunUnknown
+from lightly.openapi_generated.swagger_client import (
+    SelectionConfig,
+    SelectionConfigEntry,
+    SelectionInputType,
+    SelectionStrategyType,
+    ApiClient,
+    DockerApi,
+    SelectionConfigEntryInput,
+    SelectionStrategyThresholdOperation,
+    SelectionInputPredictionsName,
+    SelectionConfigEntryStrategy,
+    DockerWorkerConfig,
+    DockerWorkerType,
+    DockerRunScheduledPriority,
+    DockerRunScheduledState,
+    DockerRunState,
+)
+from lightly.openapi_generated.swagger_client.models.docker_run_data import (
+    DockerRunData,
+)
+from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_data import (
+    DockerRunScheduledData,
+)
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
-from lightly.api import api_workflow_compute_worker
+from lightly.api import api_workflow_compute_worker, ApiWorkflowClient
+
 
 class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
     def test_register_compute_worker(self):
@@ -23,50 +43,54 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
         assert worker_id
 
     def test_delete_compute_worker(self):
-        worker_id = self.api_workflow_client.register_compute_worker(name='my-worker')
+        worker_id = self.api_workflow_client.register_compute_worker(name="my-worker")
         assert worker_id
         self.api_workflow_client.delete_compute_worker(worker_id)
 
     def test_create_compute_worker_config(self):
         config_id = self.api_workflow_client.create_compute_worker_config(
             worker_config={
-                'enable_corruptness_check': True,
-                'stopping_condition': {
-                    'n_samples': 10,
-                }
+                "enable_corruptness_check": True,
+                "stopping_condition": {
+                    "n_samples": 10,
+                },
             },
             lightly_config={
-                'resize': 224,
-                'loader': {
-                    'batch_size': 64,
-                }
+                "resize": 224,
+                "loader": {
+                    "batch_size": 64,
+                },
             },
             selection_config={
-                'n_samples': 20,
-                'strategies': [
+                "n_samples": 20,
+                "strategies": [
                     {
-                        "input": {"type": "EMBEDDINGS", "dataset_id": "some-dataset-id", "tag_name": "some-tag-name"},
-                        "strategy": {"type": "SIMILARITY"}
+                        "input": {
+                            "type": "EMBEDDINGS",
+                            "dataset_id": "some-dataset-id",
+                            "tag_name": "some-tag-name",
+                        },
+                        "strategy": {"type": "SIMILARITY"},
                     },
-                ]
-            }
+                ],
+            },
         )
         assert config_id
 
     def test_schedule_compute_worker_run(self):
         scheduled_run_id = self.api_workflow_client.schedule_compute_worker_run(
             worker_config={
-                'enable_corruptness_check': True,
-                'stopping_condition': {
-                    'n_samples': 10,
-                }
+                "enable_corruptness_check": True,
+                "stopping_condition": {
+                    "n_samples": 10,
+                },
             },
             lightly_config={
-                'resize': 224,
-                'loader': {
-                    'batch_size': 64,
-                }
-            }
+                "resize": 224,
+                "loader": {
+                    "batch_size": 64,
+                },
+            },
         )
         assert scheduled_run_id
 
@@ -105,25 +129,50 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
             strategies=[
                 SelectionConfigEntry(
                     input=SelectionConfigEntryInput(type=SelectionInputType.EMBEDDINGS),
-                    strategy=SelectionConfigEntryStrategy(type=SelectionStrategyType.DIVERSITY, stopping_condition_minimum_distance=-1)
+                    strategy=SelectionConfigEntryStrategy(
+                        type=SelectionStrategyType.DIVERSITY,
+                        stopping_condition_minimum_distance=-1,
+                    ),
                 ),
                 SelectionConfigEntry(
-                    input=SelectionConfigEntryInput(type=SelectionInputType.SCORES, task="my-classification-task", score="uncertainty_margin"),
-                    strategy=SelectionConfigEntryStrategy(type=SelectionStrategyType.WEIGHTS)
+                    input=SelectionConfigEntryInput(
+                        type=SelectionInputType.SCORES,
+                        task="my-classification-task",
+                        score="uncertainty_margin",
+                    ),
+                    strategy=SelectionConfigEntryStrategy(
+                        type=SelectionStrategyType.WEIGHTS
+                    ),
                 ),
                 SelectionConfigEntry(
-                    input=SelectionConfigEntryInput(type=SelectionInputType.METADATA, key="lightly.sharpness"),
-                    strategy=SelectionConfigEntryStrategy(type=SelectionStrategyType.THRESHOLD, threshold=20, operation=SelectionStrategyThresholdOperation.BIGGER_EQUAL)
+                    input=SelectionConfigEntryInput(
+                        type=SelectionInputType.METADATA, key="lightly.sharpness"
+                    ),
+                    strategy=SelectionConfigEntryStrategy(
+                        type=SelectionStrategyType.THRESHOLD,
+                        threshold=20,
+                        operation=SelectionStrategyThresholdOperation.BIGGER_EQUAL,
+                    ),
                 ),
                 SelectionConfigEntry(
-                    input=SelectionConfigEntryInput(type=SelectionInputType.PREDICTIONS, task="my_object_detection_task", name=SelectionInputPredictionsName.CLASS_DISTRIBUTION),
-                    strategy=SelectionConfigEntryStrategy(type=SelectionStrategyType.BALANCE, target= {"Ambulance": 0.2, "Bus": 0.4})
-                )
-            ]
+                    input=SelectionConfigEntryInput(
+                        type=SelectionInputType.PREDICTIONS,
+                        task="my_object_detection_task",
+                        name=SelectionInputPredictionsName.CLASS_DISTRIBUTION,
+                    ),
+                    strategy=SelectionConfigEntryStrategy(
+                        type=SelectionStrategyType.BALANCE,
+                        target={"Ambulance": 0.2, "Bus": 0.4},
+                    ),
+                ),
+            ],
         )
-        config = DockerWorkerConfig(worker_type=DockerWorkerType.FULL, selection=selection_config)
+        config = DockerWorkerConfig(
+            worker_type=DockerWorkerType.FULL, selection=selection_config
+        )
 
         config_api = self._check_if_openapi_generated_obj_is_valid(config)
+
 
 def test_selection_config_from_dict() -> None:
     cfg = {
@@ -131,8 +180,12 @@ def test_selection_config_from_dict() -> None:
         "proportion_samples": 0.1,
         "strategies": [
             {
-                "input": {"type": "EMBEDDINGS", "dataset_id": "some-dataset-id", "tag_name": "some-tag-name"},
-                "strategy": {"type": "SIMILARITY"}
+                "input": {
+                    "type": "EMBEDDINGS",
+                    "dataset_id": "some-dataset-id",
+                    "tag_name": "some-tag-name",
+                },
+                "strategy": {"type": "SIMILARITY"},
             },
             {
                 "input": {
@@ -145,7 +198,7 @@ def test_selection_config_from_dict() -> None:
                     "operation": "BIGGER",
                 },
             },
-        ]
+        ],
     }
     selection_cfg = api_workflow_compute_worker.selection_config_from_dict(cfg)
     assert selection_cfg.n_samples == 10
@@ -162,7 +215,7 @@ def test_selection_config_from_dict() -> None:
     assert selection_cfg.strategies[1].strategy.threshold == 20
     assert selection_cfg.strategies[1].strategy.operation == "BIGGER"
     # verify that original dict was not mutated
-    assert isinstance(cfg['strategies'][0]['input'], dict)
+    assert isinstance(cfg["strategies"][0]["input"], dict)
 
 
 def test_selection_config_from_dict__missing_strategies() -> None:
@@ -173,7 +226,9 @@ def test_selection_config_from_dict__missing_strategies() -> None:
 
 def test_selection_config_from_dict__extra_key() -> None:
     cfg = {"strategies": [], "invalid-key": 0}
-    with pytest.raises(TypeError, match="got an unexpected keyword argument 'invalid-key'"):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument 'invalid-key'"
+    ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
 
 
@@ -181,14 +236,17 @@ def test_selection_config_from_dict__extra_stratey_key() -> None:
     cfg = {
         "strategies": [
             {
-                "input": {"type": "EMBEDDINGS"}, 
+                "input": {"type": "EMBEDDINGS"},
                 "strategy": {"type": "DIVERSITY"},
                 "invalid-key": {"type": ""},
             },
         ],
     }
-    with pytest.raises(TypeError, match="got an unexpected keyword argument 'invalid-key'"):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument 'invalid-key'"
+    ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
+
 
 def test_selection_config_from_dict__extra_input_key() -> None:
     cfg = {
@@ -199,7 +257,9 @@ def test_selection_config_from_dict__extra_input_key() -> None:
             },
         ],
     }
-    with pytest.raises(TypeError, match="got an unexpected keyword argument 'datasetId'"):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument 'datasetId'"
+    ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
 
 
@@ -208,15 +268,153 @@ def test_selection_config_from_dict__extra_strategy_strategy_key() -> None:
         "strategies": [
             {
                 "input": {"type": "EMBEDDINGS"},
-                "strategy": {"type": "DIVERSITY", "stoppingConditionMinimumDistance": 0},
+                "strategy": {
+                    "type": "DIVERSITY",
+                    "stoppingConditionMinimumDistance": 0,
+                },
             },
         ],
     }
-    with pytest.raises(TypeError, match="got an unexpected keyword argument 'stoppingConditionMinimumDistance'"):
+    with pytest.raises(
+        TypeError,
+        match="got an unexpected keyword argument 'stoppingConditionMinimumDistance'",
+    ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
 
 
 def test_selection_config_from_dict__typo() -> None:
     cfg = {"nSamples": 10}
-    with pytest.raises(TypeError, match="got an unexpected keyword argument 'nSamples'"):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument 'nSamples'"
+    ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
+
+
+def test_get_scheduled_run_by_id() -> None:
+
+    scheduled_runs = [
+        DockerRunScheduledData(
+            id=f"id_{i}",
+            dataset_id="dataset_id",
+            config_id="config_id",
+            priority=DockerRunScheduledPriority,
+            state=DockerRunScheduledState.OPEN,
+            created_at=0,
+            last_modified_at=1,
+        )
+        for i in range(3)
+    ]
+    mocked_compute_worker_api = MagicMock(
+        get_docker_runs_scheduled_by_dataset_id=lambda dataset_id: scheduled_runs
+    )
+    mocked_api_client = MagicMock(
+        dataset_id="asdf", _compute_worker_api=mocked_compute_worker_api
+    )
+
+    scheduled_run_id = "id_2"
+    scheduled_run_data = ApiWorkflowClient.get_scheduled_run_by_id(
+        self=mocked_api_client, scheduled_run_id=scheduled_run_id
+    )
+    assert scheduled_run_data.id == scheduled_run_id
+
+
+def test_get_scheduled_run_by_id_not_found() -> None:
+
+    scheduled_runs = [
+        DockerRunScheduledData(
+            id=f"id_{i}",
+            dataset_id="dataset_id",
+            config_id="config_id",
+            priority=DockerRunScheduledPriority,
+            state=DockerRunScheduledState.OPEN,
+            created_at=0,
+            last_modified_at=1,
+        )
+        for i in range(3)
+    ]
+    mocked_compute_worker_api = MagicMock(
+        get_docker_runs_scheduled_by_dataset_id=lambda dataset_id: scheduled_runs
+    )
+    mocked_api_client = MagicMock(
+        dataset_id="asdf", _compute_worker_api=mocked_compute_worker_api
+    )
+
+    scheduled_run_id = "id_5"
+    with pytest.raises(
+        ScheduledRunUnknown,
+        match=f"No scheduled run found for scheduled_run_id='{scheduled_run_id}'.",
+    ):
+        scheduled_run_data = ApiWorkflowClient.get_scheduled_run_by_id(
+            self=mocked_api_client, scheduled_run_id=scheduled_run_id
+        )
+
+
+def test_get_compute_worker_state_and_message_OPEN() -> None:
+
+    scheduled_run = DockerRunScheduledData(
+        id=f"id_2",
+        dataset_id="dataset_id",
+        config_id="config_id",
+        priority=DockerRunScheduledPriority,
+        state=DockerRunScheduledState.OPEN,
+        created_at=0,
+        last_modified_at=1,
+    )
+    mocked_api_client = MagicMock(
+        dataset_id="asdf", get_scheduled_run_by_id=lambda id: scheduled_run
+    )
+
+    state, message = ApiWorkflowClient.get_compute_worker_state_and_message(
+        self=mocked_api_client, scheduled_run_id=""
+    )
+    assert state == DockerRunScheduledState.OPEN
+    assert message == "Waiting for pickup by compute worker."
+
+
+def test_get_compute_worker_state_and_message_CANCELED() -> None:
+    def mocked_get_scheduled_run_by_id(id):
+        raise ScheduledRunUnknown()
+
+    mocked_api_client = MagicMock(
+        dataset_id="asdf", get_scheduled_run_by_id=mocked_get_scheduled_run_by_id
+    )
+
+    state, message = ApiWorkflowClient.get_compute_worker_state_and_message(
+        self=mocked_api_client, scheduled_run_id=""
+    )
+    assert state == DockerRunScheduledState.CANCELED
+    assert message == "The scheduled run was either canceled or never existed."
+
+
+def test_get_compute_worker_state_and_message_docker_state() -> None:
+    message = "SOME_MESSAGE"
+    scheduled_run = DockerRunScheduledData(
+        id=f"id_2",
+        dataset_id="dataset_id",
+        config_id="config_id",
+        priority=DockerRunScheduledPriority,
+        state=DockerRunScheduledState.LOCKED,
+        created_at=0,
+        last_modified_at=1,
+    )
+    docker_run = DockerRunData(
+        id="id",
+        state=DockerRunState.GENERATING_REPORT,
+        docker_version="",
+        created_at=0,
+        last_modified_at=0,
+        message=message,
+    )
+    mocked_api_client = MagicMock(
+        dataset_id="asdf",
+        get_scheduled_run_by_id=lambda id: scheduled_run,
+        _compute_worker_api=MagicMock(
+            get_docker_run_by_scheduled_id=lambda scheduled_id: docker_run
+        ),
+    )
+
+    state, message = ApiWorkflowClient.get_compute_worker_state_and_message(
+        self=mocked_api_client, scheduled_run_id=""
+    )
+    assert state == DockerRunState.GENERATING_REPORT
+    assert message == message

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -313,7 +313,7 @@ def test_get_scheduled_run_by_id() -> None:
     )
 
     scheduled_run_id = "id_2"
-    scheduled_run_data = ApiWorkflowClient.get_scheduled_run_by_id(
+    scheduled_run_data = ApiWorkflowClient._get_scheduled_run_by_id(
         self=mocked_api_client, scheduled_run_id=scheduled_run_id
     )
     assert scheduled_run_data.id == scheduled_run_id
@@ -345,7 +345,7 @@ def test_get_scheduled_run_by_id_not_found() -> None:
         ApiException,
         match=f"No scheduled run found for run with scheduled_run_id='{scheduled_run_id}'.",
     ):
-        scheduled_run_data = ApiWorkflowClient.get_scheduled_run_by_id(
+        scheduled_run_data = ApiWorkflowClient._get_scheduled_run_by_id(
             self=mocked_api_client, scheduled_run_id=scheduled_run_id
         )
 

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -364,7 +364,7 @@ def test_get_compute_worker_state_and_message_OPEN() -> None:
     )
     def mocked_raise_exception(*args, **kwargs):
         raise ApiException
-    mocked_api_client = MagicMock(dataset_id="asdf", _compute_worker_api=MagicMock(get_docker_run_by_scheduled_id=mocked_raise_exception), get_scheduled_run_by_id=lambda id: scheduled_run)
+    mocked_api_client = MagicMock(dataset_id="asdf", _compute_worker_api=MagicMock(get_docker_run_by_scheduled_id=mocked_raise_exception), _get_scheduled_run_by_id=lambda id: scheduled_run)
 
     run_info = ApiWorkflowClient.get_compute_worker_run_info(
         self=mocked_api_client, scheduled_run_id=""
@@ -377,7 +377,7 @@ def test_get_compute_worker_state_and_message_OPEN() -> None:
 def test_get_compute_worker_state_and_message_CANCELED() -> None:
     def mocked_raise_exception(*args, **kwargs):
         raise ApiException
-    mocked_api_client = MagicMock(dataset_id="asdf", _compute_worker_api=MagicMock(get_docker_run_by_scheduled_id=mocked_raise_exception), get_scheduled_run_by_id=mocked_raise_exception)
+    mocked_api_client = MagicMock(dataset_id="asdf", _compute_worker_api=MagicMock(get_docker_run_by_scheduled_id=mocked_raise_exception), _get_scheduled_run_by_id=mocked_raise_exception)
     run_info = ApiWorkflowClient.get_compute_worker_run_info(self=mocked_api_client, scheduled_run_id="")
     assert run_info.state == STATE_SCHEDULED_ID_NOT_FOUND
     assert run_info.message == 'The scheduled run was either canceled or does not exist.'


### PR DESCRIPTION
## Description

- added ApiWorfklowClient method to get the state and message of a compute worker run.
- added example on how to use that for monitoring to the docs
- added unittests

- autoformatted `lightly/api/api_workflow_compute_worker.py` with black

## Tests

- unittests
- manual tests: see below:

### Example of successful run:
```
Compute worker run is now in state='OPEN' with message='Waiting for pickup by compute worker.'
Compute worker run is now in state='INITIALIZING' with message='State set to INITIALIZING'
Compute worker run is now in state='CHECKING_CORRUPTNESS' with message='State set to CHECKING_CORRUPTNESS'
Compute worker run is now in state='PRETAGGING' with message='State set to PRETAGGING'
Compute worker run is now in state='EMBEDDING' with message='State set to EMBEDDING'
Compute worker run is now in state='SAMPLING' with message='State set to SAMPLING'
Compute worker run is now in state='UPLOADING_DATASET' with message='State set to UPLOADING_DATASET'
Compute worker run is now in state='GENERATING_REPORT' with message='State set to GENERATING_REPORT'
Compute worker run is now in state='COMPLETED' with message='State set to COMPLETED'
```

### Example of failed run:
```
Compute worker run is now in state='OPEN' with message='Waiting for pickup by compute worker.'
Compute worker run is now in state='STARTED' with message='State set to STARTED'
Compute worker run is now in state='INITIALIZING' with message='State set to INITIALIZING'
Compute worker run is now in state='CHECKING_CORRUPTNESS' with message='State set to CHECKING_CORRUPTNESS'
Compute worker run is now in state='PRETAGGING' with message='State set to PRETAGGING'
Compute worker run is now in state='FAILED' with message='[Errno 111] Connection refused'
```

### Example of canceled run:
```
Compute worker run is now in state='OPEN' with message='Waiting for pickup by compute worker.'
Compute worker run is now in state='CANCELED' with message='The scheduled run was either canceled or never existed.'
```