### PR TITLE
Update docs links

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -76,6 +76,8 @@ class _ComputeWorkerMixin:
                 The name of the Lightly Worker.
             labels:
                 The labels of the Lightly Worker.
+                See our docs for more information regarding the labels parameter: 
+                https://docs.lightly.ai/docs/assign-scheduled-runs-to-specific-workers
 
         Returns:
             The id of the newly registered compute worker.
@@ -112,16 +114,16 @@ class _ComputeWorkerMixin:
     ) -> str:
         """Creates a new configuration for a compute worker run.
 
+        See our docs for more information regarding the different configurations:
+        https://docs.lightly.ai/docs/all-configuration-options
+
         Args:
             worker_config:
-                Compute worker configuration. All possible values are listed in
-                our docs: https://docs.lightly.ai/docker/configuration/configuration.html#list-of-parameters
+                Compute worker configuration.
             lightly_config:
-                Lightly configuration. All possible values are listed in our
-                docs: https://docs.lightly.ai/lightly.cli.html#default-settings
+                Lightly configuration.
             selection_config:
-                Selection configuration. See the docs for more information:
-                TODO: add link
+                Selection configuration.
 
         Returns:
             The id of the created config.
@@ -151,18 +153,20 @@ class _ComputeWorkerMixin:
     ) -> str:
         """Schedules a run with the given configurations.
 
+        See our docs for more information regarding the different configurations: 
+        https://docs.lightly.ai/docs/all-configuration-options
+
         Args:
             worker_config:
-                Compute worker configuration. All possible values are listed in
-                our docs: https://docs.lightly.ai/docker/configuration/configuration.html#list-of-parameters
+                Compute worker configuration.
             lightly_config:
-                Lightly configuration. All possible values are listed in our
-                docs: https://docs.lightly.ai/lightly.cli.html#default-settings
+                Lightly configuration.
             selection_config:
-                Selection configuration. See the docs for more information:
-                https://docs.lightly.ai/docker/getting_started/selection.html
+                Selection configuration.
             runs_on:
                 The required labels the Lightly Worker must have to take the job.
+                See our docs for more information regarding the runs_on paramter:
+                https://docs.lightly.ai/docs/assign-scheduled-runs-to-specific-workers
 
         Returns:
             The id of the scheduled run.
@@ -411,8 +415,8 @@ class _ComputeWorkerMixin:
     ) -> None:
         """Downloads the last training checkpoint from a run.
 
-        See https://docs.lightly.ai/docker/advanced/load_model_from_checkpoint.html
-        for information on how to use the checkpoint.
+        See our docs for more information regarding checkpoints:
+        https://docs.lightly.ai/docs/train-a-self-supervised-model#checkpoints
 
         Args:
             run: 

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -321,8 +321,8 @@ class _DatasourcesMixin:
     ) -> None:
         """Sets the Azure configuration for the datasource of the current dataset.
 
-        Find a detailed explanation on how to setup Lightly with
-        Azure Blob Storage in our docs: https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_azure_storage.html#
+        See our docs for a detailed explanation on how to setup Lightly with
+        Azure: https://docs.lightly.ai/docs/azure
 
         Args:
             container_name:
@@ -368,8 +368,8 @@ class _DatasourcesMixin:
         """Sets the Google Cloud Storage configuration for the datasource of the
         current dataset.
 
-        Find a detailed explanation on how to setup Lightly with
-        Google Cloud Storage in our docs: https://docs.lightly.ai/getting_started/dataset_creation/dataset_creation_gcloud_bucket.html
+        See our docs for a detailed explanation on how to setup Lightly with
+        Google Cloud Storage: https://docs.lightly.ai/docs/google-cloud-storage
 
         Args:
             resource_path:
@@ -448,6 +448,9 @@ class _DatasourcesMixin:
     ) -> None:
         """Sets the S3 configuration for the datasource of the current dataset.
 
+        See our docs for a detailed explanation on how to setup Lightly with
+        AWS S3: https://docs.lightly.ai/docs/aws-s3
+
         Args:
             resource_path:
                 S3 url of your dataset, for example "s3://my_bucket/path/to/my/data".
@@ -494,6 +497,9 @@ class _DatasourcesMixin:
         purpose: str = DatasourcePurpose.INPUT_OUTPUT,
     ) -> None:
         """Sets the S3 configuration for the datasource of the current dataset.
+
+        See our docs for a detailed explanation on how to setup Lightly with
+        AWS S3 and delegated access: https://docs.lightly.ai/docs/aws-s3#delegated-access
 
         Args:
             resource_path:


### PR DESCRIPTION
Updates some broken links to point to our new docs.

[lightly.api — lightly 1.2.35 documentation.pdf](https://github.com/lightly-ai/lightly/files/10068394/lightly.api.lightly.1.2.35.documentation.pdf)
