### PR TITLE
Guarin lig 1719 Add subdir info to prediction and metadata docs

### DIFF
--- a/docs/source/docker/advanced/datasource_metadata.rst
+++ b/docs/source/docker/advanced/datasource_metadata.rst
@@ -19,17 +19,21 @@ your input and output bucket will look like this:
 .. code-block:: bash
 
     input/bucket/
-        + image_1.png
-        + image_2.png
-        + ...
-        + image_N.png
+        + image_0.png
+        + subdir/
+            + image_1.png
+            + image_2.png
+            + ...
+            + image_N.png
 
     output/bucket/
         + .lightly/metadata
             + schema.json
-            + image_1.json
-            ...
-            + image_N.json
+            + image_0.json
+            + subdir/
+                + image_1.json
+                ...
+                + image_N.json
 
 
 All of the `.json` files are explained in the next sections.
@@ -112,14 +116,17 @@ as the image or video in the `.lightly/metadata` directory but change the file e
 
 .. code-block:: bash
 
-    # filename of the metadata for file FILENAME.EXT
-    .lightly/metadata/${FILENAME}.json
+    # filename of the metadata for file input/bucket/SUBDIR/FILENAME.EXT
+    .lightly/metadata/${SUBDIR}/${FILENAME}.json
 
-    # example: my_image.png
-    .lightly/metadata/my_image.json
+    # example: input/bucket/subdir/image_1.png
+    .lightly/metadata/subdir/image_1.json
 
-    # example: my_video.mp4
-    .lightly/metadata/my_video.json
+    # example: input/bucket/image_0.png
+    .lightly/metadata/image_0.json
+
+    # example: input/bucket/subdir/video_1.mp4
+    .lightly/metadata/subdir/video_1.json
 
 
 When working with videos it's also possible to provide metadata on a per-frame basis.
@@ -133,15 +140,15 @@ to length three. For a video with 1000 frames, the frame number will be padded t
 
 .. code-block:: bash
 
-    # filename of the metadata of the Xth frame of video FILENAME.EXT
+    # filename of the metadata of the Xth frame of video input/bucket/SUBDIR/FILENAME.EXT
     # with 200 frames (padding: len(str(200)) = 3)
-    .lightly/metadata/${FILENAME}-${X:03d}-${EXT}.json
+    .lightly/metadata/${SUBDIR}/${FILENAME}-${X:03d}-${EXT}.json
 
-    # example: my_video.mp4, frame 99/200
-    .lightly/metadata/my_video-099-mp4.json
+    # example: input/bucket/subdir/video_1.mp4, frame 99/200
+    .lightly/metadata/subdir/video_1-099-mp4.json
 
-    # example: my_subdir/my_video.mp4, frame 99/200
-    .lightly/metadata/my_subdir/my_video-099-mp4.json
+    # example: input/bucket/video_0.mp4, frame 99/200
+    .lightly/metadata/video_0-099-mp4.json
 
 
 .. _metadata-format:
@@ -162,10 +169,10 @@ For our example from above, a metadata file corresponding to a image/video/frame
     .. tab:: Video
     
         .. code-block:: javascript
-            :caption: .lightly/metadata/my_video.json
+            :caption: .lightly/metadata/subdir/video_1.json
 
             {
-                "file_name": "my_video.mp4",
+                "file_name": "subdir/video_1.mp4",
                 "type": "video",
                 "metadata": {
                     "scene": "city street",
@@ -181,10 +188,10 @@ For our example from above, a metadata file corresponding to a image/video/frame
     .. tab:: Frame
     
         .. code-block:: javascript
-            :caption: .lightly/metadata/my_video-099-mp4.json
+            :caption: .lightly/metadata/subdir/video_1-099-mp4.json
 
             {
-                "file_name": "my_video-099-mp4.png",
+                "file_name": "subdir/video_1-099-mp4.png",
                 "type": "frame",
                 "metadata": {
                     "scene": "city street",
@@ -200,10 +207,10 @@ For our example from above, a metadata file corresponding to a image/video/frame
     .. tab:: Image
     
         .. code-block:: javascript
-            :caption: .lightly/metadata/my_image.json
+            :caption: .lightly/metadata/subdir/image_1.json
 
             {
-                "file_name": "my_image.png",
+                "file_name": "subdir/image_1.png",
                 "type": "image",
                 "metadata": {
                     "scene": "highway",

--- a/docs/source/docker/advanced/datasource_predictions.rst
+++ b/docs/source/docker/advanced/datasource_predictions.rst
@@ -29,24 +29,30 @@ of your input and output bucket will look like this:
 .. code-block:: bash
 
     input/bucket/
-        + image_1.png
-        + image_2.png
-        + ...
-        + image_N.png
+        + image_0.png
+        + subdir/
+            + image_1.png
+            + image_2.png
+            + ...
+            + image_N.png
   
     output/bucket/
         + .lightly/predictions/
             + tasks.json
             + task_1/
                  + schema.json
-                 + image_1.json
-                 ...
-                 + image_N.json
+                 + image_0.json
+                 + subdir/
+                    + image_1.json
+                    ...
+                    + image_N.json
             + task_2/
                  + schema.json
-                 + image_1.json
-                 ...
-                 + image_N.json
+                 + image_0.json
+                 + subdir/
+                    + image_1.json
+                    ...
+                    + image_N.json
 
 
 
@@ -169,14 +175,14 @@ it's necessary to follow the naming convention:
 
 .. code-block:: bash
 
-    # filename of the prediction for image FILENAME.EXT
-    .lightly/predictions/${TASK_NAME}/${FILENAME}.json
+    # filename of the prediction for image input/bucket/SUBDIR/FILENAME.EXT
+    .lightly/predictions/${TASK_NAME}/${SUBDIR}/${FILENAME}.json
 
-    # example: my_image.png, classification
-    .lightly/predictions/my_classification_task/my_image.json
+    # example: input/bucket/subdir/image_1.png, classification
+    .lightly/predictions/my_classification_task/subdir/image_1.json
 
-    # example: my_subdir/my_image.png, classification
-    .lightly/predictions/my_classification_task/my_subdir/my_image.json
+    # example: input/bucket/image_0.png, classification
+    .lightly/predictions/my_classification_task/image_0.json
 
 
 .. _prediction-files-for-videos:
@@ -192,15 +198,15 @@ with 1000 frames, the frame number will be padded to length four (99 becomes 009
 
 .. code-block:: bash
 
-    # filename of the predictions of the Xth frame of video FILENAME.EXT
+    # filename of the predictions of the Xth frame of video input/bucket/SUBDIR/FILENAME.EXT
     # with 200 frames (padding: len(str(200)) = 3)
-    .lightly/predictions/${TASK_NAME}/${FILENAME}-${X:03d}-${EXT}.json
+    .lightly/predictions/${TASK_NAME}/${SUBDIR}/${FILENAME}-${X:03d}-${EXT}.json
 
-    # example: my_video.mp4, frame 99/200
-    .lightly/predictions/my_classification_task/my_video-099-mp4.json
+    # example: input/bucket/subdir/video_1.mp4, frame 99/200
+    .lightly/predictions/my_classification_task/subdir/video_1-099-mp4.json
 
-    # example: my_subdir/my_video.mp4, frame 99/200
-    .lightly/predictions/my_classification_task/my_subdir/my_video-099-mp4.json
+    # example: input/bucket/video_0.mp4, frame 99/200
+    .lightly/predictions/my_classification_task/video_0-099-mp4.json
 
 See :ref:`creating-prediction-files-for-videos` on how to extract video frames
 and create predictions using `ffmpeg <https://ffmpeg.org/>`_ or Python.
@@ -235,10 +241,10 @@ the predictions are made and predictions is a list of `Prediction Singletons` fo
 Example classification:
 
 .. code-block:: javascript
-    :caption: .lightly/predictions/classification_weather/my_image.json
+    :caption: .lightly/predictions/classification_weather/subdir/image_1.json
 
     {
-        "file_name": "my_image.png",
+        "file_name": "subdir/image_1.png",
         "predictions": [ // classes: [sunny, clouded, rainy]
             {
                 "category_id": 0,
@@ -250,10 +256,10 @@ Example classification:
 Example object detection:
 
 .. code-block:: javascript
-    :caption: .lightly/predictions/object_detection/my_image.json
+    :caption: .lightly/predictions/object_detection/subdir/image_1.json
 
     {
-        "file_name": "my_image.png",
+        "file_name": "subdir/image_1.png",
         "predictions": [ // classes: [person, car]
             {
                 "category_id": 0,
@@ -279,10 +285,10 @@ Example object detection:
 Example semantic segmentation:
 
 .. code-block:: javascript
-    :caption: .lightly/predictions/semantic_segmentation_cars/my_image.json
+    :caption: .lightly/predictions/semantic_segmentation_cars/subdir/image_1.json
 
     {
-        "file_name": "my_image.png",
+        "file_name": "subdir/image_1.png",
         "predictions": [ // classes: [background, car, tree]
             {
                 "category_id": 0,
@@ -422,7 +428,7 @@ format required by Lightly.
         })
 
     prediction = {
-        'file_name': 'image_name.png',
+        'file_name': 'subdir/image_name.png',
         'predictions': predictions,
     }
 


### PR DESCRIPTION
* Change examples to use subdirectories by default

[Add Predictions to a Datasource — lightly 1.2.31 documentation.pdf](https://github.com/lightly-ai/lightly/files/9754418/Add.Predictions.to.a.Datasource.lightly.1.2.31.documentation.pdf)
[Add Metadata to a Datasource — lightly 1.2.31 documentation.pdf](https://github.com/lightly-ai/lightly/files/9754420/Add.Metadata.to.a.Datasource.lightly.1.2.31.documentation.pdf)
