### PR TITLE
create PendingDeprecationWarning for upload_cli

### DIFF
--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -42,6 +42,12 @@ def _upload_cli(cfg, is_cli_call=True) -> Union[str, None]:
             None
 
     """
+    # TODO (Malte, 19.01,2023): Remove the _upload_cli completely
+    print_as_warning(
+        "PendingDeprecationWarning: Uploading via CLI is deprecated and will be removed soon! "
+        "Please use the Lightly Worker instead: https://docs.lightly.ai/docs/install-lightly\n"
+    )
+
     input_dir = cfg['input_dir']
     if input_dir and is_cli_call:
         input_dir = fix_input_path(input_dir)

--- a/lightly/cli/upload_cli.py
+++ b/lightly/cli/upload_cli.py
@@ -44,8 +44,8 @@ def _upload_cli(cfg, is_cli_call=True) -> Union[str, None]:
     """
     # TODO (Malte, 19.01,2023): Remove the _upload_cli completely
     print_as_warning(
-        "PendingDeprecationWarning: Uploading via CLI is deprecated and will be removed soon! "
-        "Please use the Lightly Worker instead: https://docs.lightly.ai/docs/install-lightly\n"
+        message="DeprecationWarning: Uploading via CLI is deprecated and will be removed soon! "
+        "Please use the Lightly Worker instead: https://docs.lightly.ai/docs/install-lightly\n",
     )
 
     input_dir = cfg['input_dir']


### PR DESCRIPTION
## Description

Print a `DeprecationWarning` to the console. This cannot be printed directly via `warnings.warn`, as `DeprecationWarnings` are not printed, I tried it out.

## Tests
![image](https://user-images.githubusercontent.com/20324507/212128911-310bc8c9-9306-4e57-b0a3-850897b99cba.jpeg)
