### PR TITLE
Add download embeddings method

### DIFF
--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -149,14 +149,15 @@ class _DownloadDatasetMixin:
             warnings.warn(msg)
 
     def download_embeddings_csv(self, output_path: str) -> None:
-        """Downloads the last created embedding from the dataset to the output path.
+        """Downloads the latest embeddings from the dataset and saves them to the output
+        path.
 
         Raises:
             RuntimeError:
-                If no embedding could be found for the dataset.
+                If no embeddings could be found for the dataset.
 
         """
-        last_embedding = self._get_last_default_embeddings_data()
+        last_embedding = self._get_latest_default_embeddings_data()
         if last_embedding is None:
             raise RuntimeError(
                 f"Could not find embedding for dataset with id '{self.dataset_id}'."
@@ -167,9 +168,9 @@ class _DownloadDatasetMixin:
         )
         download.download_and_write_file(url=read_url, output_path=output_path)
 
-    def _get_last_default_embeddings_data(self) -> Optional[DatasetEmbeddingData]:
-        """Returns the last created embedding with a default name from the dataset or
-        None if no such embedding exists.
+    def _get_latest_default_embeddings_data(self) -> Optional[DatasetEmbeddingData]:
+        """Returns the latest embeddings with a default name from the dataset or None
+        if no such embedding exists.
         """
         embeddings = self._embeddings_api.get_embeddings_by_dataset_id(
             dataset_id=self.dataset_id

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -170,18 +170,6 @@ class _DownloadDatasetMixin:
             f"'{self.dataset_id}'."
         )
 
-    def _get_latest_default_embedding_data(self) -> Optional[DatasetEmbeddingData]:
-        """Returns the latest embedding data with a default name from the dataset or
-        None if no such embedding exists.
-        """
-        embeddings = self.get_all_embedding_data()
-        default_embeddings = [e for e in embeddings if e.name.startswith("default")]
-        if default_embeddings:
-            last_embedding = sorted(default_embeddings, key=lambda e: e.created_at)[-1]
-            return last_embedding
-        else:
-            return None
-
     def download_embeddings_csv_by_id(
         self, 
         embedding_id: str, 
@@ -205,7 +193,9 @@ class _DownloadDatasetMixin:
                 If no embeddings could be found for the dataset.
 
         """
-        last_embedding = self._get_latest_default_embedding_data()
+        last_embedding = _get_latest_default_embedding_data(
+            embeddings=self.get_all_embedding_data()
+        )
         if last_embedding is None:
             raise RuntimeError(
                 f"Could not find embeddings for dataset with id '{self.dataset_id}'."
@@ -420,3 +410,17 @@ class _DownloadDatasetMixin:
         """
         tag = self.get_tag_by_name(tag_name)
         return self.export_filenames_and_read_urls_by_tag_id(tag.id)
+
+
+def _get_latest_default_embedding_data(
+    embeddings: List[DatasetEmbeddingData]
+) -> Optional[DatasetEmbeddingData]:
+    """Returns the latest embedding data with a default name or None if no such
+    default embedding exists.
+    """
+    default_embeddings = [e for e in embeddings if e.name.startswith("default")]
+    if default_embeddings:
+        last_embedding = sorted(default_embeddings, key=lambda e: e.created_at)[-1]
+        return last_embedding
+    else:
+        return None

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -1,22 +1,13 @@
-import os
 import shutil
+from unittest import mock
 
-from unittest.mock import patch
-
-import PIL
 import numpy as np
-from lightly.openapi_generated.swagger_client.models.filename_and_read_url import FilenameAndReadUrl
-from lightly.openapi_generated.swagger_client.models.label_box_data_row import LabelBoxDataRow
-from lightly.openapi_generated.swagger_client.models.label_studio_task import LabelStudioTask
-
-import torchvision
+import PIL
 
 import lightly
-from lightly.data.dataset import LightlyDataset
-
+from lightly.api import download
+from lightly.openapi_generated.swagger_client import DatasetData, DatasetEmbeddingData
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
-from lightly.openapi_generated.swagger_client.models.dataset_data import DatasetData
-
 
 
 class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
@@ -44,11 +35,103 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
         self.api_workflow_client.download_dataset('path-to-dir-remove-me', tag_name='initial-tag')
         shutil.rmtree('path-to-dir-remove-me')
 
+    def test_download_embeddings_csv(self) -> None:
+        with (
+            mock.patch.object(
+                self.api_workflow_client,
+                "_get_last_default_embeddings_data",
+                return_value=DatasetEmbeddingData(
+                    id="0",
+                    name="default_20221209_10h45m49s",
+                    created_at=0,
+                    is_processed=False,
+                )
+            ) as mock_get_last_default_embeddings_data,
+            mock.patch.object(
+                self.api_workflow_client._embeddings_api,
+                "get_embeddings_csv_read_url_by_id",
+                return_value="read-url",
+            ) as mock_get_embeddings_csv_read_url_by_id,
+            mock.patch.object(download, "download_and_write_file") as mock_download,
+        ):
+            self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
+            mock_get_last_default_embeddings_data.assert_called_once()
+            mock_get_embeddings_csv_read_url_by_id.assert_called_once_with(
+                dataset_id="dataset_0_id",
+                embedding_id="0",
+            )
+            mock_download.assert_called_once_with(
+                url="read-url",
+                output_path="embeddings.csv",
+            )
+
+    def test_download_embeddings_csv__no_default_embedding(self) -> None:
+        with (
+            mock.patch.object(
+                self.api_workflow_client,
+                "_get_last_default_embeddings_data",
+                return_value=None,
+            ) as mock_get_last_default_embeddings_data,
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Could not find embedding for dataset with id 'dataset_0_id'."
+            )
+        ):
+            self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
+            mock_get_last_default_embeddings_data.assert_called_once()
+
+    def test__get_last_default_embeddings_data(self) -> None:
+        embedding_0 = DatasetEmbeddingData(
+            id="0",
+            name="default_20221209_10h45m49s",
+            created_at=0,
+            is_processed=False,
+        )
+        embedding_1 = DatasetEmbeddingData(
+            id="1",
+            name="default_20221209_10h45m50s",
+            created_at=1,
+            is_processed=False,
+        )
+        embedding_2 = DatasetEmbeddingData(
+            id="2",
+            name="custom-name",
+            created_at=2,
+            is_processed=False,
+        )
+        with mock.patch.object(
+            self.api_workflow_client._embeddings_api,
+            "get_embeddings_by_dataset_id",
+            return_value=[embedding_0, embedding_1, embedding_2],
+        ) as mock_get_embeddings_by_dataset_id:
+            embedding = self.api_workflow_client._get_last_default_embeddings_data()
+            mock_get_embeddings_by_dataset_id.assert_called_once_with(
+                dataset_id="dataset_0_id"
+            )
+            assert embedding == embedding_1
+
+    def test__get_last_default_embeddings_data__no_default_embedding(self) -> None:
+        custom_embedding = DatasetEmbeddingData(
+            id="0",
+            name="custom-name",
+            created_at=0,
+            is_processed=False,
+        )
+        with mock.patch.object(
+            self.api_workflow_client._embeddings_api,
+            "get_embeddings_by_dataset_id",
+            return_value=[custom_embedding],
+        ) as mock_get_embeddings_by_dataset_id:
+            embedding = self.api_workflow_client._get_last_default_embeddings_data()
+            mock_get_embeddings_by_dataset_id.assert_called_once_with(
+                dataset_id="dataset_0_id"
+            )
+            assert embedding is None
+
     def test_export_label_box_data_rows_by_tag_name(self):
         rows = self.api_workflow_client.export_label_box_data_rows_by_tag_name('initial-tag')
         self.assertIsNotNone(rows)
         self.assertTrue(all(isinstance(row, dict) for row in rows))
-
 
     def test_export_label_studio_tasks_by_tag_name(self):
         tasks = self.api_workflow_client.export_label_studio_tasks_by_tag_name('initial-tag')

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -35,50 +35,58 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
         self.api_workflow_client.download_dataset('path-to-dir-remove-me', tag_name='initial-tag')
         shutil.rmtree('path-to-dir-remove-me')
 
-    def test_download_embeddings_csv(self) -> None:
+    def test_get_embedding_data_by_name(self) -> None:
+        embedding_0 = DatasetEmbeddingData(
+            id="0",
+            name="embedding_0",
+            created_at=0,
+            is_processed=False,
+        )
+        embedding_1 = DatasetEmbeddingData(
+            id="1",
+            name="embedding_1",
+            created_at=1,
+            is_processed=False,
+        )
         with mock.patch.object(
-                self.api_workflow_client,
-                "_get_latest_default_embeddings_data",
-                return_value=DatasetEmbeddingData(
-                    id="0",
-                    name="default_20221209_10h45m49s",
-                    created_at=0,
-                    is_processed=False,
-                )
-            ) as mock_get_latest_default_embeddings_data, \
-            mock.patch.object(
-                self.api_workflow_client._embeddings_api,
-                "get_embeddings_csv_read_url_by_id",
-                return_value="read-url",
-            ) as mock_get_embeddings_csv_read_url_by_id, \
-            mock.patch.object(download, "download_and_write_file") as mock_download:
+            self.api_workflow_client._embeddings_api,
+            "get_embeddings_by_dataset_id",
+            return_value=[embedding_0, embedding_1]
+        ) as mock_get_embeddings_by_dataset_id:
 
-            self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
-            mock_get_latest_default_embeddings_data.assert_called_once()
-            mock_get_embeddings_csv_read_url_by_id.assert_called_once_with(
+            embedding = self.api_workflow_client.get_embedding_data_by_name(
+                name="embedding_0"
+            )
+            mock_get_embeddings_by_dataset_id.assert_called_once_with(
                 dataset_id="dataset_0_id",
-                embedding_id="0",
             )
-            mock_download.assert_called_once_with(
-                url="read-url",
-                output_path="embeddings.csv",
-            )
+            assert embedding == embedding_0
 
-    def test_download_embeddings_csv__no_default_embedding(self) -> None:
+    def test_get_embedding_data_by_name__no_embedding_with_name(self) -> None:
+        embedding_0 = DatasetEmbeddingData(
+            id="0",
+            name="embedding_0",
+            created_at=0,
+            is_processed=False,
+        )
         with mock.patch.object(
-                self.api_workflow_client,
-                "_get_latest_default_embeddings_data",
-                return_value=None,
-            ) as mock_get_latest_default_embeddings_data, \
+                self.api_workflow_client._embeddings_api,
+                "get_embeddings_by_dataset_id",
+                return_value=[embedding_0]
+            ) as mock_get_embeddings_by_dataset_id, \
             self.assertRaisesRegex(
-                RuntimeError,
-                "Could not find embedding for dataset with id 'dataset_0_id'."
+                ValueError, 
+                "There are no embeddings with name 'other_embedding' for dataset with id 'dataset_0_id'."
             ):
 
-            self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
-            mock_get_latest_default_embeddings_data.assert_called_once()
+            self.api_workflow_client.get_embedding_data_by_name(
+                name="other_embedding"
+            )
+            mock_get_embeddings_by_dataset_id.assert_called_once_with(
+                dataset_id="dataset_0_id",
+            )
 
-    def test__get_latest_default_embeddings_data(self) -> None:
+    def test__get_latest_default_embedding_data(self) -> None:
         embedding_0 = DatasetEmbeddingData(
             id="0",
             name="default_20221209_10h45m49s",
@@ -102,13 +110,13 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
             "get_embeddings_by_dataset_id",
             return_value=[embedding_0, embedding_1, embedding_2],
         ) as mock_get_embeddings_by_dataset_id:
-            embedding = self.api_workflow_client._get_latest_default_embeddings_data()
+            embedding = self.api_workflow_client._get_latest_default_embedding_data()
             mock_get_embeddings_by_dataset_id.assert_called_once_with(
                 dataset_id="dataset_0_id"
             )
             assert embedding == embedding_1
 
-    def test__get_latest_default_embeddings_data__no_default_embedding(self) -> None:
+    def test__get_latest_default_embedding_data__no_default_embedding(self) -> None:
         custom_embedding = DatasetEmbeddingData(
             id="0",
             name="custom-name",
@@ -120,11 +128,73 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
             "get_embeddings_by_dataset_id",
             return_value=[custom_embedding],
         ) as mock_get_embeddings_by_dataset_id:
-            embedding = self.api_workflow_client._get_latest_default_embeddings_data()
+            embedding = self.api_workflow_client._get_latest_default_embedding_data()
             mock_get_embeddings_by_dataset_id.assert_called_once_with(
                 dataset_id="dataset_0_id"
             )
             assert embedding is None
+
+    def test_download_embeddings_csv_by_id(self) -> None:
+        with mock.patch.object(
+                self.api_workflow_client._embeddings_api,
+                "get_embeddings_csv_read_url_by_id",
+                return_value="read_url",
+            ) as mock_get_embeddings_csv_read_url_by_id, \
+            mock.patch.object(
+                download,
+                "download_and_write_file"
+            ) as mock_download:
+
+            self.api_workflow_client.download_embeddings_csv_by_id(
+                embedding_id="embedding_id",
+                output_path="embeddings.csv",
+            )
+            mock_get_embeddings_csv_read_url_by_id.assert_called_once_with(
+                dataset_id="dataset_0_id",
+                embedding_id="embedding_id",
+            )
+            mock_download.assert_called_once_with(
+                url="read_url",
+                output_path="embeddings.csv",
+            )
+
+    def test_download_embeddings_csv(self) -> None:
+        with mock.patch.object(
+                self.api_workflow_client,
+                "_get_latest_default_embedding_data",
+                return_value=DatasetEmbeddingData(
+                    id="0",
+                    name="default_20221209_10h45m49s",
+                    created_at=0,
+                    is_processed=False,
+                )
+            ) as mock_get_latest_default_embedding_data, \
+            mock.patch.object(
+                self.api_workflow_client,
+                "download_embeddings_csv_by_id",
+            ) as mock_download_embeddings_csv_by_id:
+
+            self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
+            mock_get_latest_default_embedding_data.assert_called_once()
+            mock_download_embeddings_csv_by_id.assert_called_once_with(
+                embedding_id="0",
+                output_path="embeddings.csv",
+            )
+
+    def test_download_embeddings_csv__no_default_embedding(self) -> None:
+        with mock.patch.object(
+                self.api_workflow_client,
+                "_get_latest_default_embedding_data",
+                return_value=None,
+            ) as mock_get_latest_default_embedding_data, \
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Could not find embeddings for dataset with id 'dataset_0_id'."
+            ):
+
+            self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
+            mock_get_latest_default_embedding_data.assert_called_once()
+
 
     def test_export_label_box_data_rows_by_tag_name(self):
         rows = self.api_workflow_client.export_label_box_data_rows_by_tag_name('initial-tag')

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -36,8 +36,7 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
         shutil.rmtree('path-to-dir-remove-me')
 
     def test_download_embeddings_csv(self) -> None:
-        with (
-            mock.patch.object(
+        with mock.patch.object(
                 self.api_workflow_client,
                 "_get_last_default_embeddings_data",
                 return_value=DatasetEmbeddingData(
@@ -46,14 +45,14 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
                     created_at=0,
                     is_processed=False,
                 )
-            ) as mock_get_last_default_embeddings_data,
+            ) as mock_get_last_default_embeddings_data, \
             mock.patch.object(
                 self.api_workflow_client._embeddings_api,
                 "get_embeddings_csv_read_url_by_id",
                 return_value="read-url",
-            ) as mock_get_embeddings_csv_read_url_by_id,
-            mock.patch.object(download, "download_and_write_file") as mock_download,
-        ):
+            ) as mock_get_embeddings_csv_read_url_by_id, \
+            mock.patch.object(download, "download_and_write_file") as mock_download:
+
             self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
             mock_get_last_default_embeddings_data.assert_called_once()
             mock_get_embeddings_csv_read_url_by_id.assert_called_once_with(
@@ -66,17 +65,16 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
             )
 
     def test_download_embeddings_csv__no_default_embedding(self) -> None:
-        with (
-            mock.patch.object(
+        with mock.patch.object(
                 self.api_workflow_client,
                 "_get_last_default_embeddings_data",
                 return_value=None,
-            ) as mock_get_last_default_embeddings_data,
+            ) as mock_get_last_default_embeddings_data, \
             self.assertRaisesRegex(
                 RuntimeError,
                 "Could not find embedding for dataset with id 'dataset_0_id'."
-            )
-        ):
+            ):
+
             self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
             mock_get_last_default_embeddings_data.assert_called_once()
 

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -38,14 +38,14 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
     def test_download_embeddings_csv(self) -> None:
         with mock.patch.object(
                 self.api_workflow_client,
-                "_get_last_default_embeddings_data",
+                "_get_latest_default_embeddings_data",
                 return_value=DatasetEmbeddingData(
                     id="0",
                     name="default_20221209_10h45m49s",
                     created_at=0,
                     is_processed=False,
                 )
-            ) as mock_get_last_default_embeddings_data, \
+            ) as mock_get_latest_default_embeddings_data, \
             mock.patch.object(
                 self.api_workflow_client._embeddings_api,
                 "get_embeddings_csv_read_url_by_id",
@@ -54,7 +54,7 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
             mock.patch.object(download, "download_and_write_file") as mock_download:
 
             self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
-            mock_get_last_default_embeddings_data.assert_called_once()
+            mock_get_latest_default_embeddings_data.assert_called_once()
             mock_get_embeddings_csv_read_url_by_id.assert_called_once_with(
                 dataset_id="dataset_0_id",
                 embedding_id="0",
@@ -67,18 +67,18 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
     def test_download_embeddings_csv__no_default_embedding(self) -> None:
         with mock.patch.object(
                 self.api_workflow_client,
-                "_get_last_default_embeddings_data",
+                "_get_latest_default_embeddings_data",
                 return_value=None,
-            ) as mock_get_last_default_embeddings_data, \
+            ) as mock_get_latest_default_embeddings_data, \
             self.assertRaisesRegex(
                 RuntimeError,
                 "Could not find embedding for dataset with id 'dataset_0_id'."
             ):
 
             self.api_workflow_client.download_embeddings_csv(output_path="embeddings.csv")
-            mock_get_last_default_embeddings_data.assert_called_once()
+            mock_get_latest_default_embeddings_data.assert_called_once()
 
-    def test__get_last_default_embeddings_data(self) -> None:
+    def test__get_latest_default_embeddings_data(self) -> None:
         embedding_0 = DatasetEmbeddingData(
             id="0",
             name="default_20221209_10h45m49s",
@@ -102,13 +102,13 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
             "get_embeddings_by_dataset_id",
             return_value=[embedding_0, embedding_1, embedding_2],
         ) as mock_get_embeddings_by_dataset_id:
-            embedding = self.api_workflow_client._get_last_default_embeddings_data()
+            embedding = self.api_workflow_client._get_latest_default_embeddings_data()
             mock_get_embeddings_by_dataset_id.assert_called_once_with(
                 dataset_id="dataset_0_id"
             )
             assert embedding == embedding_1
 
-    def test__get_last_default_embeddings_data__no_default_embedding(self) -> None:
+    def test__get_latest_default_embeddings_data__no_default_embedding(self) -> None:
         custom_embedding = DatasetEmbeddingData(
             id="0",
             name="custom-name",
@@ -120,7 +120,7 @@ class TestApiWorkflowDownloadDataset(MockedApiWorkflowSetup):
             "get_embeddings_by_dataset_id",
             return_value=[custom_embedding],
         ) as mock_get_embeddings_by_dataset_id:
-            embedding = self.api_workflow_client._get_last_default_embeddings_data()
+            embedding = self.api_workflow_client._get_latest_default_embeddings_data()
             mock_get_embeddings_by_dataset_id.assert_called_once_with(
                 dataset_id="dataset_0_id"
             )


### PR DESCRIPTION
### What has changed and why?

* Add `download_embeddings_csv` to `ApiWorkflowClient`
* Remove unused imports

I limited to method to download only the latest embedding file. This file should include all embeddings for all samples in the dataset. There is currently no way to get the embeddings from a specific run as the embeddings are not linked to runs.

### How has it been tested?

* Add unit tests
* Tested it also manually