### PR TITLE
Fix typehints for export functions

### DIFF
--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -157,7 +157,7 @@ class _DownloadDatasetMixin:
     def export_label_studio_tasks_by_tag_id(
         self,
         tag_id: str,
-    ) -> List[LabelStudioTask]:
+    ) -> List[Dict]:
         """Exports samples in a format compatible with Label Studio.
 
         The format is documented here:
@@ -182,7 +182,7 @@ class _DownloadDatasetMixin:
     def export_label_studio_tasks_by_tag_name(
         self,
         tag_name: str,
-    ) -> List[LabelStudioTask]:
+    ) -> List[Dict]:
         """Exports samples in a format compatible with Label Studio.
 
         The format is documented here:
@@ -211,7 +211,7 @@ class _DownloadDatasetMixin:
     def export_label_box_data_rows_by_tag_id(
         self,
         tag_id: str,
-    ) -> List[LabelBoxDataRow]:
+    ) -> List[Dict]:
         """Exports samples in a format compatible with Labelbox.
 
         The format is documented here:
@@ -236,7 +236,7 @@ class _DownloadDatasetMixin:
     def export_label_box_data_rows_by_tag_name(
         self,
         tag_name: str,
-    ) -> List[LabelBoxDataRow]:
+    ) -> List[Dict]:
         """Exports samples in a format compatible with Labelbox.
 
         The format is documented here:
@@ -314,7 +314,7 @@ class _DownloadDatasetMixin:
     def export_filenames_and_read_urls_by_tag_id(
         self,
         tag_id: str,
-    ) -> List[FilenameAndReadUrl]:
+    ) -> List[Dict]:
         """Export the samples filenames to map with their readURL.
 
         Args:
@@ -336,7 +336,7 @@ class _DownloadDatasetMixin:
     def export_filenames_and_read_urls_by_tag_name(
         self,
         tag_name: str,
-    ) -> List[FilenameAndReadUrl]:
+    ) -> List[Dict]:
         """Export the samples filenames to map with their readURL.
 
         Args:

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -379,7 +379,7 @@ class MockedTagsApi(TagsApi):
 
     def export_tag_to_label_studio_tasks(
         self, dataset_id: str, tag_id: str, **kwargs
-    ) -> List[LabelStudioTask]:
+    ) -> List[Dict]:
         if kwargs["page_offset"] and kwargs["page_offset"] > 0:
             return []
         return [
@@ -425,31 +425,31 @@ class MockedTagsApi(TagsApi):
                         ),
                     ),
                 )
-            )
+            ).to_dict() # temporary until we have a proper openapi generator
         ]
 
     def export_tag_to_label_box_data_rows(
         self, dataset_id: str, tag_id: str, **kwargs
-    ) -> List[LabelBoxDataRow]:
+    ) -> List[Dict]:
         if kwargs["page_offset"] and kwargs["page_offset"] > 0:
             return []
         return [
             LabelBoxDataRow(
                 external_id = "2008_007291_jpg.rf.2fca436925b52ea33cf897125a34a2fb.jpg",
                 image_url = "https://api.lightly.ai/v1/datasets/62383ab8f9cb290cd83ab5f9/samples/62383cb7e6a0f29e3f31e233/readurlRedirect?type=CENSORED",
-            )
+            ).to_dict() # temporary until we have a proper openapi generator
         ]
 
     def export_tag_to_basic_filenames_and_read_urls(
         self, dataset_id: str, tag_id: str, **kwargs
-    ) -> List[FilenameAndReadUrl]:
+    ) -> List[Dict]:
         if kwargs["page_offset"] and kwargs["page_offset"] > 0:
             return []
         return [
             FilenameAndReadUrl(
                 file_name = "export-basic-test-sample-0.png",
                 read_url = "https://storage.googleapis.com/somwhere/export-basic-test-sample-0.png?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=CENSORED",
-            )
+            ).to_dict() # temporary until we have a proper openapi generator
         ]
 
     def export_tag_to_basic_filenames(self, dataset_id: str, tag_id: str) -> str:

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -47,18 +47,18 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
     def test_export_label_box_data_rows_by_tag_name(self):
         rows = self.api_workflow_client.export_label_box_data_rows_by_tag_name('initial-tag')
         self.assertIsNotNone(rows)
-        self.assertTrue(all(isinstance(row, LabelBoxDataRow) for row in rows))
+        self.assertTrue(all(isinstance(row, dict) for row in rows))
 
 
     def test_export_label_studio_tasks_by_tag_name(self):
         tasks = self.api_workflow_client.export_label_studio_tasks_by_tag_name('initial-tag')
         self.assertIsNotNone(tasks)
-        self.assertTrue(all(isinstance(task, LabelStudioTask) for task in tasks))
+        self.assertTrue(all(isinstance(task, dict) for task in tasks))
 
     def test_export_tag_to_basic_filenames_and_read_urls(self):
         filenames_and_read_urls = self.api_workflow_client.export_filenames_and_read_urls_by_tag_name('initial-tag')
         self.assertIsNotNone(filenames_and_read_urls)
-        self.assertTrue(all(isinstance(filenames_and_read_url, FilenameAndReadUrl) for filenames_and_read_url in filenames_and_read_urls))
+        self.assertTrue(all(isinstance(filenames_and_read_url, dict) for filenames_and_read_url in filenames_and_read_urls))
 
     def test_export_filenames_by_tag_name(self):
         filenames = self.api_workflow_client.export_filenames_by_tag_name('initial-tag')


### PR DESCRIPTION
# Fix typehints for export functions

The typehints for the export functions are inaccurate because swagger codegen can't handle arrays of types correctly.