### PR TITLE
Fix export filenames and read-urls

### DIFF
--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -3,7 +3,6 @@ import io
 import warnings
 import os
 import tqdm
-import json
 from urllib.request import Request, urlopen
 from PIL import Image
 
@@ -401,14 +400,13 @@ class _DownloadDatasetMixin:
         read_urls = read_urls_string.split("\n")
         # The order of the fileNames and readUrls is guaranteed to be the same
         # by the API so we can simply zip them.
-        mappings = [
+        return [
             {
                 "fileName": filename,
                 "readUrl": read_url,
             }
             for filename, read_url in zip(filenames, read_urls, strict=True)
         ]
-        return mappings
 
     def export_filenames_and_read_urls_by_tag_name(
         self,

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -405,7 +405,7 @@ class _DownloadDatasetMixin:
                 "fileName": filename,
                 "readUrl": read_url,
             }
-            for filename, read_url in zip(filenames, read_urls, strict=True)
+            for filename, read_url in zip(filenames, read_urls)
         ]
 
     def export_filenames_and_read_urls_by_tag_name(

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -3,6 +3,7 @@ import io
 import warnings
 import os
 import tqdm
+import json
 from urllib.request import Request, urlopen
 from PIL import Image
 
@@ -13,8 +14,11 @@ from concurrent.futures.thread import ThreadPoolExecutor
 
 from lightly.api import download
 from lightly.api.bitmask import BitMask
-from lightly.openapi_generated.swagger_client import DatasetEmbeddingData, ImageType
-
+from lightly.openapi_generated.swagger_client import (
+    DatasetEmbeddingData,
+    ImageType,
+    FileNameFormat,
+)
 
 
 def _make_dir_and_save_image(output_dir: str, filename: str, img: Image):
@@ -377,12 +381,33 @@ class _DownloadDatasetMixin:
             A list of mappings of the samples filenames and readURLs within a certain tag.
 
         """
-        mappings = paginate_endpoint(
-            self._tags_api.export_tag_to_basic_filenames_and_read_urls,
-            page_size=20000,
+        # TODO (Philipp, 10.01.2023): Switch to the exportTagToBasicFilenamesAndReadUrls
+        # when the read-urls are fixed.
+        filenames_string = retry(
+            self._tags_api.export_tag_to_basic_filenames,
             dataset_id=self.dataset_id,
-            tag_id=tag_id
+            tag_id=tag_id,
+            file_name_format=FileNameFormat.NAME,
         )
+        read_urls_string = retry(
+            self._tags_api.export_tag_to_basic_filenames,
+            dataset_id=self.dataset_id,
+            tag_id=tag_id,
+            file_name_format=FileNameFormat.REDIRECTED_READ_URL,
+        )
+        # The endpoint exportTagToBasicFilenames returns a plain string so we
+        # have to split it by newlines in order to get the individual entries.
+        filenames = filenames_string.split("\n")
+        read_urls = read_urls_string.split("\n")
+        # The order of the fileNames and readUrls is guaranteed to be the same
+        # by the API so we can simply zip them.
+        mappings = [
+            {
+                "fileName": filename,
+                "readUrl": read_url,
+            }
+            for filename, read_url in zip(filenames, read_urls, strict=True)
+        ]
         return mappings
 
     def export_filenames_and_read_urls_by_tag_name(

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -451,7 +451,7 @@ class MockedTagsApi(TagsApi):
             ).to_dict() # temporary until we have a proper openapi generator
         ]
 
-    def export_tag_to_basic_filenames(self, dataset_id: str, tag_id: str) -> str:
+    def export_tag_to_basic_filenames(self, dataset_id: str, tag_id: str, **kwargs) -> str:
         return """
 IMG_2276_jpeg_jpg.rf.7411b1902c81bad8cdefd2cc4eb3a97b.jpg
 IMG_2285_jpeg_jpg.rf.4a93d99b9f0b6cccfb27bf2f4a13b99e.jpg


### PR DESCRIPTION
# Fix export filenames and read-urls

Switch to a different endpoint to get working read-urls for video frames.

I tested it manually on a dataset with video frames and the read-urls work as expected. Exmaple output:
```
[{'fileName': '00a2e3ca-5c856cde-4-mp4.png',
  'readUrl': 'https://censored-read-url.ai'}]

```