### PR TITLE
Guarin lig 2037 paginate endpoints pip

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Union, Iterator
 
 from lightly.api.utils import retry
 from lightly.api import download
+from lightly.api import utils
 from lightly.openapi_generated.swagger_client import (
     CreateDockerWorkerRegistryEntryRequest,
     DockerRunData,
@@ -69,7 +70,10 @@ class ComputeWorkerRunInfo:
 
 class _ComputeWorkerMixin:
     def register_compute_worker(self, name: str = "Default", labels: Optional[List[str]] = None) -> str:
-        """Registers a new compute worker.
+        """Registers a new compute worker. 
+
+        If a worker with the same name already exists, the worker id of the existing
+        worker is returned instead of registering a new worker.
 
         Args:
             name:
@@ -198,7 +202,9 @@ class _ComputeWorkerMixin:
             Runs sorted by creation time from old to new.
 
         """
-        runs: List[DockerRunData] = self._compute_worker_api.get_docker_runs()
+        runs: List[DockerRunData] = utils.paginate_endpoint(
+            self._compute_worker_api.get_docker_runs,
+        )
         if dataset_id is not None:
             runs = [run for run in runs if run.dataset_id == dataset_id]
         sorted_runs = sorted(runs, key=lambda run: run.created_at or -1)
@@ -223,7 +229,8 @@ class _ComputeWorkerMixin:
 
         Raises:
             ApiException:
-                If no run with the given scheduled run id exists.
+                If no run with the given scheduled run id exists or if the scheduled 
+                run has not yet started being processed by a worker.
         """
         return self._compute_worker_api.get_docker_run_by_scheduled_id(
             scheduled_id=scheduled_run_id
@@ -231,12 +238,24 @@ class _ComputeWorkerMixin:
 
     def get_scheduled_compute_worker_runs(
         self,
+        state: Optional[str] = None,
     ) -> List[DockerRunScheduledData]:
         """Returns a list of all scheduled compute worker runs for the current
         dataset.
+
+        Args:
+            state:
+                DockerRunScheduledState value. If specified, then only runs in the given
+                state are returned. If omitted, then runs which have not yet finished 
+                (neither 'DONE' nor 'CANCELED') are returned. Valid states are 'OPEN',
+                'LOCKED', 'DONE', and 'CANCELED'.
         """
+        if state is not None:
+            return self._compute_worker_api.get_docker_runs_scheduled_by_dataset_id(
+                dataset_id=self.dataset_id, state=state,
+            )
         return self._compute_worker_api.get_docker_runs_scheduled_by_dataset_id(
-            dataset_id=self.dataset_id
+            dataset_id=self.dataset_id,
         )
 
     def _get_scheduled_run_by_id(self, scheduled_run_id: str) -> DockerRunScheduledData:

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -56,7 +56,7 @@ class _DatasetsMixin:
         self,
         dataset_name: str,
         shared: Optional[bool] = False,
-    ) -> list[DatasetData]:
+    ) -> List[DatasetData]:
         """Returns datasets by name.
 
         An empty list is returned if no datasets with the name exist.

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -1,10 +1,14 @@
+import warnings
 from typing import List, Optional
 
-from lightly.openapi_generated.swagger_client.models.create_entity_response import CreateEntityResponse
-from lightly.openapi_generated.swagger_client.models.dataset_create_request import DatasetCreateRequest
-
-from lightly.openapi_generated.swagger_client.models.dataset_data import DatasetData
+from lightly.api import utils
+from lightly.openapi_generated.swagger_client import (
+    CreateEntityResponse,
+    DatasetCreateRequest,
+    DatasetData,
+)
 from lightly.openapi_generated.swagger_client.rest import ApiException
+
 
 class _DatasetsMixin:
 
@@ -20,7 +24,7 @@ class _DatasetsMixin:
         """Returns the dataset with id == self.dataset_id.
 
         """
-        return self.get_dataset_by_id(self.dataset_id)
+        return self.get_dataset_by_id(dataset_id=self.dataset_id)
 
     def dataset_exists(self, dataset_id: str) -> bool:
         """Returns True if a dataset with dataset_id exists. """
@@ -30,55 +34,137 @@ class _DatasetsMixin:
         except ApiException:
             return False
 
-    def dataset_name_exists(self, dataset_name: str) -> bool:
-        """Returns True if a dataset with dataset_name exists."""
-        return any(dataset.name == dataset_name for dataset in self.get_all_datasets())
+    def dataset_name_exists(self, dataset_name: str, shared: Optional[bool] = False) -> bool:
+        """Returns True if a dataset with dataset_name exists and False otherwise.
+
+        Args:
+            dataset_name:
+                Name of the dataset.
+            shared:
+                If False, considers only datasets owned by the user.
+                If True, considers only datasets which have been shared with the user.
+                If None, considers all datasets the users has access to.
+        """
+        return bool(self.get_datasets_by_name(dataset_name=dataset_name, shared=shared))
 
     def get_dataset_by_id(self, dataset_id: str) -> DatasetData:
         """Returns the dataset for the given dataset id. """
         dataset: DatasetData = self._datasets_api.get_dataset_by_id(dataset_id)
         return dataset
 
-    def get_datasets(self, shared: bool = False) -> List[DatasetData]:
+    def get_datasets_by_name(
+        self,
+        dataset_name: str,
+        shared: Optional[bool] = False,
+    ) -> list[DatasetData]:
+        """Returns datasets by name.
+
+        An empty list is returned if no datasets with the name exist.
+
+        Args:
+            dataset_name:
+                Name of the dataset.
+            shared:
+                If False, returns only datasets owned by the user. In this case at most
+                one dataset will be returned.
+                If True, returns only datasets which have been shared with the user. Can
+                return multiple datasets.
+                If None, returns datasets the users has access to. Can return multiple
+                datasets.
+        """
+        datasets = []
+        if not shared or shared is None:
+            datasets.extend(
+                self._datasets_api.get_datasets_query_by_name(
+                    dataset_name=dataset_name,
+                    exact=True,
+                    shared=False,
+                )
+            )
+        if shared or shared is None:
+            datasets.extend(
+                self._datasets_api.get_datasets_query_by_name(
+                    dataset_name=dataset_name,
+                    exact=True,
+                    shared=True,
+                )
+            )
+        return datasets
+
+    def get_datasets(self, shared: Optional[bool] = False) -> List[DatasetData]:
         """Returns all datasets the user owns.
 
         Args:
             shared:
-                If True, only returns the datasets which have been shared with
-                the user.
+                If False, returns only datasets owned by the user.
+                If True, returns only the datasets which have been shared with the user.
+                If None, returns all datasets the user has access to (owned and shared).
 
         """
-        datasets = self._datasets_api.get_datasets(shared=shared)
+        datasets = []
+        if not shared or shared is None:
+            datasets.extend(utils.paginate_endpoint(
+                self._datasets_api.get_datasets,
+                shared=False,
+            ))
+        if shared or shared is None:
+            datasets.extend(utils.paginate_endpoint(
+                self._datasets_api.get_datasets,
+                shared=True,
+            ))
         return datasets
 
     def get_all_datasets(self) -> List[DatasetData]:
-        """Returns all datasets the user has access to. """
-        owned_datasets = self.get_datasets(shared=False)
-        shared_datasets = self.get_datasets(shared=True)
-        owned_datasets.extend(shared_datasets)
+        """Returns all datasets the user has access to.
+
+        DEPRECATED in favour of get_datasets(shared=None) and will be removed in the
+        future.
+        """
+        warnings.warn(
+            "get_all_datasets() is deprecated in favour of get_datasets(shared=None) "
+            "and will be removed in the future.",
+            PendingDeprecationWarning,
+        )
+        owned_datasets = self.get_datasets(shared=None)
         return owned_datasets
 
-    def set_dataset_id_by_name(self, dataset_name: str):
+
+    def set_dataset_id_by_name(self, dataset_name: str, shared: Optional[bool] = False):
         """Sets the dataset id given the name of the dataset
 
         Args:
             dataset_name:
-                The name of the dataset for which the dataset_id
-                should be set as attribute
+                The name of the dataset for which the dataset_id should be set as 
+                attribute.
+            shared:
+                If False, considers only datasets owned by the user.
+                If True, considers only the datasets which have been shared with the user.
+                If None, consider all datasets the user has access to (owned and shared).
 
         Raises: ValueError
 
         """
-        current_datasets: List[DatasetData] = self.get_all_datasets()
-
-        try:
-            dataset_with_specified_name = next(dataset for dataset in current_datasets if dataset.name == dataset_name)
-            self._dataset_id = dataset_with_specified_name.id
-        except StopIteration:
+        datasets = self.get_datasets_by_name(dataset_name=dataset_name, shared=shared)
+        if not datasets:
             raise ValueError(
-                f"A dataset with the name {dataset_name} does not exist on the "
+                f"A dataset with the name '{dataset_name}' does not exist on the "
                 f"Lightly Platform. Please create it first."
             )
+        self._dataset_id = datasets[0].id
+        if len(datasets) > 1:
+            msg = (
+                f"Found {len(datasets)} datasets with the name '{dataset_name}'. Their "
+                f"ids are {[dataset.id for dataset in datasets]}. "
+                f"The dataset_id of the client was set to '{self._dataset_id}'. "
+            )
+            if shared or shared is None:
+                msg += (
+                    f"We noticed that you set shared={shared} which also retrieves "
+                    f"datasets shared with you. Set shared=False to only consider "
+                    "datasets you own."
+                )
+            warnings.warn(msg)
+
 
     def create_dataset(self, dataset_name: str, dataset_type: Optional[str] = None):
         """Creates a dataset on the Lightly Platform.
@@ -166,18 +252,21 @@ class _DatasetsMixin:
                 constants `DatasetType.IMAGES` and `DatasetType.VIDEOS`.
 
         """
-        current_datasets = self.get_datasets()
-        current_datasets_names = [dataset.name for dataset in current_datasets]
-
-        if dataset_basename not in current_datasets_names:
+        if not self.dataset_name_exists(dataset_name=dataset_basename):
             self._create_dataset_without_check_existing(
                 dataset_name=dataset_basename,
                 dataset_type=dataset_type
             )
         else:
+            existing_datasets = self._datasets_api.get_datasets_query_by_name(
+                dataset_name=dataset_basename,
+                exact=False,
+                shared=False,
+            )
+            existing_dataset_names = {dataset.name for dataset in existing_datasets}
             counter = 1
             dataset_name = f"{dataset_basename}_{counter}"
-            while dataset_name in current_datasets_names:
+            while dataset_name in existing_dataset_names:
                 counter += 1
                 dataset_name = f"{dataset_basename}_{counter}"
             self._create_dataset_without_check_existing(

--- a/lightly/openapi_generated/swagger_client/api/datasets_api.py
+++ b/lightly/openapi_generated/swagger_client/api/datasets_api.py
@@ -432,6 +432,8 @@ class DatasetsApi(object):
 
         :param async_req bool
         :param bool shared: if set, only returns the datasets which have been shared with the user
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[DatasetData]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -454,12 +456,14 @@ class DatasetsApi(object):
 
         :param async_req bool
         :param bool shared: if set, only returns the datasets which have been shared with the user
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[DatasetData]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['shared']  # noqa: E501
+        all_params = ['shared', 'page_size', 'page_offset']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -482,6 +486,10 @@ class DatasetsApi(object):
         query_params = []
         if 'shared' in params:
             query_params.append(('shared', params['shared']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page_offset' in params:
+            query_params.append(('pageOffset', params['page_offset']))  # noqa: E501
 
         header_params = {}
 
@@ -523,7 +531,9 @@ class DatasetsApi(object):
 
         :param async_req bool
         :param bool shared: if set, only returns the datasets which have been shared with the user
-        :param int limit: if set, only returns the newest up until limit
+        :param int limit: DEPRECATED, use pageSize instead. if set, only returns the newest up until limit
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[DatasetDataEnriched]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -546,13 +556,15 @@ class DatasetsApi(object):
 
         :param async_req bool
         :param bool shared: if set, only returns the datasets which have been shared with the user
-        :param int limit: if set, only returns the newest up until limit
+        :param int limit: DEPRECATED, use pageSize instead. if set, only returns the newest up until limit
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[DatasetDataEnriched]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['shared', 'limit']  # noqa: E501
+        all_params = ['shared', 'limit', 'page_size', 'page_offset']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -577,6 +589,10 @@ class DatasetsApi(object):
             query_params.append(('shared', params['shared']))  # noqa: E501
         if 'limit' in params:
             query_params.append(('limit', params['limit']))  # noqa: E501
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page_offset' in params:
+            query_params.append(('pageOffset', params['page_offset']))  # noqa: E501
 
         header_params = {}
 
@@ -600,6 +616,109 @@ class DatasetsApi(object):
             post_params=form_params,
             files=local_var_files,
             response_type='list[DatasetDataEnriched]',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=params.get('async_req'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
+    def get_datasets_query_by_name(self, dataset_name, **kwargs):  # noqa: E501
+        """get_datasets_query_by_name  # noqa: E501
+
+        Query for datasets by their name prefix unless exact flag is set  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_datasets_query_by_name(dataset_name, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param DatasetName dataset_name: (required)
+        :param bool shared: if set, only returns the datasets which have been shared with the user
+        :param bool exact: if set, only returns the datasets which match the name exactly (not just by prefix)
+        :return: list[DatasetData]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.get_datasets_query_by_name_with_http_info(dataset_name, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_datasets_query_by_name_with_http_info(dataset_name, **kwargs)  # noqa: E501
+            return data
+
+    def get_datasets_query_by_name_with_http_info(self, dataset_name, **kwargs):  # noqa: E501
+        """get_datasets_query_by_name  # noqa: E501
+
+        Query for datasets by their name prefix unless exact flag is set  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_datasets_query_by_name_with_http_info(dataset_name, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param DatasetName dataset_name: (required)
+        :param bool shared: if set, only returns the datasets which have been shared with the user
+        :param bool exact: if set, only returns the datasets which match the name exactly (not just by prefix)
+        :return: list[DatasetData]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['dataset_name', 'shared', 'exact']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_datasets_query_by_name" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'dataset_name' is set
+        if self.api_client.client_side_validation and ('dataset_name' not in params or
+                                                       params['dataset_name'] is None):  # noqa: E501
+            raise ValueError("Missing the required parameter `dataset_name` when calling `get_datasets_query_by_name`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'dataset_name' in params:
+            path_params['datasetName'] = params['dataset_name']  # noqa: E501
+
+        query_params = []
+        if 'shared' in params:
+            query_params.append(('shared', params['shared']))  # noqa: E501
+        if 'exact' in params:
+            query_params.append(('exact', params['exact']))  # noqa: E501
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = ['ApiKeyAuth', 'auth0Bearer']  # noqa: E501
+
+        return self.api_client.call_api(
+            '/v1/datasets/query/name/{datasetName}', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='list[DatasetData]',  # noqa: E501
             auth_settings=auth_settings,
             async_req=params.get('async_req'),
             _return_http_data_only=params.get('_return_http_data_only'),

--- a/lightly/openapi_generated/swagger_client/api/docker_api.py
+++ b/lightly/openapi_generated/swagger_client/api/docker_api.py
@@ -1034,7 +1034,7 @@ class DockerApi(object):
     def get_docker_run_by_scheduled_id(self, scheduled_id, **kwargs):  # noqa: E501
         """get_docker_run_by_scheduled_id  # noqa: E501
 
-        Retrieves the associated docker run of a scheduled run; returns the docker run by the id of the scheduled run which caused this docker run. If a scheduled docker run has not yet started being processed by a worker, a 404 will be returned.    # noqa: E501
+        Retrieves the associated docker run of a scheduled run; returns the docker run by the id of the scheduled run which caused this docker run. If a scheduled docker run has not yet started being processed by a worker, a 404 will be returned.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.get_docker_run_by_scheduled_id(scheduled_id, async_req=True)
@@ -1056,7 +1056,7 @@ class DockerApi(object):
     def get_docker_run_by_scheduled_id_with_http_info(self, scheduled_id, **kwargs):  # noqa: E501
         """get_docker_run_by_scheduled_id  # noqa: E501
 
-        Retrieves the associated docker run of a scheduled run; returns the docker run by the id of the scheduled run which caused this docker run. If a scheduled docker run has not yet started being processed by a worker, a 404 will be returned.    # noqa: E501
+        Retrieves the associated docker run of a scheduled run; returns the docker run by the id of the scheduled run which caused this docker run. If a scheduled docker run has not yet started being processed by a worker, a 404 will be returned.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.get_docker_run_by_scheduled_id_with_http_info(scheduled_id, async_req=True)
@@ -1425,6 +1425,8 @@ class DockerApi(object):
         >>> result = thread.get()
 
         :param async_req bool
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[DockerRunData]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1446,12 +1448,14 @@ class DockerApi(object):
         >>> result = thread.get()
 
         :param async_req bool
+        :param float page_size: pagination size/limit of the number of samples to return
+        :param float page_offset: pagination offset
         :return: list[DockerRunData]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = []  # noqa: E501
+        all_params = ['page_size', 'page_offset']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -1472,6 +1476,10 @@ class DockerApi(object):
         path_params = {}
 
         query_params = []
+        if 'page_size' in params:
+            query_params.append(('pageSize', params['page_size']))  # noqa: E501
+        if 'page_offset' in params:
+            query_params.append(('pageOffset', params['page_offset']))  # noqa: E501
 
         header_params = {}
 
@@ -1502,10 +1510,97 @@ class DockerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_docker_runs_count(self, **kwargs):  # noqa: E501
+        """get_docker_runs_count  # noqa: E501
+
+        Gets the total count of the amount of runs existing  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_docker_runs_count(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :return: str
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.get_docker_runs_count_with_http_info(**kwargs)  # noqa: E501
+        else:
+            (data) = self.get_docker_runs_count_with_http_info(**kwargs)  # noqa: E501
+            return data
+
+    def get_docker_runs_count_with_http_info(self, **kwargs):  # noqa: E501
+        """get_docker_runs_count  # noqa: E501
+
+        Gets the total count of the amount of runs existing  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_docker_runs_count_with_http_info(async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :return: str
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = []  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_docker_runs_count" % key
+                )
+            params[key] = val
+        del params['kwargs']
+
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['text/plain', 'application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = ['ApiKeyAuth', 'auth0Bearer']  # noqa: E501
+
+        return self.api_client.call_api(
+            '/v1/docker/runs/count', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='str',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=params.get('async_req'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_docker_runs_scheduled_by_dataset_id(self, dataset_id, **kwargs):  # noqa: E501
         """get_docker_runs_scheduled_by_dataset_id  # noqa: E501
 
-        Get all scheduled docker runs by dataset id which have not finished (not DONE or CANCLED).  # noqa: E501
+        Get all scheduled docker runs by dataset id. If no state is specified, returns runs which have not yet finished (neither DONE or CANCELED).  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.get_docker_runs_scheduled_by_dataset_id(dataset_id, async_req=True)
@@ -1513,6 +1608,7 @@ class DockerApi(object):
 
         :param async_req bool
         :param MongoObjectID dataset_id: ObjectId of the dataset (required)
+        :param DockerRunScheduledState state:
         :return: list[DockerRunScheduledData]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -1527,7 +1623,7 @@ class DockerApi(object):
     def get_docker_runs_scheduled_by_dataset_id_with_http_info(self, dataset_id, **kwargs):  # noqa: E501
         """get_docker_runs_scheduled_by_dataset_id  # noqa: E501
 
-        Get all scheduled docker runs by dataset id which have not finished (not DONE or CANCLED).  # noqa: E501
+        Get all scheduled docker runs by dataset id. If no state is specified, returns runs which have not yet finished (neither DONE or CANCELED).  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.get_docker_runs_scheduled_by_dataset_id_with_http_info(dataset_id, async_req=True)
@@ -1535,12 +1631,13 @@ class DockerApi(object):
 
         :param async_req bool
         :param MongoObjectID dataset_id: ObjectId of the dataset (required)
+        :param DockerRunScheduledState state:
         :return: list[DockerRunScheduledData]
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['dataset_id']  # noqa: E501
+        all_params = ['dataset_id', 'state']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -1567,6 +1664,8 @@ class DockerApi(object):
             path_params['datasetId'] = params['dataset_id']  # noqa: E501
 
         query_params = []
+        if 'state' in params:
+            query_params.append(('state', params['state']))  # noqa: E501
 
         header_params = {}
 
@@ -2455,7 +2554,7 @@ class DockerApi(object):
     def register_docker_worker(self, body, **kwargs):  # noqa: E501
         """register_docker_worker  # noqa: E501
 
-        Registers a worker for a user.  # noqa: E501
+        Registers a worker for a user. If a worker with the same name is passed that already exists, the same workerId will be returned  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.register_docker_worker(body, async_req=True)
@@ -2477,7 +2576,7 @@ class DockerApi(object):
     def register_docker_worker_with_http_info(self, body, **kwargs):  # noqa: E501
         """register_docker_worker  # noqa: E501
 
-        Registers a worker for a user.  # noqa: E501
+        Registers a worker for a user. If a worker with the same name is passed that already exists, the same workerId will be returned  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.register_docker_worker_with_http_info(body, async_req=True)
@@ -2661,7 +2760,7 @@ class DockerApi(object):
     def update_docker_worker_config_by_id(self, body, config_id, **kwargs):  # noqa: E501
         """update_docker_worker_config_by_id  # noqa: E501
 
-        Updates a docker worker configuration by id.  # noqa: E501
+        DEPRECATED, DONT USE. Updates a docker worker configuration by id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_docker_worker_config_by_id(body, config_id, async_req=True)
@@ -2684,7 +2783,7 @@ class DockerApi(object):
     def update_docker_worker_config_by_id_with_http_info(self, body, config_id, **kwargs):  # noqa: E501
         """update_docker_worker_config_by_id  # noqa: E501
 
-        Updates a docker worker configuration by id.  # noqa: E501
+        DEPRECATED, DONT USE. Updates a docker worker configuration by id.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.update_docker_worker_config_by_id_with_http_info(body, config_id, async_req=True)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -908,8 +908,6 @@ class MockedComputeWorkerApi(DockerApi):
 
     def get_docker_runs(self, page_size: Optional[int] = None, page_offset: Optional[int] = None, **kwargs):
         start, end = _start_and_end_offset(page_size=page_size, page_offset=page_offset)
-        print(start, end)
-        print(self._compute_worker_runs)
         return self._compute_worker_runs[start:end]
 
     def get_docker_runs_count(self, **kwargs):

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -603,7 +603,6 @@ class MockedDatasetsApi(DatasetsApi):
         self.datasets = self._default_datasets
         self.shared_datasets = self._shared_datasets
 
-    #
     def get_datasets(
         self, 
         shared: bool, 
@@ -615,12 +614,6 @@ class MockedDatasetsApi(DatasetsApi):
             return self.shared_datasets[start:end]
         else:
             return self.datasets[start:end]
-
-    # def get_all_datasets(self, **kwargs):
-    #     return self.get_datasets()
-
-    # def dataset_exists(self, dataset_id: str):
-    #     return dataset_id in [d.id for d in self._default_datasets]
 
     def create_dataset(self, body: DatasetCreateRequest, **kwargs):
         assert isinstance(body, DatasetCreateRequest)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -1,10 +1,9 @@
 import csv
 import io
-from os import access
 import tempfile
 import unittest
 from io import IOBase
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 import json
 
 import numpy as np
@@ -565,7 +564,7 @@ class MockedSamplesApi(SamplesApi):
 class MockedDatasetsApi(DatasetsApi):
     def __init__(self, api_client):
         no_datasets = 3
-        self.default_datasets = [
+        self._default_datasets = [
             DatasetData(
                 name=f"dataset_{i}",
                 id=f"dataset_{i}_id",
@@ -579,19 +578,49 @@ class MockedDatasetsApi(DatasetsApi):
             )
             for i in range(no_datasets)
         ]
+        self._shared_datasets = [
+            DatasetData(
+                name=f"shared_dataset_{i}",
+                id=f"shared_dataset_{i}_id",
+                last_modified_at=-1,
+                type="Images",
+                img_type="full",
+                size_in_bytes=-1,
+                n_samples=-1,
+                created_at=-1,
+                user_id="another_user",
+            )
+            for i in range(2)
+        ]
         self.reset()
 
+    @property
+    def _all_datasets(self) -> List[DatasetData]:
+        return [*self.datasets, *self.shared_datasets]
+
+
     def reset(self):
-        self.datasets = self.default_datasets
+        self.datasets = self._default_datasets
+        self.shared_datasets = self._shared_datasets
 
-    def get_datasets(self, **kwargs):
-        return self.datasets
+    #
+    def get_datasets(
+        self, 
+        shared: bool, 
+        page_size: Optional[int] = None, 
+        page_offset: Optional[int] = None,
+    ):
+        start, end = _start_and_end_offset(page_size=page_size, page_offset=page_offset)
+        if shared:
+            return self.shared_datasets[start:end]
+        else:
+            return self.datasets[start:end]
 
-    def get_all_datasets(self, **kwargs):
-        return self.get_datasets()
+    # def get_all_datasets(self, **kwargs):
+    #     return self.get_datasets()
 
-    def dataset_exists(self, dataset_id: str):
-        return dataset_id in [d.id for d in self.default_datasets]
+    # def dataset_exists(self, dataset_id: str):
+    #     return dataset_id in [d.id for d in self._default_datasets]
 
     def create_dataset(self, body: DatasetCreateRequest, **kwargs):
         assert isinstance(body, DatasetCreateRequest)
@@ -608,14 +637,14 @@ class MockedDatasetsApi(DatasetsApi):
             created_at=-1,
             user_id="user_0",
         )
-        self.datasets += [dataset]
+        self.datasets.append(dataset)
         response_ = CreateEntityResponse(id=id)
         return response_
 
     def get_dataset_by_id(self, dataset_id):
         _check_dataset_id(dataset_id)
         dataset = next(
-            (dataset for dataset in self.default_datasets if dataset_id == dataset.id),
+            (dataset for dataset in self._all_datasets if dataset_id == dataset.id),
             None,
         )
         if dataset is None:
@@ -626,13 +655,29 @@ class MockedDatasetsApi(DatasetsApi):
         _check_dataset_id(dataset_id)
         return True
 
-    def delete_dataset_by_id(self, dataset_id, **kwargs):
+    def delete_dataset_by_id(self, dataset_id, **kwargs) -> None:
         _check_dataset_id(dataset_id)
         datasets_without_that_id = [
             dataset for dataset in self.datasets if dataset.id != dataset_id
         ]
         assert len(datasets_without_that_id) == len(self.datasets) - 1
         self.datasets = datasets_without_that_id
+
+    def get_children_of_dataset_id(self, dataset_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_datasets_enriched(self, **kwargs):
+        raise NotImplementedError()
+
+    def get_datasets_query_by_name(self, dataset_name: str, shared: bool, exact: bool) -> List[DatasetData]:
+        datasets = self.get_datasets(shared=shared)
+        if exact:
+            return [dataset for dataset in datasets if dataset.name == dataset_name]
+        else:
+            return [dataset for dataset in datasets if dataset.name is not None and dataset.name.startswith(dataset_name)]
+
+    def update_dataset_by_id(self, body, dataset_id, **kwargs):
+        raise NotImplementedError()
 
 
 class MockedDatasourcesApi(DatasourcesApi):
@@ -868,14 +913,88 @@ class MockedComputeWorkerApi(DockerApi):
         _check_dataset_id(dataset_id)
         return CreateEntityResponse(id=f"scheduled-run-id-123-dataset-{dataset_id}")
 
-    def get_docker_runs(self, **kwargs):
-        return self._compute_worker_runs
+    def get_docker_runs(self, page_size: Optional[int] = None, page_offset: Optional[int] = None, **kwargs):
+        start, end = _start_and_end_offset(page_size=page_size, page_offset=page_offset)
+        print(start, end)
+        print(self._compute_worker_runs)
+        return self._compute_worker_runs[start:end]
 
-    def get_docker_runs_scheduled_by_dataset_id(self, dataset_id, **kwargs):
+    def get_docker_runs_count(self, **kwargs):
+        return len(self._compute_worker_runs)
+
+    def get_docker_runs_scheduled_by_dataset_id(self, dataset_id, state: Optional[str] = None, **kwargs):
         runs = self._scheduled_compute_worker_runs
         runs = [run for run in runs if run.dataset_id == dataset_id]
         return runs
 
+    def cancel_scheduled_docker_run_state_by_id(self, dataset_id: str, scheduled_id: str, **kwargs):
+        raise NotImplementedError()
+
+    def confirm_docker_run_artifact_creation(self, run_id: str, artifact_id: str, **kwargs):
+        raise NotImplementedError()
+
+    def create_docker_run(self, body, **kwargs):
+        raise NotImplementedError()
+
+    def create_docker_run_artifact(self, body, run_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_license_information(self, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_run_artifact_read_url_by_id(self, run_id, artifact_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_run_by_id(self, run_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_run_by_scheduled_id(self, scheduled_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_run_logs_by_id(self, run_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_run_report_read_url_by_id(self, run_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_run_report_write_url_by_id(self, run_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_runs_scheduled_by_state_and_labels(self, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_runs_scheduled_by_worker_id(self, worker_id, **kwargs):
+        raise NotImplementedError()
+
+    def get_docker_worker_config_by_id(self, config_id, **kwargs):
+        raise NotImplementedError()
+    
+    def get_docker_worker_configs(self, **kwargs):
+        raise NotImplementedError()
+    
+    def get_docker_worker_registry_entry_by_id(self, worker_id, **kwargs):
+        raise NotImplementedError()
+
+    def post_docker_authorization_request(self, body, **kwargs):
+        raise NotImplementedError()
+
+    def post_docker_usage_stats(self, body, **kwargs):
+        raise NotImplementedError()
+
+    def post_docker_worker_authorization_request(self, body, **kwargs):
+        raise NotImplementedError()
+
+    def update_docker_run_by_id(self, body, run_id, **kwargs):
+        raise NotImplementedError()
+
+    def update_docker_worker_config_by_id(self, body, config_id, **kwargs):
+        raise NotImplementedError()
+
+    def update_docker_worker_registry_entry_by_id(self, body, worker_id, **kwargs):
+        raise NotImplementedError()
+
+    def update_scheduled_docker_run_state_by_id(self, body, dataset_id, worker_id, scheduled_id, **kwargs):
+        raise NotImplementedError()
 
 class MockedVersioningApi(VersioningApi):
     def get_latest_pip_version(self, **kwargs):
@@ -1033,3 +1152,14 @@ class MockedApiWorkflowSetup(unittest.TestCase):
         self.api_workflow_client = MockedApiWorkflowClient(
             token=token, dataset_id=dataset_id
         )
+
+def _start_and_end_offset(
+    page_size: Optional[int], 
+    page_offset: Optional[int],
+) -> Union[Tuple[int, int], Tuple[None, None]]:
+    if page_size is None and page_offset is None:
+        return None, None
+    elif page_size is not None and page_offset is not None:
+        return page_offset, page_offset + page_size
+    else:
+        assert False, "page_size and page_offset must either both be None or both set"

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -504,6 +504,7 @@ def test_get_compute_worker_runs(mocker: MockerFixture) -> None:
         DockerRunData(id="run-2", created_at=10,  dataset_id="", docker_version="", state="", last_modified_at=0),
         DockerRunData(id="run-1", created_at=20,  dataset_id="", docker_version="", state="", last_modified_at=0),
     ]
+    assert mock_compute_worker_api.get_docker_runs.call_count == 2
 
 def test_get_compute_worker_runs__dataset(mocker: MockerFixture) -> None:
     client = ApiWorkflowClient(token="123")
@@ -516,12 +517,12 @@ def test_get_compute_worker_runs__dataset(mocker: MockerFixture) -> None:
         [],
     ]
 
-    # mock_compute_worker_api.side_effect = get_docker_runs
     client._compute_worker_api = mock_compute_worker_api
     runs = client.get_compute_worker_runs(dataset_id="dataset-2")
     assert runs == [
         DockerRunData(id="run-2", dataset_id="dataset-2", docker_version="", state="", created_at=0, last_modified_at=0),
     ]
+    assert mock_compute_worker_api.get_docker_runs.call_count == 2
 
 def test_download_compute_worker_run_artifacts(mocker: MockerFixture) -> None:
     client = ApiWorkflowClient(token="123")

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -491,9 +491,12 @@ def test_compute_worker_run_info_generator(mocker) -> None:
 def test_get_compute_worker_runs(mocker: MockerFixture) -> None:
     client = ApiWorkflowClient(token="123")
     mock_compute_worker_api = mocker.create_autospec(DockerApi, spec_set=True).return_value
-    mock_compute_worker_api.get_docker_runs.return_value = [
-        DockerRunData(id="run-1", created_at=20,  dataset_id="", docker_version="", state="", last_modified_at=0),
-        DockerRunData(id="run-2", created_at=10,  dataset_id="", docker_version="", state="", last_modified_at=0),
+    mock_compute_worker_api.get_docker_runs.side_effect = [
+        [
+            DockerRunData(id="run-1", created_at=20,  dataset_id="", docker_version="", state="", last_modified_at=0),
+            DockerRunData(id="run-2", created_at=10,  dataset_id="", docker_version="", state="", last_modified_at=0),
+        ], 
+        [],
     ]
     client._compute_worker_api = mock_compute_worker_api
     runs = client.get_compute_worker_runs()
@@ -505,10 +508,15 @@ def test_get_compute_worker_runs(mocker: MockerFixture) -> None:
 def test_get_compute_worker_runs__dataset(mocker: MockerFixture) -> None:
     client = ApiWorkflowClient(token="123")
     mock_compute_worker_api = mocker.create_autospec(DockerApi, spec_set=True).return_value
-    mock_compute_worker_api.get_docker_runs.return_value = [
-        DockerRunData(id="run-1", dataset_id="dataset-1", docker_version="", state="", created_at=0, last_modified_at=0),
-        DockerRunData(id="run-2", dataset_id="dataset-2", docker_version="", state="", created_at=0, last_modified_at=0),
+    mock_compute_worker_api.get_docker_runs.side_effect = [
+        [
+            DockerRunData(id="run-1", dataset_id="dataset-1", docker_version="", state="", created_at=0, last_modified_at=0),
+            DockerRunData(id="run-2", dataset_id="dataset-2", docker_version="", state="", created_at=0, last_modified_at=0),
+        ],
+        [],
     ]
+
+    # mock_compute_worker_api.side_effect = get_docker_runs
     client._compute_worker_api = mock_compute_worker_api
     runs = client.get_compute_worker_runs(dataset_id="dataset-2")
     assert runs == [

--- a/tests/api_workflow/test_api_workflow_datasets.py
+++ b/tests/api_workflow/test_api_workflow_datasets.py
@@ -5,26 +5,76 @@ from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
 
-    def test_create_dataset_new(self):
+    def setUp(self, token="token_xyz", dataset_id="dataset_id_xyz") -> None:
+        super().setUp(token, dataset_id)
         self.api_workflow_client._datasets_api.reset()
+
+    def test_create_dataset_new(self):
         self.api_workflow_client.create_dataset(dataset_name="dataset_new")
-        test_var = self.api_workflow_client.dataset_id
+        assert isinstance(self.api_workflow_client.dataset_id, str)
+        assert len(self.api_workflow_client.dataset_id) > 0
 
     def test_create_dataset_existing(self):
-        self.api_workflow_client._datasets_api.reset()
         with self.assertRaises(ValueError):
             self.api_workflow_client.create_dataset(dataset_name="dataset_1")
 
-    def test_dataset_name_exists__new(self):
-        self.api_workflow_client._datasets_api.reset()
-        assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_new") == False
+    def test_dataset_name_exists__own_not_existing(self):
+        assert not self.api_workflow_client.dataset_name_exists(dataset_name="not_existing_dataset")
 
-    def test_dataset_name_exists__existing(self):
-        self.api_workflow_client._datasets_api.reset()
-        assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_1") == True
+    def test_dataset_name_exists__own_existing(self):
+        assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_1")
+
+    def test_dataset_name_exists__shared_existing(self):
+        assert self.api_workflow_client.dataset_name_exists(dataset_name="shared_dataset_1", shared=True)
+
+    def test_dataset_name_exists__shared_not_existing(self):
+        assert not self.api_workflow_client.dataset_name_exists(dataset_name="not_existing_dataset", shared=True)
+
+    def test_dataset_name_exists__own_and_shared_existing(self):
+        assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_1", shared=None)
+        assert self.api_workflow_client.dataset_name_exists(dataset_name="shared_dataset_1", shared=None)
+
+    def test_dataset_name_exists__own_and_shared_not_existing(self):
+        assert not self.api_workflow_client.dataset_name_exists(dataset_name="not_existing_dataset", shared=None)
+
+    def test_get_datasets_by_name__own_not_existing(self):
+        datasets = self.api_workflow_client.get_datasets_by_name(dataset_name="shared_dataset_1", shared=False)
+        assert datasets == []
+
+    def test_get_datasets_by_name__own_existing(self):
+        datasets = self.api_workflow_client.get_datasets_by_name(dataset_name="dataset_1", shared=False)
+        assert all(dataset.name == "dataset_1" for dataset in datasets)
+        assert len(datasets) == 1
+
+    def test_get_datasets_by_name__shared_not_existing(self):
+        datasets = self.api_workflow_client.get_datasets_by_name(dataset_name="dataset_1", shared=True)
+        assert datasets == []
+
+    def test_get_datasets_by_name__shared_existing(self):
+        datasets = self.api_workflow_client.get_datasets_by_name(dataset_name="shared_dataset_1", shared=True)
+        assert all(dataset.name == "shared_dataset_1" for dataset in datasets)
+        assert len(datasets) == 1
+
+    def test_get_datasets_by_name__own_and_shared_not_existing(self):
+        datasets = self.api_workflow_client.get_datasets_by_name(dataset_name="not_existing_dataset", shared=None)
+        assert datasets == []
+
+    def test_get_datasets_by_name__own_and_shared_existing(self):
+        datasets = self.api_workflow_client.get_datasets_by_name(dataset_name="dataset_1", shared=None)
+        assert all(dataset.name == "dataset_1" for dataset in datasets)
+        assert len(datasets) == 1
+
+        datasets = self.api_workflow_client.get_datasets_by_name(dataset_name="shared_dataset_1", shared=True)
+        assert all(dataset.name == "shared_dataset_1" for dataset in datasets)
+        assert len(datasets) == 1
+
+    def test_get_all_datasets(self):
+        datasets = self.api_workflow_client.get_all_datasets()
+        dataset_names = {dataset.name for dataset in datasets}
+        assert "dataset_1" in dataset_names
+        assert "shared_dataset_1" in dataset_names
 
     def test_create_dataset_with_counter(self):
-        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="basename")
         n_tries = 3
         for i in range(n_tries):
@@ -32,34 +82,47 @@ class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
         assert self.api_workflow_client._datasets_api.datasets[-1].name == f"basename_{n_tries}"
 
     def test_create_dataset_with_counter_nonexisting(self):
-        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="basename")
         self.api_workflow_client.create_new_dataset_with_unique_name(dataset_basename="baseName")
         assert self.api_workflow_client._datasets_api.datasets[-1].name == "baseName"
 
-    def test_set_dataset_id_success(self):
-        self.api_workflow_client._datasets_api.reset()
-        self.api_workflow_client.set_dataset_id_by_name("dataset_1")
+    def test_set_dataset_id__own_success(self):
+        self.api_workflow_client.set_dataset_id_by_name("dataset_1", shared=False)
         assert self.api_workflow_client.dataset_id == "dataset_1_id"
 
-    def test_set_dataset_id_error(self):
-        self.api_workflow_client._datasets_api.reset()
+    def test_set_dataset_id__own_error(self):
         with self.assertRaises(ValueError):
-            self.api_workflow_client.set_dataset_id_by_name("nonexisting-dataset")
+            self.api_workflow_client.set_dataset_id_by_name("shared_dataset_1", shared=False)
+
+    def test_set_dataset_id__shared_success(self):
+        self.api_workflow_client.set_dataset_id_by_name("shared_dataset_1", shared=True)
+        assert self.api_workflow_client.dataset_id == "shared_dataset_1_id"
+
+    def test_set_dataset_id__shared_error(self):
+        with self.assertRaises(ValueError):
+            self.api_workflow_client.set_dataset_id_by_name("dataset_1", shared=True)
+
+    def test_set_dataset_id__own_and_shared_success(self):
+        self.api_workflow_client.set_dataset_id_by_name("dataset_1", shared=None)
+        assert self.api_workflow_client.dataset_id == "dataset_1_id"
+
+        self.api_workflow_client.set_dataset_id_by_name("shared_dataset_1", shared=None)
+        assert self.api_workflow_client.dataset_id == "shared_dataset_1_id"
+
+    def test_set_dataset_id__own_and_shared_error(self):
+        with self.assertRaises(ValueError):
+            self.api_workflow_client.set_dataset_id_by_name("not_existing_dataset", shared=None)
 
     def test_delete_dataset(self):
-        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="dataset_to_delete")
         self.api_workflow_client.delete_dataset_by_id(self.api_workflow_client.dataset_id)
         assert not hasattr(self, "_dataset_id")
 
     def test_dataset_type(self):
-        self.api_workflow_client._datasets_api.reset()
         self.api_workflow_client.create_dataset(dataset_name="some_dataset")
         assert self.api_workflow_client.dataset_type == "Images"
 
     def test_get_datasets(self):
-        self.api_workflow_client._datasets_api.reset()
         num_datasets_before = len(self.api_workflow_client.get_datasets())
         self.api_workflow_client.create_new_dataset_with_unique_name('dataset')
         num_datasets_after = len(self.api_workflow_client.get_datasets())


### PR DESCRIPTION
## Changes

* Use paginated endpoints when loading datasets and runs
* Add option to filter by `state` when listing scheduled compute worker runs
* Use query datasets by name endpoint for faster dataset listing
* Mark `get_all_datasets` as deprecated
* Make `shared` parameter optional
   * If `shared=None` then all datasets (own and shared) are listed

## Tests Changes

* Update mocked API endpoints
* Docker run and datasets endpoints with a missing mock implementation raise now a `NotImplementedError`
* Remove unused mocked methods
* Add unit tests for new methods/arguments

## How was this tested

* Unit tests
* Manually tested the methods against API