### PR TITLE
Igor lig 2244 add link from oss repo readme to oss

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lightly is a computer vision framework for self-supervised learning.
 
 - [Homepage](https://www.lightly.ai)
 - [Web-App](https://app.lightly.ai)
-- [Documentation](https://docs.lightly.ai)
+- [Documentation](https://docs.lightly.ai/self-supervised-learning/)
 - [Github](https://github.com/lightly-ai/lightly)
 - [Discord](https://discord.gg/xvNJW94)
 
@@ -27,7 +27,7 @@ Lightly offers features like
 
 #### Supported Models
 
-You can [find sample code for all the supported models here.](https://docs.lightly.ai/examples/models.html)
+You can [find sample code for all the supported models here.](https://docs.lightly.ai/self-supervised-learning/examples/models.html)
 We provide PyTorch, PyTorch Lightning and PyTorch Lightning distributed examples for each of the models
 to kickstart your project.
 
@@ -53,15 +53,15 @@ Some of our supported models:
 
 Want to jump to the tutorials and see lightly in action?
 
-- [Train MoCo on CIFAR-10](https://docs.lightly.ai/tutorials/package/tutorial_moco_memory_bank.html)
-- [Train SimCLR on clothing data](https://docs.lightly.ai/tutorials/package/tutorial_simclr_clothing.html)
-- [Train SimSiam on satellite images](https://docs.lightly.ai/tutorials/package/tutorial_simsiam_esa.html)
-- [Use lightly with custom augmentations](https://docs.lightly.ai/tutorials/package/tutorial_custom_augmentations.html)
-- [Pre-train a Detectron2 Backbone with Lightly](https://docs.lightly.ai/tutorials/package/tutorial_pretrain_detectron2.html)
+- [Train MoCo on CIFAR-10](https://docs.lightly.ai/self-supervised-learning/tutorials/package/tutorial_moco_memory_bank.html)
+- [Train SimCLR on clothing data](https://docs.lightly.ai/self-supervised-learning/tutorials/package/tutorial_simclr_clothing.html)
+- [Train SimSiam on satellite images](https://docs.lightly.ai/self-supervised-learning/tutorials/package/tutorial_simsiam_esa.html)
+- [Use lightly with custom augmentations](https://docs.lightly.ai/self-supervised-learning/tutorials/package/tutorial_custom_augmentations.html)
+- [Pre-train a Detectron2 Backbone with Lightly](https://docs.lightly.ai/self-supervised-learning/tutorials/package/tutorial_pretrain_detectron2.html)
 
 Tutorials of using the lightly packge together with the Lightly Platform:
 
-- [Active Learning using Detectron2 on Comma10k](https://docs.lightly.ai/tutorials/platform/tutorial_active_learning_detectron2.html)
+- [Active Learning Using YOLOv7 and Comma10k](https://docs.lightly.ai/docs/active-learning-yolov7)
 - [Active Learning with the Nvidia TLT](https://github.com/lightly-ai/NvidiaTLTActiveLearning)
 
 Community and partner projects:
@@ -96,7 +96,7 @@ We strongly recommend that you install Lightly in a dedicated virtualenv, to avo
 With lightly, you can use the latest self-supervised learning methods in a modular
 way using the full power of PyTorch. Experiment with different backbones,
 models, and loss functions. The framework has been designed to be easy to use
-from the ground up. [Find more examples in our docs](https://docs.lightly.ai/examples/models.html).
+from the ground up. [Find more examples in our docs](https://docs.lightly.ai/self-supervised-learning/examples/models.html).
 
 ```python
 import torch
@@ -172,7 +172,7 @@ model = SimSiam(backbone)
 # use the SimSiam loss function
 criterion = loss.NegativeCosineSimilarity()
 ```
-You can [find a more complete example for SimSiam here.](https://docs.lightly.ai/examples/simsiam.html)
+You can [find a more complete example for SimSiam here.](https://docs.lightly.ai/self-supervised-learning/examples/simsiam.html)
 
 
 Use PyTorch Lightning to train the model:
@@ -204,14 +204,14 @@ trainer.fit(
 
 We provide proper multi-GPU training with distributed gather and synchronized BatchNorm.
 
-[Have a look at our docs regarding distributed training](https://docs.lightly.ai/getting_started/distributed_training.html)
+[Have a look at our docs regarding distributed training](https://docs.lightly.ai/self-supervised-learning/getting_started/distributed_training.html)
 
 
 
 ### Benchmarks
 
 Currently implemented models and their accuracy on cifar10 and imagenette. All models have been evaluated using kNN. We report the max test accuracy over the epochs as well as the maximum GPU memory consumption. All models in this benchmark use the same augmentations as well as the same ResNet-18 backbone. Training precision is set to FP32 and SGD is used as an optimizer with cosineLR.
-One epoch on cifar10 takes ~35 seconds on a V100 GPU. [Learn more about the cifar10 and imagenette benchmark here](https://docs.lightly.ai/getting_started/benchmarks.html)
+One epoch on cifar10 takes ~35 seconds on a V100 GPU. [Learn more about the cifar10 and imagenette benchmark here](https://docs.lightly.ai/self-supervised-learning/getting_started/benchmarks.html)
 
 #### ImageNette
 
@@ -246,7 +246,7 @@ One epoch on cifar10 takes ~35 seconds on a V100 GPU. [Learn more about the cifa
 
 ## Terminology
 
-Below you can see a schematic overview of the different concepts present in the lightly Python package. The terms in bold are explained in more detail in our [documentation](https://docs.lightly.ai).
+Below you can see a schematic overview of the different concepts present in the lightly Python package. The terms in bold are explained in more detail in our [documentation](https://docs.lightly.ai/self-supervised-learning/).
 
 <img src="/docs/source/getting_started/images/lightly_overview.png" alt="Overview of the lightly pip package"/></a>
 

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -183,4 +183,4 @@ hydra:
       Use self-supervised methods to understand and filter raw image data:
 
       Website: https://www.lightly.ai
-      Documentation: https://docs.lightly.ai/getting_started/command_line_tool.html
+      Documentation: https://docs.lightly.ai/self-supervised-learning/getting_started/command_line_tool.html

--- a/lightly/models/__init__.py
+++ b/lightly/models/__init__.py
@@ -5,7 +5,7 @@ lightly version 1.3.0. Instead, use low-level building blocks to build the
 models yourself.
 
 Example implementations for all models can be found here:
-`Model Examples <https://docs.lightly.ai/examples/models.html>`_
+`Model Examples <https://docs.lightly.ai/self-supervised-learning/examples/models.html>`_
 
 The package contains an implementation of the commonly used ResNet and
 adaptations of the architecture which make self-supervised learning simpler.

--- a/lightly/models/barlowtwins.py
+++ b/lightly/models/barlowtwins.py
@@ -35,11 +35,13 @@ class BarlowTwins(nn.Module):
 
     """
 
-    def __init__(self,
-                 backbone: nn.Module,
-                 num_ftrs: int = 2048,
-                 proj_hidden_dim: int = 8192,
-                 out_dim: int = 8192):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        num_ftrs: int = 2048,
+        proj_hidden_dim: int = 8192,
+        out_dim: int = 8192,
+    ):
 
         super(BarlowTwins, self).__init__()
 
@@ -49,21 +51,21 @@ class BarlowTwins(nn.Module):
         self.out_dim = out_dim
 
         self.projection_mlp = BarlowTwinsProjectionHead(
-            num_ftrs,
-            proj_hidden_dim,
-            out_dim
+            num_ftrs, proj_hidden_dim, out_dim
         )
 
-        warnings.warn(Warning(
-            'The high-level building block BarlowTwins will be deprecated in version 1.3.0. '
-            + 'Use low-level building blocks instead. '
-            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
-            PendingDeprecationWarning)
+        warnings.warn(
+            Warning(
+                "The high-level building block BarlowTwins will be deprecated in version 1.3.0. "
+                + "Use low-level building blocks instead. "
+                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+            ),
+            PendingDeprecationWarning,
+        )
 
-    def forward(self,
-                x0: torch.Tensor,
-                x1: torch.Tensor = None,
-                return_features: bool = False):
+    def forward(
+        self, x0: torch.Tensor, x1: torch.Tensor = None, return_features: bool = False
+    ):
 
         """Forward pass through BarlowTwins.
 

--- a/lightly/models/byol.py
+++ b/lightly/models/byol.py
@@ -23,7 +23,7 @@ def _get_byol_mlp(num_ftrs: int, hidden_dim: int, out_dim: int):
         nn.Linear(num_ftrs, hidden_dim),
         nn.BatchNorm1d(hidden_dim),
         nn.ReLU(),
-        nn.Linear(hidden_dim, out_dim)
+        nn.Linear(hidden_dim, out_dim),
     ]
     return nn.Sequential(*modules)
 
@@ -44,12 +44,14 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
             Momentum for the momentum update of encoder.
     """
 
-    def __init__(self,
-                 backbone: nn.Module,
-                 num_ftrs: int = 2048,
-                 hidden_dim: int = 4096,
-                 out_dim: int = 256,
-                 m: float = 0.9):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        num_ftrs: int = 2048,
+        hidden_dim: int = 4096,
+        out_dim: int = 256,
+        m: float = 0.9,
+    ):
 
         super(BYOL, self).__init__()
 
@@ -63,15 +65,16 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
         self._init_momentum_encoder()
         self.m = m
 
-        warnings.warn(Warning(
-            'The high-level building block BYOL will be deprecated in version 1.3.0. '
-            + 'Use low-level building blocks instead. '
-            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
-            PendingDeprecationWarning)
+        warnings.warn(
+            Warning(
+                "The high-level building block BYOL will be deprecated in version 1.3.0. "
+                + "Use low-level building blocks instead. "
+                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+            ),
+            PendingDeprecationWarning,
+        )
 
-    def _forward(self,
-                 x0: torch.Tensor,
-                 x1: torch.Tensor = None):
+    def _forward(self, x0: torch.Tensor, x1: torch.Tensor = None):
         """Forward pass through the encoder and the momentum encoder.
 
         Performs the momentum update, extracts features with the backbone and
@@ -86,9 +89,9 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
                 Tensor of shape bsz x channels x W x H.
 
         Returns:
-            The output proejction of x0 and (if x1 is not None) the output 
+            The output proejction of x0 and (if x1 is not None) the output
             projection of x1.
-        
+
         Examples:
             >>> # single input, single output
             >>> out = model._forward(x)
@@ -113,19 +116,18 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
 
             f1 = self.momentum_backbone(x1).flatten(start_dim=1)
             out1 = self.momentum_projection_head(f1)
-        
+
         return out0, out1
 
-    def forward(self,
-                x0: torch.Tensor,
-                x1: torch.Tensor,
-                return_features: bool = False):
+    def forward(
+        self, x0: torch.Tensor, x1: torch.Tensor, return_features: bool = False
+    ):
         """Symmetrizes the forward pass (see _forward).
 
         Performs two forward passes, once where x0 is passed through the encoder
         and x1 through the momentum encoder and once the other way around.
 
-        Note that this model currently requires two inputs for the forward pass 
+        Note that this model currently requires two inputs for the forward pass
         (x0 and x1) which correspond to the two augmentations.
         Furthermore, `the return_features` argument does not work yet.
 
@@ -135,7 +137,7 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
             x1:
                 Tensor of shape bsz x channels x W x H.
 
-        Returns: 
+        Returns:
             A tuple out0, out1, where out0 and out1 are tuples containing the
             predictions and projections of x0 and x1: out0 = (z0, p0) and
             out1 = (z1, p1).
@@ -152,13 +154,13 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
         """
 
         if x0 is None:
-            raise ValueError('x0 must not be None!')
+            raise ValueError("x0 must not be None!")
         if x1 is None:
-            raise ValueError('x1 must not be None!')
+            raise ValueError("x1 must not be None!")
 
         if not all([s0 == s1 for s0, s1 in zip(x0.shape, x1.shape)]):
             raise ValueError(
-                f'x0 and x1 must have same shape but got shapes {x0.shape} and {x1.shape}!'
+                f"x0 and x1 must have same shape but got shapes {x0.shape} and {x1.shape}!"
             )
 
         p0, z1 = self._forward(x0, x1)

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -15,7 +15,7 @@ from lightly.models.modules import MoCoProjectionHead
 class MoCo(nn.Module, _MomentumEncoderMixin):
     """Implementation of the MoCo (Momentum Contrast)[0] architecture.
 
-    Recommended loss: :py:class:`lightly.loss.ntx_ent_loss.NTXentLoss` with 
+    Recommended loss: :py:class:`lightly.loss.ntx_ent_loss.NTXentLoss` with
     a memory bank.
 
     [0] MoCo, 2020, https://arxiv.org/abs/1911.05722
@@ -32,12 +32,14 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
 
     """
 
-    def __init__(self,
-                 backbone: nn.Module,
-                 num_ftrs: int = 32,
-                 out_dim: int = 128,
-                 m: float = 0.999,
-                 batch_shuffle: bool = False):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        num_ftrs: int = 32,
+        out_dim: int = 128,
+        m: float = 0.999,
+        batch_shuffle: bool = False,
+    ):
 
         super(MoCo, self).__init__()
 
@@ -52,19 +54,21 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
         # initialize momentum features and momentum projection head
         self._init_momentum_encoder()
 
-        warnings.warn(Warning(
-            'The high-level building block MoCo will be deprecated in version 1.3.0. '
-            + 'Use low-level building blocks instead. '
-            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
-            PendingDeprecationWarning)
+        warnings.warn(
+            Warning(
+                "The high-level building block MoCo will be deprecated in version 1.3.0. "
+                + "Use low-level building blocks instead. "
+                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+            ),
+            PendingDeprecationWarning,
+        )
 
-    def forward(self,
-                x0: torch.Tensor,
-                x1: torch.Tensor = None,
-                return_features: bool = False):
+    def forward(
+        self, x0: torch.Tensor, x1: torch.Tensor = None, return_features: bool = False
+    ):
         """Embeds and projects the input image.
 
-        Performs the momentum update, extracts features with the backbone and 
+        Performs the momentum update, extracts features with the backbone and
         applies the projection head to the output space. If both x0 and x1 are
         not None, both will be passed through the backbone and projection head.
         If x1 is None, only x0 will be forwarded.
@@ -85,8 +89,8 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
 
         Examples:
             >>> # single input, single output
-            >>> out = model(x) 
-            >>> 
+            >>> out = model(x)
+            >>>
             >>> # single input with return_features=True
             >>> out, f = model(x, return_features=True)
             >>>
@@ -98,7 +102,7 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
 
         """
         self._momentum_update(self.m)
-        
+
         # forward pass of first input x0
         f0 = self.backbone(x0).flatten(start_dim=1)
         out0 = self.projection_head(f0)
@@ -121,7 +125,7 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
             # run x1 through momentum encoder
             f1 = self.momentum_backbone(x1).flatten(start_dim=1)
             out1 = self.momentum_projection_head(f1).detach()
-        
+
             # unshuffle for batchnorm
             if self.batch_shuffle:
                 f1 = self._batch_unshuffle(f1, shuffle)

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -28,26 +28,25 @@ class SimCLR(nn.Module):
 
     """
 
-    def __init__(self,
-                 backbone: nn.Module,
-                 num_ftrs: int = 32,
-                 out_dim: int = 128):
+    def __init__(self, backbone: nn.Module, num_ftrs: int = 32, out_dim: int = 128):
 
         super(SimCLR, self).__init__()
 
         self.backbone = backbone
         self.projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
 
-        warnings.warn(Warning(
-            'The high-level building block SimCLR will be deprecated in version 1.3.0. '
-            + 'Use low-level building blocks instead. '
-            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
-            PendingDeprecationWarning)
+        warnings.warn(
+            Warning(
+                "The high-level building block SimCLR will be deprecated in version 1.3.0. "
+                + "Use low-level building blocks instead. "
+                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+            ),
+            PendingDeprecationWarning,
+        )
 
-    def forward(self,
-                x0: torch.Tensor,
-                x1: torch.Tensor = None,
-                return_features: bool = False):
+    def forward(
+        self, x0: torch.Tensor, x1: torch.Tensor = None, return_features: bool = False
+    ):
         """Embeds and projects the input images.
 
         Extracts features with the backbone and applies the projection
@@ -71,8 +70,8 @@ class SimCLR(nn.Module):
 
         Examples:
             >>> # single input, single output
-            >>> out = model(x) 
-            >>> 
+            >>> out = model(x)
+            >>>
             >>> # single input with return_features=True
             >>> out, f = model(x, return_features=True)
             >>>
@@ -83,7 +82,7 @@ class SimCLR(nn.Module):
             >>> (out0, f0), (out1, f1) = model(x0, x1, return_features=True)
 
         """
-        
+
         # forward pass of first input x0
         f0 = self.backbone(x0).flatten(start_dim=1)
         out0 = self.projection_head(f0)

--- a/lightly/models/simsiam.py
+++ b/lightly/models/simsiam.py
@@ -35,12 +35,14 @@ class SimSiam(nn.Module):
 
     """
 
-    def __init__(self,
-                 backbone: nn.Module,
-                 num_ftrs: int = 2048,
-                 proj_hidden_dim: int = 2048,
-                 pred_hidden_dim: int = 512,
-                 out_dim: int = 2048):
+    def __init__(
+        self,
+        backbone: nn.Module,
+        num_ftrs: int = 2048,
+        proj_hidden_dim: int = 2048,
+        pred_hidden_dim: int = 512,
+        out_dim: int = 2048,
+    ):
 
         super(SimSiam, self).__init__()
 
@@ -62,16 +64,18 @@ class SimSiam(nn.Module):
             out_dim,
         )
 
-        warnings.warn(Warning(
-            'The high-level building block SimSiam will be deprecated in version 1.3.0. '
-            + 'Use low-level building blocks instead. '
-            + 'See https://docs.lightly.ai/lightly.models.html for more information'),
-            PendingDeprecationWarning)
-        
-    def forward(self, 
-                x0: torch.Tensor, 
-                x1: torch.Tensor = None,
-                return_features: bool = False):
+        warnings.warn(
+            Warning(
+                "The high-level building block SimSiam will be deprecated in version 1.3.0. "
+                + "Use low-level building blocks instead. "
+                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+            ),
+            PendingDeprecationWarning,
+        )
+
+    def forward(
+        self, x0: torch.Tensor, x1: torch.Tensor = None, return_features: bool = False
+    ):
         """Forward pass through SimSiam.
 
         Extracts features with the backbone and applies the projection
@@ -92,11 +96,11 @@ class SimSiam(nn.Module):
             the output prediction and projection of x1. If return_features is
             True, the output for each x is a tuple (out, f) where f are the
             features before the projection head.
-            
+
         Examples:
             >>> # single input, single output
-            >>> out = model(x) 
-            >>> 
+            >>> out = model(x)
+            >>>
             >>> # single input with return_features=True
             >>> out, f = model(x, return_features=True)
             >>>
@@ -118,7 +122,7 @@ class SimSiam(nn.Module):
 
         if x1 is None:
             return out0
-        
+
         f1 = self.backbone(x1).flatten(start_dim=1)
         z1 = self.projection_mlp(f1)
         p1 = self.prediction_mlp(z1)


### PR DESCRIPTION
## Changes

- Update links in readme and code files to use the new link to the OSS repo documentation (https://docs.lightly.ai/self-supervised-learning/ instead of https://docs.lightly.ai)