### PR TITLE
Allow self signed certificates

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -293,7 +293,7 @@ def set_api_client_request_timeout(
 
 
 def get_api_client_configuration(
-    token: Optional[str]
+    token: Optional[str] = None,
 ) -> Configuration:
 
     host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai")

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -79,22 +79,18 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
             but used by a workflow, the newest embedding is taken by default
     """
 
-    def __init__(self, token: str = None, dataset_id: str = None, embedding_id: str = None):
+    def __init__(
+        self,
+        token: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        embedding_id: Optional[str] = None
+    ):
 
         self.check_version_compatibility()
 
-        configuration = Configuration()
-        configuration.host = getenv('LIGHTLY_SERVER_LOCATION', 'https://api.lightly.ai')
-        if token is None:
-            token = getenv('LIGHTLY_TOKEN', None)
-            if token is None:
-                raise ValueError(f"Either provide a 'token' argument or export"
-                                 f" a LIGHTLY_TOKEN environment variable")
-                
-        configuration.api_key = {'token': token}
-        api_client = ApiClient(configuration=configuration)
+        configuration = get_api_client_configuration(token=token)
+        self.api_client = ApiClient(configuration=configuration)
         self.user_agent = f"Lightly/{__version__}/python ({platform.platform()})"
-        self.api_client = api_client
         self.set_request_timeout(DEFAULT_API_TIMEOUT)
 
         self.token = token
@@ -110,13 +106,13 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
         self._selection_api = SamplingsApi(api_client=self.api_client)
         self._jobs_api = JobsApi(api_client=self.api_client)
         self._tags_api = TagsApi(api_client=self.api_client)
-        self._embeddings_api = EmbeddingsApi(api_client=api_client)
-        self._mappings_api = MappingsApi(api_client=api_client)
-        self._scores_api = ScoresApi(api_client=api_client)
-        self._samples_api = SamplesApi(api_client=api_client)
-        self._quota_api = QuotaApi(api_client=api_client)
+        self._embeddings_api = EmbeddingsApi(api_client=self.api_client)
+        self._mappings_api = MappingsApi(api_client=self.api_client)
+        self._scores_api = ScoresApi(api_client=self.api_client)
+        self._samples_api = SamplesApi(api_client=self.api_client)
+        self._quota_api = QuotaApi(api_client=self.api_client)
         self._metadata_configurations_api = \
-            MetaDataConfigurationsApi(api_client=api_client)
+            MetaDataConfigurationsApi(api_client=self.api_client)
 
     def check_version_compatibility(self):
         minimum_version = get_minimum_compatible_version()
@@ -294,3 +290,25 @@ def set_api_client_request_timeout(
         return request_fn(*args, **kwargs)
 
     client.rest_client.request = new_request_fn
+
+
+def get_api_client_configuration(
+    token: Optional[str]
+) -> Configuration:
+
+    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai")
+    ssl_ca_cert = getenv("LIGHTLY_CA_CERTS", None)
+
+    if token is None:
+        token = getenv("LIGHTLY_TOKEN", None)
+    if token is None:
+        raise ValueError(
+            "Either provide a 'token' argument or export a LIGHTLY_TOKEN environment variable"
+        )
+
+    configuration = Configuration()
+    configuration.api_key = {"token": token}
+    configuration.ssl_ca_cert = ssl_ca_cert
+    configuration.host = host
+
+    return configuration


### PR DESCRIPTION
# Allow self signed certificates

- Refactor the way a `Configuration` object is created to make it easily reusable.
- Allow passing of self-signed certificate bundles to the `ApiWorkflowClient`.