### PR TITLE
Malte lig 1897 implement run worker label matching

### DIFF
--- a/lightly/api/__init__.py
+++ b/lightly/api/__init__.py
@@ -5,3 +5,10 @@
 
 from lightly.api.api_workflow_client import ApiWorkflowClient
 from lightly.api.api_workflow_compute_worker import ArtifactNotExist
+
+# Mock the urlencode to use doseq, so that arrays in the query are properly encoded
+from six.moves.urllib.parse import urlencode
+def doseq_urlencode(fields):
+    return urlencode(fields, doseq=True)
+import urllib3.request
+urllib3.request.urlencode = doseq_urlencode

--- a/lightly/api/__init__.py
+++ b/lightly/api/__init__.py
@@ -5,10 +5,9 @@
 
 from lightly.api.api_workflow_client import ApiWorkflowClient
 from lightly.api.api_workflow_compute_worker import ArtifactNotExist
+from lightly.api.patch_rest_client import patch_rest_client
 
-# Mock the urlencode to use doseq, so that arrays in the query are properly encoded
-from six.moves.urllib.parse import urlencode
-def doseq_urlencode(fields):
-    return urlencode(fields, doseq=True)
-import urllib3.request
-urllib3.request.urlencode = doseq_urlencode
+from lightly.openapi_generated.swagger_client.rest import RESTClientObject
+
+# Needed to handle list of arguments correctly
+patch_rest_client(RESTClientObject)

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -68,7 +68,7 @@ class ComputeWorkerRunInfo:
 
 
 class _ComputeWorkerMixin:
-    def register_compute_worker(self, name: str = "Default", labels: List[str] = None) -> str:
+    def register_compute_worker(self, name: str = "Default", labels: Optional[List[str]] = None) -> str:
         """Registers a new compute worker.
 
         Args:
@@ -147,7 +147,7 @@ class _ComputeWorkerMixin:
         lightly_config: Optional[Dict[str, Any]] = None,
         selection_config: Optional[Union[Dict[str, Any], SelectionConfig]] = None,
         priority: str = DockerRunScheduledPriority.MID,
-        runs_on=None
+        runs_on: Optional[List[str]] = None
     ) -> str:
         """Schedules a run with the given configurations.
 

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -68,19 +68,23 @@ class ComputeWorkerRunInfo:
 
 
 class _ComputeWorkerMixin:
-    def register_compute_worker(self, name: str = "Default") -> str:
+    def register_compute_worker(self, name: str = "Default", labels=None) -> str:
         """Registers a new compute worker.
 
         Args:
             name:
-                The name of the compute worker.
+                The name of the Lightly Worker.
+            labels:
+                The labels of the Lightly Worker.
 
         Returns:
             The id of the newly registered compute worker.
 
         """
+        if labels is None:
+            labels = []
         request = CreateDockerWorkerRegistryEntryRequest(
-            name=name, worker_type=DockerWorkerType.FULL
+            name=name, worker_type=DockerWorkerType.FULL, labels=labels
         )
         response = self._compute_worker_api.register_docker_worker(request)
         return response.id

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -143,6 +143,7 @@ class _ComputeWorkerMixin:
         lightly_config: Optional[Dict[str, Any]] = None,
         selection_config: Optional[Union[Dict[str, Any], SelectionConfig]] = None,
         priority: str = DockerRunScheduledPriority.MID,
+        runs_on: List[str] = []
     ) -> str:
         """Schedules a run with the given configurations.
 
@@ -156,6 +157,8 @@ class _ComputeWorkerMixin:
             selection_config:
                 Selection configuration. See the docs for more information:
                 https://docs.lightly.ai/docker/getting_started/selection.html
+            runs_on:
+                The required labels the Lightly Worker must have to take the job.
 
         Returns:
             The id of the scheduled run.
@@ -167,7 +170,7 @@ class _ComputeWorkerMixin:
             selection_config=selection_config,
         )
         request = DockerRunScheduledCreateRequest(
-            config_id=config_id, priority=priority
+            config_id=config_id, priority=priority, runs_on=runs_on
         )
         response = self._compute_worker_api.create_docker_run_scheduled_by_dataset_id(
             body=request,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -68,7 +68,7 @@ class ComputeWorkerRunInfo:
 
 
 class _ComputeWorkerMixin:
-    def register_compute_worker(self, name: str = "Default", labels=None) -> str:
+    def register_compute_worker(self, name: str = "Default", labels: List[str] = None) -> str:
         """Registers a new compute worker.
 
         Args:
@@ -147,7 +147,7 @@ class _ComputeWorkerMixin:
         lightly_config: Optional[Dict[str, Any]] = None,
         selection_config: Optional[Union[Dict[str, Any], SelectionConfig]] = None,
         priority: str = DockerRunScheduledPriority.MID,
-        runs_on: List[str] = []
+        runs_on=None
     ) -> str:
         """Schedules a run with the given configurations.
 
@@ -168,6 +168,8 @@ class _ComputeWorkerMixin:
             The id of the scheduled run.
 
         """
+        if runs_on is None:
+            runs_on = []
         config_id = self.create_compute_worker_config(
             worker_config=worker_config,
             lightly_config=lightly_config,

--- a/lightly/api/patch_rest_client.py
+++ b/lightly/api/patch_rest_client.py
@@ -1,0 +1,20 @@
+from typing import Type
+
+
+def patch_rest_client(rest_client: Type):
+    request = rest_client.request
+
+    def request_patched(self, method, url, query_params=None, headers=None,
+                    body=None, post_params=None, _preload_content=True,
+                    _request_timeout=None):
+        if query_params is not None:
+            new_query_params = []
+            for name, value in query_params:
+                if isinstance(value, list):
+                    new_query_params.extend([(name, val) for val in value])
+                else:
+                    new_query_params.append((name, value))
+            query_params = new_query_params
+        return request(self, method=method, url=url, query_params=query_params, headers=headers, body=body, post_params=post_params, _preload_content=_preload_content, _request_timeout=_request_timeout)
+
+    rest_client.request = request_patched

--- a/lightly/api/patch_rest_client.py
+++ b/lightly/api/patch_rest_client.py
@@ -2,6 +2,26 @@ from typing import Type
 
 
 def patch_rest_client(rest_client: Type):
+    """
+
+    Patches the rest client to flatten out array query parameters.
+
+    Example:
+        query_params: [('labels', ['AAA', 'BBB'])]
+        new_query_params: [('labels', 'AAA'), ('labels', 'BBB')]
+        url part in query: "labels=AAA&labels=BBB"
+
+        Without this patch, the query_params would be translated into
+        "labels=['AAA', 'BBB']" in the url itself, which fails.
+
+    Args:
+        rest_client:
+            Must be the class swagger_client.rest.RESTClientObject to patch.
+            Note: it must be the class itself, not an instance of it.
+
+    Returns:
+
+    """
     request = rest_client.request
 
     def request_patched(self, method, url, query_params=None, headers=None,

--- a/lightly/openapi_generated/swagger_client/api/docker_api.py
+++ b/lightly/openapi_generated/swagger_client/api/docker_api.py
@@ -1597,45 +1597,47 @@ class DockerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def get_docker_runs_scheduled_by_state(self, **kwargs):  # noqa: E501
-        """get_docker_runs_scheduled_by_state  # noqa: E501
+    def get_docker_runs_scheduled_by_state_and_labels(self, **kwargs):  # noqa: E501
+        """get_docker_runs_scheduled_by_state_and_labels  # noqa: E501
 
-        Get all scheduled docker runs of the user with the specified state.  # noqa: E501
+        Get all scheduled docker runs of the user. Additionally, you can filter by state.  Furthermore, you can filter by only providing labels an only return scheduled runs whose runsOn labels are included in the provided labels.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.get_docker_runs_scheduled_by_state(async_req=True)
+        >>> thread = api.get_docker_runs_scheduled_by_state_and_labels(async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param DockerRunScheduledState state:
+        :param DockerWorkerLabels labels:
         :return: list[DockerRunScheduledData]
                  If the method is called asynchronously,
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
         if kwargs.get('async_req'):
-            return self.get_docker_runs_scheduled_by_state_with_http_info(**kwargs)  # noqa: E501
+            return self.get_docker_runs_scheduled_by_state_and_labels_with_http_info(**kwargs)  # noqa: E501
         else:
-            (data) = self.get_docker_runs_scheduled_by_state_with_http_info(**kwargs)  # noqa: E501
+            (data) = self.get_docker_runs_scheduled_by_state_and_labels_with_http_info(**kwargs)  # noqa: E501
             return data
 
-    def get_docker_runs_scheduled_by_state_with_http_info(self, **kwargs):  # noqa: E501
-        """get_docker_runs_scheduled_by_state  # noqa: E501
+    def get_docker_runs_scheduled_by_state_and_labels_with_http_info(self, **kwargs):  # noqa: E501
+        """get_docker_runs_scheduled_by_state_and_labels  # noqa: E501
 
-        Get all scheduled docker runs of the user with the specified state.  # noqa: E501
+        Get all scheduled docker runs of the user. Additionally, you can filter by state.  Furthermore, you can filter by only providing labels an only return scheduled runs whose runsOn labels are included in the provided labels.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.get_docker_runs_scheduled_by_state_with_http_info(async_req=True)
+        >>> thread = api.get_docker_runs_scheduled_by_state_and_labels_with_http_info(async_req=True)
         >>> result = thread.get()
 
         :param async_req bool
         :param DockerRunScheduledState state:
+        :param DockerWorkerLabels labels:
         :return: list[DockerRunScheduledData]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['state']  # noqa: E501
+        all_params = ['state', 'labels']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -1646,7 +1648,7 @@ class DockerApi(object):
             if key not in all_params:
                 raise TypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method get_docker_runs_scheduled_by_state" % key
+                    " to method get_docker_runs_scheduled_by_state_and_labels" % key
                 )
             params[key] = val
         del params['kwargs']
@@ -1658,6 +1660,8 @@ class DockerApi(object):
         query_params = []
         if 'state' in params:
             query_params.append(('state', params['state']))  # noqa: E501
+        if 'labels' in params:
+            query_params.append(('labels', params['labels']))  # noqa: E501
 
         header_params = {}
 
@@ -1691,7 +1695,7 @@ class DockerApi(object):
     def get_docker_runs_scheduled_by_worker_id(self, worker_id, **kwargs):  # noqa: E501
         """get_docker_runs_scheduled_by_worker_id  # noqa: E501
 
-        Get all scheduled docker runs of a workerId, optionally filtered by state.  # noqa: E501
+        Get all scheduled runs that might be picked up by the worker with that workerId.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.get_docker_runs_scheduled_by_worker_id(worker_id, async_req=True)
@@ -1714,7 +1718,7 @@ class DockerApi(object):
     def get_docker_runs_scheduled_by_worker_id_with_http_info(self, worker_id, **kwargs):  # noqa: E501
         """get_docker_runs_scheduled_by_worker_id  # noqa: E501
 
-        Get all scheduled docker runs of a workerId, optionally filtered by state.  # noqa: E501
+        Get all scheduled runs that might be picked up by the worker with that workerId.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.get_docker_runs_scheduled_by_worker_id_with_http_info(worker_id, async_req=True)

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_create_request.py
@@ -34,15 +34,17 @@ class DockerRunScheduledCreateRequest(object):
     """
     swagger_types = {
         'config_id': 'MongoObjectID',
-        'priority': 'DockerRunScheduledPriority'
+        'priority': 'DockerRunScheduledPriority',
+        'runs_on': 'DockerWorkerLabels'
     }
 
     attribute_map = {
         'config_id': 'configId',
-        'priority': 'priority'
+        'priority': 'priority',
+        'runs_on': 'runsOn'
     }
 
-    def __init__(self, config_id=None, priority=None, _configuration=None):  # noqa: E501
+    def __init__(self, config_id=None, priority=None, runs_on=None, _configuration=None):  # noqa: E501
         """DockerRunScheduledCreateRequest - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -50,10 +52,13 @@ class DockerRunScheduledCreateRequest(object):
 
         self._config_id = None
         self._priority = None
+        self._runs_on = None
         self.discriminator = None
 
         self.config_id = config_id
         self.priority = priority
+        if runs_on is not None:
+            self.runs_on = runs_on
 
     @property
     def config_id(self):
@@ -100,6 +105,27 @@ class DockerRunScheduledCreateRequest(object):
             raise ValueError("Invalid value for `priority`, must not be `None`")  # noqa: E501
 
         self._priority = priority
+
+    @property
+    def runs_on(self):
+        """Gets the runs_on of this DockerRunScheduledCreateRequest.  # noqa: E501
+
+
+        :return: The runs_on of this DockerRunScheduledCreateRequest.  # noqa: E501
+        :rtype: DockerWorkerLabels
+        """
+        return self._runs_on
+
+    @runs_on.setter
+    def runs_on(self, runs_on):
+        """Sets the runs_on of this DockerRunScheduledCreateRequest.
+
+
+        :param runs_on: The runs_on of this DockerRunScheduledCreateRequest.  # noqa: E501
+        :type: DockerWorkerLabels
+        """
+
+        self._runs_on = runs_on
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_data.py
@@ -37,6 +37,7 @@ class DockerRunScheduledData(object):
         'dataset_id': 'MongoObjectID',
         'config_id': 'MongoObjectID',
         'priority': 'DockerRunScheduledPriority',
+        'runs_on': 'DockerWorkerLabels',
         'state': 'DockerRunScheduledState',
         'created_at': 'Timestamp',
         'last_modified_at': 'Timestamp',
@@ -48,13 +49,14 @@ class DockerRunScheduledData(object):
         'dataset_id': 'datasetId',
         'config_id': 'configId',
         'priority': 'priority',
+        'runs_on': 'runsOn',
         'state': 'state',
         'created_at': 'createdAt',
         'last_modified_at': 'lastModifiedAt',
         'owner': 'owner'
     }
 
-    def __init__(self, id=None, dataset_id=None, config_id=None, priority=None, state=None, created_at=None, last_modified_at=None, owner=None, _configuration=None):  # noqa: E501
+    def __init__(self, id=None, dataset_id=None, config_id=None, priority=None, runs_on=None, state=None, created_at=None, last_modified_at=None, owner=None, _configuration=None):  # noqa: E501
         """DockerRunScheduledData - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -64,6 +66,7 @@ class DockerRunScheduledData(object):
         self._dataset_id = None
         self._config_id = None
         self._priority = None
+        self._runs_on = None
         self._state = None
         self._created_at = None
         self._last_modified_at = None
@@ -74,6 +77,7 @@ class DockerRunScheduledData(object):
         self.dataset_id = dataset_id
         self.config_id = config_id
         self.priority = priority
+        self.runs_on = runs_on
         self.state = state
         self.created_at = created_at
         self.last_modified_at = last_modified_at
@@ -171,6 +175,29 @@ class DockerRunScheduledData(object):
             raise ValueError("Invalid value for `priority`, must not be `None`")  # noqa: E501
 
         self._priority = priority
+
+    @property
+    def runs_on(self):
+        """Gets the runs_on of this DockerRunScheduledData.  # noqa: E501
+
+
+        :return: The runs_on of this DockerRunScheduledData.  # noqa: E501
+        :rtype: DockerWorkerLabels
+        """
+        return self._runs_on
+
+    @runs_on.setter
+    def runs_on(self, runs_on):
+        """Sets the runs_on of this DockerRunScheduledData.
+
+
+        :param runs_on: The runs_on of this DockerRunScheduledData.  # noqa: E501
+        :type: DockerWorkerLabels
+        """
+        if self._configuration.client_side_validation and runs_on is None:
+            raise ValueError("Invalid value for `runs_on`, must not be `None`")  # noqa: E501
+
+        self._runs_on = runs_on
 
     @property
     def state(self):

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_update_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_update_request.py
@@ -34,15 +34,17 @@ class DockerRunScheduledUpdateRequest(object):
     """
     swagger_types = {
         'state': 'DockerRunScheduledState',
-        'priority': 'DockerRunScheduledPriority'
+        'priority': 'DockerRunScheduledPriority',
+        'runs_on': 'DockerWorkerLabels'
     }
 
     attribute_map = {
         'state': 'state',
-        'priority': 'priority'
+        'priority': 'priority',
+        'runs_on': 'runsOn'
     }
 
-    def __init__(self, state=None, priority=None, _configuration=None):  # noqa: E501
+    def __init__(self, state=None, priority=None, runs_on=None, _configuration=None):  # noqa: E501
         """DockerRunScheduledUpdateRequest - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -50,11 +52,14 @@ class DockerRunScheduledUpdateRequest(object):
 
         self._state = None
         self._priority = None
+        self._runs_on = None
         self.discriminator = None
 
         self.state = state
         if priority is not None:
             self.priority = priority
+        if runs_on is not None:
+            self.runs_on = runs_on
 
     @property
     def state(self):
@@ -99,6 +104,27 @@ class DockerRunScheduledUpdateRequest(object):
         """
 
         self._priority = priority
+
+    @property
+    def runs_on(self):
+        """Gets the runs_on of this DockerRunScheduledUpdateRequest.  # noqa: E501
+
+
+        :return: The runs_on of this DockerRunScheduledUpdateRequest.  # noqa: E501
+        :rtype: DockerWorkerLabels
+        """
+        return self._runs_on
+
+    @runs_on.setter
+    def runs_on(self, runs_on):
+        """Sets the runs_on of this DockerRunScheduledUpdateRequest.
+
+
+        :param runs_on: The runs_on of this DockerRunScheduledUpdateRequest.  # noqa: E501
+        :type: DockerWorkerLabels
+        """
+
+        self._runs_on = runs_on
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -834,6 +834,7 @@ class MockedComputeWorkerApi(DockerApi):
                 created_at=Timestamp(0),
                 last_modified_at=Timestamp(100),
                 owner="user-id-1",
+                runs_on=[]
             )
         ]
         self._registered_workers = [

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -103,6 +103,26 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
         )
         assert scheduled_run_id
 
+    def test_schedule_compute_worker_run__priority(self):
+        scheduled_run_id = self.api_workflow_client.schedule_compute_worker_run(
+            worker_config={
+            },
+            lightly_config={
+            },
+            priority=DockerRunScheduledPriority.HIGH
+        )
+        assert scheduled_run_id
+
+    def test_schedule_compute_worker_run__runs_on(self):
+        scheduled_run_id = self.api_workflow_client.schedule_compute_worker_run(
+            worker_config={
+            },
+            lightly_config={
+            },
+            runs_on=["AAA", "BBB"]
+        )
+        assert scheduled_run_id
+
     def test_get_compute_worker_ids(self):
         ids = self.api_workflow_client.get_compute_worker_ids()
         assert all(isinstance(id_, str) for id_ in ids)

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -390,7 +390,7 @@ def test_get_compute_worker_state_and_message_OPEN() -> None:
         state=DockerRunScheduledState.OPEN,
         created_at=0,
         last_modified_at=1,
-        runs_on=[6]
+        runs_on=["asdf"]
     )
 
     def mocked_raise_exception(*args, **kwargs):

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -310,6 +310,7 @@ def test_get_scheduled_run_by_id() -> None:
             state=DockerRunScheduledState.OPEN,
             created_at=0,
             last_modified_at=1,
+            runs_on=[]
         )
         for i in range(3)
     ]
@@ -338,6 +339,7 @@ def test_get_scheduled_run_by_id_not_found() -> None:
             state=DockerRunScheduledState.OPEN,
             created_at=0,
             last_modified_at=1,
+            runs_on=[]
         )
         for i in range(3)
     ]
@@ -368,6 +370,7 @@ def test_get_compute_worker_state_and_message_OPEN() -> None:
         state=DockerRunScheduledState.OPEN,
         created_at=0,
         last_modified_at=1,
+        runs_on=[6]
     )
 
     def mocked_raise_exception(*args, **kwargs):


### PR DESCRIPTION
## What has changed?
- generated from the new spec:
  - `get_docker_runs_scheduled_by_state_and_labels` with `labels`
  - `DockerRunScheduledCreateRequest` with `runs_on`
  - `DockerRunScheduledData` with `runs_on`
  - `DockerRunScheduledUpdateRequest`with `runs_on`
- `ApiWorkflowClient.schedule_compute_worker_run`: added `runs_on` argument
- `ApiWorkflowClient.register_compute_worker`: added `labels` argument
- mock the `urllib3.request.urlencode` to use `doseq=True`. Otherwise using arrays in the query fails. This is needed for `get_docker_runs_scheduled_by_state_and_labels`

## How was it tested? + corresponding lightly-core PR
see https://github.com/lightly-ai/lightly-core/pull/2037