### PR TITLE
Update Lightly citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If you want to cite the framework feel free to use this:
 ```bibtex
 @article{susmelj2020lightly,
   title={Lightly},
-  author={Igor Susmelj, Matthias Heller, Philipp Wirth, Jeremy Prescott, Malte Ebner et al.},
+  author={Igor Susmelj and Matthias Heller and Philipp Wirth and Jeremy Prescott and Malte Ebner et al.},
   journal={GitHub. Note: https://github.com/lightly-ai/lightly},
   year={2020}
 }


### PR DESCRIPTION
This bibtex returns the following error: **Too many commas in name 1 of "Igor Susmelj, Matthias Heller, Philipp Wirth, Jeremy Prescott, Malte Ebner et al." for entry lightly.**

This is because .bib entries in LaTeX expect author separation with "and", not comma. Comma is used when author names are written in (surname,name) format. Here is a simple fix.