### PR TITLE
Add scores argument to ObjectDetectionOutput

### DIFF
--- a/tests/active_learning/test_ObjectDetectionOutput.py
+++ b/tests/active_learning/test_ObjectDetectionOutput.py
@@ -145,3 +145,28 @@ class TestObjectDetectionOutput(unittest.TestCase):
                 ['hello'],
             )
 
+        with self.assertRaises(ValueError):
+            # scores must have same length as boxes
+            ObjectDetectionOutput(
+                boxes=[],
+                object_probabilities=[],
+                class_probabilities=[],
+                scores=[1.0],
+            )
+
+def test_ObjectDetectionOutput__with_scores():
+    output = ObjectDetectionOutput(
+        boxes=[BoundingBox(0, 0, 1, 1)],
+        object_probabilities=[0.1],
+        class_probabilities=[[0.2]],
+        scores=[0.3],
+    )
+    assert output.scores == [0.3]
+
+def test_ObjectDetectionOutput__without_scores():
+    output = ObjectDetectionOutput(
+        boxes=[BoundingBox(0, 0, 1, 1)],
+        object_probabilities=[0.1],
+        class_probabilities=[[0.2]],
+    )
+    assert output.scores == [0.1 * 0.2]


### PR DESCRIPTION
### What has changed and why?

Added an optional `scores` argument to the `ObjectDetectionOutput.__init__` method. The argument should be used when `scores` and `class_probabilities` are known when an instance of the class is created. This is different from the `ObjectDetectionOutput.from_scores` method which assumes that `class_probabilities` are unknown.

I decided to add it as an optional argument to not break backwards compatibility.

### How has it been tested?

Added unit tests.