### PR TITLE
Register memory bank as a buffer

### DIFF
--- a/lightly/loss/memory_bank.py
+++ b/lightly/loss/memory_bank.py
@@ -46,10 +46,9 @@ class MemoryBankModule(torch.nn.Module):
             raise ValueError(msg)
 
         self.size = size
+        self.register_buffer("bank", tensor=torch.empty(0, dtype=torch.float), persistent=False)
+        self.register_buffer("bank_ptr", tensor=torch.empty(0, dtype=torch.long), persistent=False)
 
-        self.bank = None
-        self.bank_ptr = None
-    
     @torch.no_grad()
     def _init_memory_bank(self, dim: int):
         """Initialize the memory bank if it's empty
@@ -63,9 +62,9 @@ class MemoryBankModule(torch.nn.Module):
         # we could use register buffers like in the moco repo
         # https://github.com/facebookresearch/moco but we don't
         # want to pollute our checkpoints
-        self.bank = torch.randn(dim, self.size)
-        self.bank = torch.nn.functional.normalize(self.bank, dim=0)
-        self.bank_ptr = torch.LongTensor([0])
+        self.bank = torch.randn(dim, self.size).type_as(self.bank)
+        torch.nn.functional.normalize(self.bank, dim=0)
+        self.bank_ptr = torch.zeros(1).type_as(self.bank_ptr)
 
     @torch.no_grad()
     def _dequeue_and_enqueue(self, batch: torch.Tensor):
@@ -111,7 +110,7 @@ class MemoryBankModule(torch.nn.Module):
         _, dim = output.shape
 
         # initialize the memory bank if it is not already done
-        if self.bank is None:
+        if self.bank.nelement() == 0:
             self._init_memory_bank(dim)
 
         # query and update memory bank

--- a/tests/loss/test_MemoryBank.py
+++ b/tests/loss/test_MemoryBank.py
@@ -6,11 +6,11 @@ from lightly.loss.memory_bank import MemoryBankModule
 
 class TestNTXentLoss(unittest.TestCase):
 
-    def test_NegativeSize(self):
+    def test_init__negative_size(self):
         with self.assertRaises(ValueError):
             MemoryBankModule(size=-1)
 
-    def test_ForwardEasy(self):
+    def test_forward_easy(self):
         bsz = 3
         dim, size = 2, 9
         n = 33 * bsz
@@ -36,7 +36,7 @@ class TestNTXentLoss(unittest.TestCase):
 
             ptr = (ptr + bsz) % size
 
-    def test_Forward(self):
+    def test_forward(self):
         bsz = 3
         dim, size = 2, 10
         n = 33 * bsz
@@ -47,4 +47,20 @@ class TestNTXentLoss(unittest.TestCase):
             # see if there are any problems when the bank size
             # is no multiple of the batch size
             output = torch.randn(bsz, dim)
+            _, _ = memory_bank(output)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "cuda not available")
+    def test_forward__cuda(self):
+        bsz = 3
+        dim, size = 2, 10
+        n = 33 * bsz
+        memory_bank = MemoryBankModule(size=size)
+        device = torch.device('cuda')
+        memory_bank.to(device=device)
+
+        for i in range(0, n, bsz):
+
+            # see if there are any problems when the bank size
+            # is no multiple of the batch size
+            output = torch.randn(bsz, dim, device=device)
             _, _ = memory_bank(output)


### PR DESCRIPTION
This makes the memory bank work with distributed training. The buffer is non-persistent and will not be part of the state_dict or saved to checkpoints.

Closes #968 

## Tested With
```
import torch
from lightly.models.modules import NNMemoryBankModule
memory_bank = NNMemoryBankModule(size=1000)
memory_bank = torch.nn.DataParallel(memory_bank.to('cuda:0'), device_ids=[0,1])
memory_bank(torch.randn((100, 512)))
print(memory_bank.module.bank)
```

Which returns a tensor on device 0.