### PR TITLE
Make create_dataset throw an error on existing datasets

### DIFF
--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -83,14 +83,15 @@ class _DatasetsMixin:
     def create_dataset(self, dataset_name: str, dataset_type: Optional[str] = None):
         """Creates a dataset on the Lightly Platform..
 
-        Raises a ValueError if a dataset with the given name already exists.
-
         Args:
             dataset_name:
                 The name of the dataset to be created.
             dataset_type:
                 The type of the dataset. We recommend to use the API provided constants
                 `DatasetType.IMAGES` and `DatasetType.VIDEOS`.
+
+        Raises:
+            ValueError: If a dataset with dataset_name already exists.
 
         Examples:
             >>> from lightly.api import ApiWorkflowClient

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -81,7 +81,11 @@ class _DatasetsMixin:
             )
 
     def create_dataset(self, dataset_name: str, dataset_type: Optional[str] = None):
-        """Creates a dataset on the Lightly Platform..
+        """Creates a dataset on the Lightly Platform.
+
+        The dataset_id of the created dataset is stored in the client.dataset_id
+        attribute and all further requests with the client will use the created dataset
+        by default.
 
         Args:
             dataset_name:
@@ -102,6 +106,13 @@ class _DatasetsMixin:
             >>>
             >>> # or to work with videos
             >>> client.create_dataset('your-dataset-name', dataset_type=DatasetType.VIDEOS)
+            >>>
+            >>> # retrieving dataset_id of the created dataset
+            >>> dataset_id = client.dataset_id
+            >>>
+            >>> # future client requests use the created dataset by default
+            >>> client.dataset_type
+            'Videos'
         """
 
         if self.dataset_name_exists(dataset_name=dataset_name):

--- a/tests/api_workflow/test_api_workflow_datasets.py
+++ b/tests/api_workflow/test_api_workflow_datasets.py
@@ -12,7 +12,16 @@ class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
 
     def test_create_dataset_existing(self):
         self.api_workflow_client._datasets_api.reset()
-        self.api_workflow_client.create_dataset(dataset_name="dataset_1")
+        with self.assertRaises(ValueError):
+            self.api_workflow_client.create_dataset(dataset_name="dataset_1")
+
+    def test_dataset_name_exists__new(self):
+        self.api_workflow_client._datasets_api.reset()
+        assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_new") == False
+
+    def test_dataset_name_exists__existing(self):
+        self.api_workflow_client._datasets_api.reset()
+        assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_1") == True
 
     def test_create_dataset_with_counter(self):
         self.api_workflow_client._datasets_api.reset()
@@ -55,4 +64,3 @@ class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
         self.api_workflow_client.create_new_dataset_with_unique_name('dataset')
         num_datasets_after = len(self.api_workflow_client.get_datasets())
         assert num_datasets_before + 1 == num_datasets_after
-


### PR DESCRIPTION
Changes:
* Add `dataset_name_exists` method
* Make `create_dataset` throw a ValueError if a dataset with the given name exists

Tested the code with:
* Add unit test
* Test manually

Note that this is a potentially breaking change for users and we should make sure to point this out in the release notes.