### PR TITLE
Rename TOKEN to LIGHTLY_TOKEN

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ make html-noplot
 
 Shortcut to build the docs (with env variables for active-learning tutorial) use:
 ```
-LIGHTLY_SERVER_LOCATION='https://api.lightly.ai' TOKEN='YOUR_TOKEN' AL_TUTORIAL_DATASET_ID='YOUR_DATASET_ID' make html && python -m http.server 1234 -d build/html
+LIGHTLY_SERVER_LOCATION='https://api.lightly.ai' LIGHTLY_TOKEN='YOUR_TOKEN' AL_TUTORIAL_DATASET_ID='YOUR_DATASET_ID' make html && python -m http.server 1234 -d build/html
 ```
 
 You can host the docs after building using the following python command 

--- a/docs/source/docker/integration/dagster_aws.rst
+++ b/docs/source/docker/integration/dagster_aws.rst
@@ -100,14 +100,14 @@ Make sure you have the API token and the worker id from the setup steps. Start t
     OUTPUT_DIR=/home/ubuntu/output_dir/
 
     # api
-    TOKEN=YOUR_LIGHTLY_TOKEN
+    LIGHTLY_TOKEN=YOUR_LIGHTLY_TOKEN
     WORKER_ID=MY_WORKER_ID
 
     # run command
     # this makes the Lightly Worker start up and wait for jobs
     docker run --shm-size="1024m" --gpus all --rm -it \
         lightly/worker:latest \
-        token=${TOKEN} \
+        token=${LIGHTLY_TOKEN} \
         worker.worker_id=${WORKER_ID}
 
 
@@ -302,7 +302,7 @@ Set the `YOUR_LIGHTLY_TOKEN`, `YOUR_DATASET_ID` accordingly.
 
     from dagster import solid
 
-    TOKEN: str = 'YOUR_LIGHTLY_TOKEN'
+    LIGHTLY_TOKEN: str = 'YOUR_LIGHTLY_TOKEN'
     DATASET_ID: str = 'YOUR_DATASET_ID'
 
 
@@ -355,7 +355,7 @@ Set the `YOUR_LIGHTLY_TOKEN`, `YOUR_DATASET_ID` accordingly.
 
         """
 
-        lightly_client = LightlyClient(TOKEN, DATASET_ID)
+        lightly_client = LightlyClient(LIGHTLY_TOKEN, DATASET_ID)
         lightly_client.run_lightly_worker()
 
 

--- a/docs/source/docker/integration/examples/create_dataset.py
+++ b/docs/source/docker/integration/examples/create_dataset.py
@@ -1,7 +1,7 @@
 import lightly
 
 # Create the Lightly client to connect to the API.
-client = lightly.api.ApiWorkflowClient(token="TOKEN")
+client = lightly.api.ApiWorkflowClient(token="LIGHTLY_TOKEN")
 
 # Create a new dataset on the Lightly Platform.
 client.create_dataset('dataset-name')

--- a/docs/source/docker/integration/examples/trigger_job.py
+++ b/docs/source/docker/integration/examples/trigger_job.py
@@ -5,7 +5,7 @@ from lightly.openapi_generated.swagger_client import DockerRunScheduledState, Do
 # You can reuse the client from previous scripts. If you want to create a new
 # one you can uncomment the following line:
 # import lightly
-# client = lightly.api.ApiWorkflowClient(token="TOKEN", dataset_id="DATASET_ID")
+# client = lightly.api.ApiWorkflowClient(token="LIGHTLY_TOKEN", dataset_id="DATASET_ID")
 
 # Schedule the compute run using a custom config.
 # You can easily edit the values according to your needs.

--- a/docs/source/docker_archive/advanced/active_learning.rst
+++ b/docs/source/docker_archive/advanced/active_learning.rst
@@ -118,7 +118,7 @@ E.g. create and run a bash script with the following content:
     SHARED_DIR=/path/to/shared
     OUTPUT_DIR=/path/to/output
 
-    TOKEN= # put your token here
+    LIGHTLY_TOKEN= # put your token here
     N_SAMPLES=1.0
 
     docker run --gpus all --rm -it \
@@ -126,7 +126,7 @@ E.g. create and run a bash script with the following content:
       -v ${SHARED_DIR}:/home/shared_dir:ro \
       -v ${OUTPUT_DIR}:/home/output_dir \
       lightly/worker:latest \
-      token=${TOKEN} \
+      token=${LIGHTLY_TOKEN} \
       lightly.loader.num_workers=4     \
       stopping_condition.n_samples=${N_SAMPLES}\
       method=coreset \
@@ -301,7 +301,7 @@ E.g. use the following bash script.
     EMBEDDINGS_REL_TO_SHARED=embeddings_al.csv
     
 
-    TOKEN= # put your token here
+    LIGHTLY_TOKEN= # put your token here
     N_SAMPLES= # Choose how many samples you want to use here, e.g. 0.1 for 10 percent.
 
     docker run --gpus all --rm -it \
@@ -309,7 +309,7 @@ E.g. use the following bash script.
         -v ${SHARED_DIR}:/home/shared_dir:ro \
         -v ${OUTPUT_DIR}:/home/output_dir \
         lightly/worker:latest \
-        token=${TOKEN} \
+        token=${LIGHTLY_TOKEN} \
         lightly.loader.num_workers=4     \
         stopping_condition.n_samples=${N_SAMPLES}\
         method=coral \

--- a/docs/source/docker_archive/advanced/code_examples/python_run_active_learning.py
+++ b/docs/source/docker_archive/advanced/code_examples/python_run_active_learning.py
@@ -1,7 +1,7 @@
 import lightly
 
 # Create the Lightly client to connect to the API.
-client = lightly.api.ApiWorkflowClient(token="TOKEN", dataset_id="DATASET_ID")
+client = lightly.api.ApiWorkflowClient(token="LIGHTLY_TOKEN", dataset_id="DATASET_ID")
 
 # Schedule the docker run with 
 #  - "active_learning.task_name" set to your task name

--- a/docs/source/docker_archive/advanced/code_examples/python_run_object_level.py
+++ b/docs/source/docker_archive/advanced/code_examples/python_run_object_level.py
@@ -1,7 +1,7 @@
 import lightly
 
 # Create the Lightly client to connect to the API.
-client = lightly.api.ApiWorkflowClient(token="TOKEN", dataset_id="DATASET_ID")
+client = lightly.api.ApiWorkflowClient(token="LIGHTLY_TOKEN", dataset_id="DATASET_ID")
 
 # Schedule the docker run with the "object_level.task_name" argument set. 
 # All other settings are default values and we show them so you can easily edit

--- a/docs/source/docker_archive/advanced/code_examples/python_run_object_level_pretagging.py
+++ b/docs/source/docker_archive/advanced/code_examples/python_run_object_level_pretagging.py
@@ -1,7 +1,7 @@
 import lightly
 
 # Create the Lightly client to connect to the API.
-client = lightly.api.ApiWorkflowClient(token="TOKEN", dataset_id="DATASET_ID")
+client = lightly.api.ApiWorkflowClient(token="LIGHTLY_TOKEN", dataset_id="DATASET_ID")
 
 # Schedule the docker run with the "object_level.task_name" argument set to
 # "lightly_pretagging" and with "pretagging" set to True.

--- a/docs/source/docker_archive/integration/dagster_aws.rst
+++ b/docs/source/docker_archive/integration/dagster_aws.rst
@@ -65,7 +65,7 @@ be changed by passing command line arguments. Use the following as a starting po
     OUTPUT_DIR=/home/ubuntu/lightly-aws-bucket/output_dir
 
     # api
-    TOKEN=YOUR_LIGHTLY_TOKEN
+    LIGHTLY_TOKEN=YOUR_LIGHTLY_TOKEN
 
     # run command
     docker run --gpus all --rm --shm-size="512m" \
@@ -73,7 +73,7 @@ be changed by passing command line arguments. Use the following as a starting po
             -v ${OUTPUT_DIR}:/home/output_dir \
             -v ${SHARED_DIR}:/home/shared_dir \
             --ipc="host" --network "host" \
-            ${IMAGE} token=${TOKEN} \
+            ${IMAGE} token=${LIGHTLY_TOKEN} \
             lightly.loader.num_workers=0 \
             enable_corruptness_check=True \
             remove_exact_duplicates=True \

--- a/docs/source/docker_archive/integration/examples/create_dataset.py
+++ b/docs/source/docker_archive/integration/examples/create_dataset.py
@@ -1,7 +1,7 @@
 import lightly
 
 # Create the Lightly client to connect to the API.
-client = lightly.api.ApiWorkflowClient(token="TOKEN")
+client = lightly.api.ApiWorkflowClient(token="LIGHTLY_TOKEN")
 
 # Create a new dataset on the Lightly Platform.
 client.create_dataset('dataset-name')

--- a/docs/source/docker_archive/integration/examples/trigger_job.py
+++ b/docs/source/docker_archive/integration/examples/trigger_job.py
@@ -1,6 +1,6 @@
 # You can reuse the client from the previous script. If you want to create a new
 # one you can uncomment the following line:
-# client = lightly.api.ApiWorkflowClient(token="TOKEN", dataset_id="DATASET_ID")
+# client = lightly.api.ApiWorkflowClient(token="LIGHTLY_TOKEN", dataset_id="DATASET_ID")
 
 # Schedule the compute run using our custom config.
 # We show here the full default config so you can easily edit the

--- a/docs/source/getting_started/dataset_creation/dataset_creation_local_server.rst
+++ b/docs/source/getting_started/dataset_creation/dataset_creation_local_server.rst
@@ -54,6 +54,6 @@ server can continue running.
     pip install lightly
 
     # Compute embeddings, create the dataset and upload metadata
-    lightly-magic token=TOKEN dataset_id=DATASET_ID input_dir=/projects/animals \
+    lightly-magic token=LIGHTLY_TOKEN dataset_id=DATASET_ID input_dir=/projects/animals \
     trainer.max_epochs=0 upload='meta'
 

--- a/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
@@ -134,7 +134,7 @@ DATASET_ROOT = '/datasets/comma10k/imgs/'
 
 # allow setting of token and dataset_id from environment variables
 def try_get_token_and_id_from_env():
-    token = os.getenv('TOKEN', YOUR_TOKEN)
+    token = os.getenv('LIGHTLY_TOKEN', YOUR_TOKEN)
     dataset_id = os.getenv('AL_TUTORIAL_DATASET_ID', YOUR_DATASET_ID)
     return token, dataset_id
 

--- a/tests/UNMOCKED_end2end_tests/README.md
+++ b/tests/UNMOCKED_end2end_tests/README.md
@@ -8,14 +8,14 @@ cd ../../../lightly # ensure you are in the top directory
 pip uninstall lightly -y
 
 pip install . 
-bash tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh TOKEN
+bash tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh LIGHTLY_TOKEN
 ```
 
 ## Testing the Server API with CLI commands
 You only need an account on the server and a dataset.
 Once you have a token from our production server `https://app.lightly.ai`, you can run:
 ```bash
-bash test_api_on_branch.sh path/to/dataset TOKEN
+bash test_api_on_branch.sh path/to/dataset LIGHTLY_TOKEN
 ```
 
 ## Testing the Server API with active learning
@@ -23,20 +23,20 @@ You only need an account on the server and a dataset.
 Once you have a token from our production server `https://app.lightly.ai`, you can run:
 
 ```bash
-python tests/UNMOCKED_end2end_tests/test_api.py path/to/dataset TOKEN
+python tests/UNMOCKED_end2end_tests/test_api.py path/to/dataset LIGHTLY_TOKEN
 ```
 
 If you want to test on another server, e.g. staging, get your token from there and then run:
 ```bash
 LIGHTLY_SERVER_LOCATION=https://api-staging.lightly.ai && \
-python tests/UNMOCKED_end2end_tests/test_api.py path/to/dataset TOKEN_FROM_STAGING
+python tests/UNMOCKED_end2end_tests/test_api.py path/to/dataset LIGHTLY_TOKEN_FROM_STAGING
 
 ```
 
 ## Testing the API latency
 This needs a token, but no dataset
 ```bash
-TOKEN="MY_TOKEN" && python tests/UNMOCKED_end2end_tests/test_api_latency.py
+LIGHTLY_TOKEN="MY_TOKEN" && python tests/UNMOCKED_end2end_tests/test_api_latency.py
 ```
 
 ## Testing the upload speed

--- a/tests/UNMOCKED_end2end_tests/delete_datasets_test_unmocked_cli.py
+++ b/tests/UNMOCKED_end2end_tests/delete_datasets_test_unmocked_cli.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
             (sys.argv[1 + i] for i in range(3))
     else:
         raise ValueError("ERROR in number of command line arguments, must be 3."
-                         "Example: python delete_datasets_test_unmocked_cli.py 6 TOKEN 2022-09-29-13-41-24")
+                         "Example: python delete_datasets_test_unmocked_cli.py 6 LIGHTLY_TOKEN 2022-09-29-13-41-24")
 
     api_workflow_client = ApiWorkflowClient(token=token)
 

--- a/tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh
+++ b/tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh
@@ -2,9 +2,9 @@
 set -e
 
 # Get the parameters
-export TOKEN=$1
-[[ -z "$TOKEN" ]] && { echo "Error: token is empty" ; exit 1; }
-echo "############################### token: ${TOKEN}"
+export LIGHTLY_TOKEN=$1
+[[ -z "$LIGHTLY_TOKEN" ]] && { echo "Error: token is empty" ; exit 1; }
+echo "############################### token: ${LIGHTLY_TOKEN}"
 
 DATE_TIME=$(date +%Y-%m-%d-%H-%M-%S)
 
@@ -23,36 +23,36 @@ python tests/UNMOCKED_end2end_tests/create_custom_metadata_from_input_dir.py $IN
 NUMBER_OF_DATASETS=0
 # Run the tests
 echo "############################### Test 1"
-lightly-magic token=$TOKEN input_dir=$INPUT_DIR trainer.max_epochs=0 new_dataset_name=test_unmocked_cli_1_${DATE_TIME}
+lightly-magic token=$LIGHTLY_TOKEN input_dir=$INPUT_DIR trainer.max_epochs=0 new_dataset_name=test_unmocked_cli_1_${DATE_TIME}
 ((NUMBER_OF_DATASETS=NUMBER_OF_DATASETS+1))
 
 echo "############################### Test 2"
-lightly-magic token=$TOKEN input_dir=$INPUT_DIR trainer.max_epochs=1 new_dataset_name=test_unmocked_cli_2_${DATE_TIME}
+lightly-magic token=$LIGHTLY_TOKEN input_dir=$INPUT_DIR trainer.max_epochs=1 new_dataset_name=test_unmocked_cli_2_${DATE_TIME}
 ((NUMBER_OF_DATASETS=NUMBER_OF_DATASETS+1))
 
 echo "############################### Test 3"
-lightly-upload token=$TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_3_${DATE_TIME}
+lightly-upload token=$LIGHTLY_TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_3_${DATE_TIME}
 ((NUMBER_OF_DATASETS=NUMBER_OF_DATASETS+1))
 
 echo "############################### Test 4"
-lightly-upload token=$TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_4_${DATE_TIME} upload=metadata
+lightly-upload token=$LIGHTLY_TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_4_${DATE_TIME} upload=metadata
 ((NUMBER_OF_DATASETS=NUMBER_OF_DATASETS+1))
 
 echo "############################### Test 5"
-lightly-upload token=$TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_5_${DATE_TIME} upload=thumbnails
+lightly-upload token=$LIGHTLY_TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_5_${DATE_TIME} upload=thumbnails
 ((NUMBER_OF_DATASETS=NUMBER_OF_DATASETS+1))
 
 echo "############################### Test 6"
-lightly-upload token=$TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_6_${DATE_TIME} upload=metadata custom_metadata=$CUSTOM_METADATA_FILENAME
+lightly-upload token=$LIGHTLY_TOKEN input_dir=$INPUT_DIR new_dataset_name=test_unmocked_cli_6_${DATE_TIME} upload=metadata custom_metadata=$CUSTOM_METADATA_FILENAME
 ((NUMBER_OF_DATASETS=NUMBER_OF_DATASETS+1))
 
 
 echo "############################### Deleting all datasets again"
-python tests/UNMOCKED_end2end_tests/delete_datasets_test_unmocked_cli.py $NUMBER_OF_DATASETS $TOKEN ${DATE_TIME}
+python tests/UNMOCKED_end2end_tests/delete_datasets_test_unmocked_cli.py $NUMBER_OF_DATASETS $LIGHTLY_TOKEN ${DATE_TIME}
 
 echo "############################### Test active learning"
 INPUT_DIR="${PWD}/clothing_dataset_small/test"
-python tests/UNMOCKED_end2end_tests/test_api.py $INPUT_DIR $TOKEN
+python tests/UNMOCKED_end2end_tests/test_api.py $INPUT_DIR $LIGHTLY_TOKEN
 
 echo "############################### Test download of large files"
 python tests/UNMOCKED_end2end_tests/test_download_large_files.py

--- a/tests/UNMOCKED_end2end_tests/scripts_for_reproducing_problems/test_api_latency.py
+++ b/tests/UNMOCKED_end2end_tests/scripts_for_reproducing_problems/test_api_latency.py
@@ -8,7 +8,7 @@ from lightly.api import ApiWorkflowClient
 from lightly.openapi_generated.swagger_client import Configuration, ApiClient, QuotaApi
 
 if __name__ == "__main__":
-    token = os.getenv("TOKEN")
+    token = os.getenv("LIGHTLY_TOKEN")
     api_client = ApiWorkflowClient(token=token).api_client
     quota_api = QuotaApi(api_client)
 

--- a/tests/UNMOCKED_end2end_tests/test_api.py
+++ b/tests/UNMOCKED_end2end_tests/test_api.py
@@ -182,6 +182,6 @@ if __name__ == "__main__":
             (sys.argv[1 + i] for i in range(2))
     else:
         raise ValueError("ERROR in number of command line arguments, must be 2."
-                         "Example: python test_api path/to/dataset TOKEN")
+                         "Example: python test_api path/to/dataset LIGHTLY_TOKEN")
 
     t_est_api_with_matrix(path_to_dataset=path_to_dataset, token=token)

--- a/tests/UNMOCKED_end2end_tests/test_api_append.py
+++ b/tests/UNMOCKED_end2end_tests/test_api_append.py
@@ -62,6 +62,6 @@ if __name__ == "__main__":
     else:
         raise ValueError(
             "ERROR in number of command line arguments, must be 2."
-            "Example: python test_api path/to/dataset TOKEN")
+            "Example: python test_api path/to/dataset LIGHTLY_TOKEN")
 
     t_est_api_append(path_to_dataset=path_to_dataset, token=token)


### PR DESCRIPTION
### What has changed

Change references to TOKEN to LIGHTLY_TOKEN.

There is no functional change:
* The customers already use LIGHTLY_TOKEN env var, as that's the one already read by ApiWorkflowClient
* There are changes to the docs
  * They are just cosmetic
* There are changes to unmocked tests
  * They used TOKEN just internally