### PR TITLE
Fix bug in SMoGProjectionHead()

### DIFF
--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -307,8 +307,8 @@ class SMoGProjectionHead(ProjectionHead):
                  hidden_dim: int = 2048,
                  output_dim: int = 128):
         super(SMoGProjectionHead, self).__init__([
-            (input_dim, hidden_dim, nn.BatchNorm1d(2048), nn.ReLU()),
-            (hidden_dim, output_dim, nn.BatchNorm1d(128, affine=False), None)
+            (input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()),
+            (hidden_dim, output_dim, nn.BatchNorm1d(output_dim, affine=False), None)
         ])
 
 


### PR DESCRIPTION
Fix bug in SMoGProjectionHead().

The current implementation has the number of BatchNorm1d nodes hard-coded, so if the number of hidden or output layers is modified, it will cause a bug.