### PR TITLE
Add list_datasource_permissions function to the api client.

### DIFF
--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import tqdm
 import warnings
-import re
 
 from lightly.openapi_generated.swagger_client.models.datasource_config import (
     DatasourceConfig,
@@ -20,9 +19,7 @@ from lightly.openapi_generated.swagger_client.models.datasource_processed_until_
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data import (
     DatasourceRawSamplesData,
 )
-from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_predictions_data import (
-    DatasourceRawSamplesPredictionsData,
-)
+from lightly.openapi_generated.swagger_client import DatasourceConfigVerifyDataErrors
 
 
 class _DatasourcesMixin:
@@ -590,4 +587,30 @@ class _DatasourcesMixin:
         return self._datasources_api.get_custom_embedding_file_read_url_from_datasource_by_dataset_id(
             self.dataset_id,
             filename,
+        )
+
+    def list_datasource_permissions(
+        self,
+    ) -> Dict[str, Union[bool, Optional[DatasourceConfigVerifyDataErrors]]]:
+        """List granted access permissions for the datasource set up with a dataset.
+
+        Returns a string dictionary, with each permission mapped to a boolean value,
+        see the example below. Additionally, there is the ``errors`` key. If there
+        are permission errors it maps to a dictionary from permission name to the
+        error message, otherwise the value is ``None``.
+
+        >>> from lightly.api import ApiWorkflowClient
+        >>> client = ApiWorkflowClient(
+        ...    token="MY_LIGHTLY_TOKEN", dataset_id="MY_DATASET_ID"
+        ... )
+        >>> client.list_datasource_permissions()
+        {'can_list': True,
+         'can_overwrite': True,
+         'can_read': True,
+         'can_write': True,
+         'errors': None}
+
+        """
+        return self._datasources_api.verify_datasource_by_dataset_id(
+            dataset_id=self.dataset_id,
         )


### PR DESCRIPTION
### What changed and why

Expose a function to check datasource permission. This was possible before only by using a private api.

### How was it tested

Manually in repl.

Generated docs:

<img width="873" alt="Screenshot 2023-01-06 at 13 02 09" src="https://user-images.githubusercontent.com/105644579/211009181-f8cf6825-e303-4b96-8727-dbea9b41045c.png">
