### PR TITLE
Fix failing github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Hack to get setup-python to work on nektos/act
       run: |
         if [ ! -f "/etc/lsb-release" ] ; then
           echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release
         fi
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - uses: actions/cache@v2

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -17,14 +17,14 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Hack to get setup-python to work on nektos/act
       run: |
         if [ ! -f "/etc/lsb-release" ] ; then
           echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release
         fi
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - uses: actions/cache@v2

--- a/.github/workflows/tests_unmocked.yml
+++ b/.github/workflows/tests_unmocked.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
     - uses: actions/cache@v2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,9 @@ lightly_utils~=0.0.0
 numpy>=1.18.1
 python_dateutil>=2.5.3
 requests>=2.23.0
-setuptools>=21.0.0
+# Temporarily force setuptools<=65.5.1 until https://github.com/pypa/setuptools/issues/3693
+# is resolved.
+setuptools>=21.0.0,<=65.5.1
 six>=1.10
 torchvision
 tqdm>=4.44


### PR DESCRIPTION
CI started failing about 24h ago due to a new release of setuptools (v65.6.0) which causes bugs in downstream packages: https://github.com/pypa/setuptools/issues/3693

Example of a failing action: https://github.com/lightly-ai/lightly/actions/runs/3524405267

## Changes
* Limited setuptools to v65.5.1 in requirements.txt
* Updated actions versions