### PR TITLE
Fix Memory Bank

### DIFF
--- a/lightly/loss/memory_bank.py
+++ b/lightly/loss/memory_bank.py
@@ -63,7 +63,7 @@ class MemoryBankModule(torch.nn.Module):
         # https://github.com/facebookresearch/moco but we don't
         # want to pollute our checkpoints
         self.bank = torch.randn(dim, self.size).type_as(self.bank)
-        torch.nn.functional.normalize(self.bank, dim=0)
+        self.bank = torch.nn.functional.normalize(self.bank, dim=0)
         self.bank_ptr = torch.zeros(1).type_as(self.bank_ptr)
 
     @torch.no_grad()


### PR DESCRIPTION
### Changes

Add missing assignment after normalizing memory bank. This made the network collapse during training because the norm of the randomly initialized bank was too large. The bug was introduced in #993 (lightly v1.2.37).

### How was it tested?

Ran the [MoCo Tutorial](https://docs.lightly.ai/self-supervised-learning/tutorials/package/tutorial_moco_memory_bank.html) and verified that the loss decreases.

Closes #1007 
