### PR TITLE
Remove model_output from Scorer

### DIFF
--- a/lightly/active_learning/scorers/classification.py
+++ b/lightly/active_learning/scorers/classification.py
@@ -98,9 +98,7 @@ class ScorerClassification(Scorer):
         if not isinstance(model_output, np.ndarray):
             model_output = np.array(model_output)
 
-        validated_model_output = self.ensure_valid_model_output(model_output)
-
-        super(ScorerClassification, self).__init__(validated_model_output)
+        self.model_output = self.ensure_valid_model_output(model_output)
 
     def ensure_valid_model_output(self, model_output: np.ndarray) -> np.ndarray:
         if len(model_output) == 0:

--- a/lightly/active_learning/scorers/detection.py
+++ b/lightly/active_learning/scorers/detection.py
@@ -197,7 +197,7 @@ class ScorerObjectDetection(Scorer):
     def __init__(self,
                  model_output: List[ObjectDetectionOutput],
                  config: Dict = None):
-        super(ScorerObjectDetection, self).__init__(model_output)
+        self.model_output = model_output
         self.config = config
         self._check_config()
 

--- a/lightly/active_learning/scorers/keypoint_detection.py
+++ b/lightly/active_learning/scorers/keypoint_detection.py
@@ -78,7 +78,7 @@ class ScorerKeypointDetection(Scorer):
     """
 
     def __init__(self, model_output: List[KeypointPrediction]):
-        super(ScorerKeypointDetection, self).__init__(model_output)
+        self.model_output = model_output
 
     def calculate_scores(self) -> Dict[str, np.ndarray]:
         """Calculates and returns active learning scores in a dictionary.

--- a/lightly/active_learning/scorers/scorer.py
+++ b/lightly/active_learning/scorers/scorer.py
@@ -1,20 +1,14 @@
-from typing import *
-import abc
+from typing import Dict, List
 
 import numpy as np
 
 
-class Scorer():
-    def __init__(self, model_output):
-        self.model_output = model_output
-
+class Scorer:
     def calculate_scores(self) -> Dict[str, np.ndarray]:
-        """Calculates and returns active learning scores in a dictionary.
-        """
+        """Calculates and returns active learning scores in a dictionary."""
         raise NotImplementedError
 
     @classmethod
     def score_names(cls) -> List[str]:
-        """Returns the names of the calculated active learning scores
-        """
+        """Returns the names of the calculated active learning scores"""
         raise NotImplementedError

--- a/lightly/active_learning/scorers/scorer.py
+++ b/lightly/active_learning/scorers/scorer.py
@@ -1,14 +1,17 @@
+from abc import ABC, abstractmethod
 from typing import Dict, List
 
 import numpy as np
 
 
-class Scorer:
+class Scorer(ABC):
+    @abstractmethod
     def calculate_scores(self) -> Dict[str, np.ndarray]:
         """Calculates and returns active learning scores in a dictionary."""
-        raise NotImplementedError
+        ...
 
     @classmethod
+    @abstractmethod
     def score_names(cls) -> List[str]:
         """Returns the names of the calculated active learning scores"""
-        raise NotImplementedError
+        ...

--- a/lightly/active_learning/scorers/semantic_segmentation.py
+++ b/lightly/active_learning/scorers/semantic_segmentation.py
@@ -105,7 +105,7 @@ class ScorerSemanticSegmentation(Scorer):
 
     def __init__(self,
                  model_output: Union[List[np.ndarray], Generator[np.ndarray, None, None]]):
-        super(ScorerSemanticSegmentation, self).__init__(model_output)
+        self.model_output = model_output
 
     def calculate_scores(self) -> Dict[str, np.ndarray]:
         """Calculates and returns the active learning scores.

--- a/lightly/active_learning/scorers/semantic_segmentation.py
+++ b/lightly/active_learning/scorers/semantic_segmentation.py
@@ -137,3 +137,8 @@ class ScorerSemanticSegmentation(Scorer):
             scores[score_name] = np.array(score_list)
 
         return scores
+
+    @classmethod
+    def score_names(cls) -> List[str]:
+        """Returns the names of the calculated active learning scores"""
+        return ScorerClassification.score_names()

--- a/tests/active_learning/test_ScorerSemanticSegmentation.py
+++ b/tests/active_learning/test_ScorerSemanticSegmentation.py
@@ -102,3 +102,10 @@ class TestScorerSemanticSegmentation(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             scorer.calculate_scores()
+
+    def test_scorer_semseg__score_names(self):
+
+        model_output = [np.empty(shape=(1,1,1))]
+        scorer = ScorerSemanticSegmentation(model_output=model_output)
+        scores = scorer.calculate_scores()
+        assert sorted(scores.keys()) == sorted(ScorerSemanticSegmentation.score_names())


### PR DESCRIPTION
### What changed and why

Minor refactor - remove `model_output` attribute from `Scorer` class.

Scorer acts as a protocol class. Different implementations use `model_output` differently, in fact, each Scorer expects a different type. No function that gets a Scorer on input accessed `model_output`.

Also made `Scorer` an abstract class and discovered that `class_names()` method was not implemented for `ScorerSemanticSegmentation`.

### How is it tested

- Unit tests pass.
- Added a unit test for `ScorerSemanticSegmentation.class_names()`
