### PR TITLE
Guarin lig 2221 add tag info to runs pip

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -22,6 +22,7 @@ from lightly.openapi_generated.swagger_client import (
     SelectionConfigEntry,
     SelectionConfigEntryInput,
     SelectionConfigEntryStrategy,
+    TagData,
 )
 from lightly.openapi_generated.swagger_client.models.docker_run_artifact_type import DockerRunArtifactType
 from lightly.openapi_generated.swagger_client.rest import ApiException
@@ -727,6 +728,34 @@ class _ComputeWorkerMixin:
             output_path=output_path,
             timeout=timeout,
         )
+
+    def get_compute_worker_run_tags(self, run_id: str) -> List[TagData]:
+        """Returns all tags from a run for the current dataset.
+
+        Only returns tags for runs made with Lightly Worker version >=2.4.2.
+
+        Args:
+            run_id:
+                Run id from which to return tags.
+
+        Returns:
+            List of tags created by the run. The tags are ordered by creation date from
+            newest to oldest.
+
+        Examples:
+            >>> # Get filenames from last run.
+            >>>
+            >>> from lightly.api import ApiWorkflowClient
+            >>> client = ApiWorkflowClient(
+            >>>     token="MY_LIGHTLY_TOKEN", dataset_id="MY_DATASET_ID"
+            >>> )
+            >>> tags = client.get_tags_by_run_id(run_id="MY_LAST_RUN_ID")
+            >>> filenames = client.export_filenames_by_tag_name(tag_name=tags[0].name)
+
+        """
+        tags = self._compute_worker_api.get_docker_run_tags(run_id=run_id)
+        tags_in_dataset = [tag for tag in tags if tag.dataset_id == self.dataset_id]
+        return tags_in_dataset
 
 
     def _download_compute_worker_run_artifact_by_type(

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -749,7 +749,7 @@ class _ComputeWorkerMixin:
             >>> client = ApiWorkflowClient(
             >>>     token="MY_LIGHTLY_TOKEN", dataset_id="MY_DATASET_ID"
             >>> )
-            >>> tags = client.get_tags_by_run_id(run_id="MY_LAST_RUN_ID")
+            >>> tags = client.get_compute_worker_run_tags(run_id="MY_LAST_RUN_ID")
             >>> filenames = client.export_filenames_by_tag_name(tag_name=tags[0].name)
 
         """

--- a/lightly/openapi_generated/swagger_client/api/docker_api.py
+++ b/lightly/openapi_generated/swagger_client/api/docker_api.py
@@ -1415,6 +1415,101 @@ class DockerApi(object):
             _request_timeout=params.get('_request_timeout'),
             collection_formats=collection_formats)
 
+    def get_docker_run_tags(self, run_id, **kwargs):  # noqa: E501
+        """get_docker_run_tags  # noqa: E501
+
+        Gets all tags which were created from a docker run by docker run id.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_docker_run_tags(run_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param MongoObjectID run_id: ObjectId of the docker run (required)
+        :return: list[TagData]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async_req'):
+            return self.get_docker_run_tags_with_http_info(run_id, **kwargs)  # noqa: E501
+        else:
+            (data) = self.get_docker_run_tags_with_http_info(run_id, **kwargs)  # noqa: E501
+            return data
+
+    def get_docker_run_tags_with_http_info(self, run_id, **kwargs):  # noqa: E501
+        """get_docker_run_tags  # noqa: E501
+
+        Gets all tags which were created from a docker run by docker run id.  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+        >>> thread = api.get_docker_run_tags_with_http_info(run_id, async_req=True)
+        >>> result = thread.get()
+
+        :param async_req bool
+        :param MongoObjectID run_id: ObjectId of the docker run (required)
+        :return: list[TagData]
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+
+        all_params = ['run_id']  # noqa: E501
+        all_params.append('async_req')
+        all_params.append('_return_http_data_only')
+        all_params.append('_preload_content')
+        all_params.append('_request_timeout')
+
+        params = locals()
+        for key, val in six.iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_docker_run_tags" % key
+                )
+            params[key] = val
+        del params['kwargs']
+        # verify the required parameter 'run_id' is set
+        if self.api_client.client_side_validation and ('run_id' not in params or
+                                                       params['run_id'] is None):  # noqa: E501
+            raise ValueError("Missing the required parameter `run_id` when calling `get_docker_run_tags`")  # noqa: E501
+
+        collection_formats = {}
+
+        path_params = {}
+        if 'run_id' in params:
+            path_params['runId'] = params['run_id']  # noqa: E501
+
+        query_params = []
+
+        header_params = {}
+
+        form_params = []
+        local_var_files = {}
+
+        body_params = None
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # Authentication setting
+        auth_settings = ['ApiKeyAuth', 'auth0Bearer']  # noqa: E501
+
+        return self.api_client.call_api(
+            '/v1/docker/runs/{runId}/tags', 'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='list[TagData]',  # noqa: E501
+            auth_settings=auth_settings,
+            async_req=params.get('async_req'),
+            _return_http_data_only=params.get('_return_http_data_only'),
+            _preload_content=params.get('_preload_content', True),
+            _request_timeout=params.get('_request_timeout'),
+            collection_formats=collection_formats)
+
     def get_docker_runs(self, **kwargs):  # noqa: E501
         """get_docker_runs  # noqa: E501
 

--- a/lightly/openapi_generated/swagger_client/models/initial_tag_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/initial_tag_create_request.py
@@ -35,16 +35,18 @@ class InitialTagCreateRequest(object):
     swagger_types = {
         'name': 'TagName',
         'creator': 'TagCreator',
-        'img_type': 'ImageType'
+        'img_type': 'ImageType',
+        'run_id': 'MongoObjectID'
     }
 
     attribute_map = {
         'name': 'name',
         'creator': 'creator',
-        'img_type': 'imgType'
+        'img_type': 'imgType',
+        'run_id': 'runId'
     }
 
-    def __init__(self, name=None, creator=None, img_type=None, _configuration=None):  # noqa: E501
+    def __init__(self, name=None, creator=None, img_type=None, run_id=None, _configuration=None):  # noqa: E501
         """InitialTagCreateRequest - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -53,6 +55,7 @@ class InitialTagCreateRequest(object):
         self._name = None
         self._creator = None
         self._img_type = None
+        self._run_id = None
         self.discriminator = None
 
         if name is not None:
@@ -60,6 +63,8 @@ class InitialTagCreateRequest(object):
         if creator is not None:
             self.creator = creator
         self.img_type = img_type
+        if run_id is not None:
+            self.run_id = run_id
 
     @property
     def name(self):
@@ -125,6 +130,27 @@ class InitialTagCreateRequest(object):
             raise ValueError("Invalid value for `img_type`, must not be `None`")  # noqa: E501
 
         self._img_type = img_type
+
+    @property
+    def run_id(self):
+        """Gets the run_id of this InitialTagCreateRequest.  # noqa: E501
+
+
+        :return: The run_id of this InitialTagCreateRequest.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._run_id
+
+    @run_id.setter
+    def run_id(self, run_id):
+        """Sets the run_id of this InitialTagCreateRequest.
+
+
+        :param run_id: The run_id of this InitialTagCreateRequest.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._run_id = run_id
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/lightly/openapi_generated/swagger_client/models/tag_arithmetics_request.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_arithmetics_request.py
@@ -37,7 +37,8 @@ class TagArithmeticsRequest(object):
         'tag_id2': 'MongoObjectID',
         'operation': 'TagArithmeticsOperation',
         'new_tag_name': 'TagName',
-        'creator': 'TagCreator'
+        'creator': 'TagCreator',
+        'run_id': 'MongoObjectID'
     }
 
     attribute_map = {
@@ -45,10 +46,11 @@ class TagArithmeticsRequest(object):
         'tag_id2': 'tagId2',
         'operation': 'operation',
         'new_tag_name': 'newTagName',
-        'creator': 'creator'
+        'creator': 'creator',
+        'run_id': 'runId'
     }
 
-    def __init__(self, tag_id1=None, tag_id2=None, operation=None, new_tag_name=None, creator=None, _configuration=None):  # noqa: E501
+    def __init__(self, tag_id1=None, tag_id2=None, operation=None, new_tag_name=None, creator=None, run_id=None, _configuration=None):  # noqa: E501
         """TagArithmeticsRequest - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -59,6 +61,7 @@ class TagArithmeticsRequest(object):
         self._operation = None
         self._new_tag_name = None
         self._creator = None
+        self._run_id = None
         self.discriminator = None
 
         self.tag_id1 = tag_id1
@@ -68,6 +71,8 @@ class TagArithmeticsRequest(object):
             self.new_tag_name = new_tag_name
         if creator is not None:
             self.creator = creator
+        if run_id is not None:
+            self.run_id = run_id
 
     @property
     def tag_id1(self):
@@ -179,6 +184,27 @@ class TagArithmeticsRequest(object):
         """
 
         self._creator = creator
+
+    @property
+    def run_id(self):
+        """Gets the run_id of this TagArithmeticsRequest.  # noqa: E501
+
+
+        :return: The run_id of this TagArithmeticsRequest.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._run_id
+
+    @run_id.setter
+    def run_id(self, run_id):
+        """Sets the run_id of this TagArithmeticsRequest.
+
+
+        :param run_id: The run_id of this TagArithmeticsRequest.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._run_id = run_id
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/lightly/openapi_generated/swagger_client/models/tag_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_create_request.py
@@ -40,7 +40,8 @@ class TagCreateRequest(object):
         'bit_mask_data': 'TagBitMaskData',
         'tot_size': 'int',
         'creator': 'TagCreator',
-        'changes': 'TagChangeData'
+        'changes': 'TagChangeData',
+        'run_id': 'MongoObjectID'
     }
 
     attribute_map = {
@@ -51,10 +52,11 @@ class TagCreateRequest(object):
         'bit_mask_data': 'bitMaskData',
         'tot_size': 'totSize',
         'creator': 'creator',
-        'changes': 'changes'
+        'changes': 'changes',
+        'run_id': 'runId'
     }
 
-    def __init__(self, name=None, prev_tag_id=None, query_tag_id=None, preselected_tag_id=None, bit_mask_data=None, tot_size=None, creator=None, changes=None, _configuration=None):  # noqa: E501
+    def __init__(self, name=None, prev_tag_id=None, query_tag_id=None, preselected_tag_id=None, bit_mask_data=None, tot_size=None, creator=None, changes=None, run_id=None, _configuration=None):  # noqa: E501
         """TagCreateRequest - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -68,6 +70,7 @@ class TagCreateRequest(object):
         self._tot_size = None
         self._creator = None
         self._changes = None
+        self._run_id = None
         self.discriminator = None
 
         self.name = name
@@ -82,6 +85,8 @@ class TagCreateRequest(object):
             self.creator = creator
         if changes is not None:
             self.changes = changes
+        if run_id is not None:
+            self.run_id = run_id
 
     @property
     def name(self):
@@ -258,6 +263,27 @@ class TagCreateRequest(object):
         """
 
         self._changes = changes
+
+    @property
+    def run_id(self):
+        """Gets the run_id of this TagCreateRequest.  # noqa: E501
+
+
+        :return: The run_id of this TagCreateRequest.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._run_id
+
+    @run_id.setter
+    def run_id(self, run_id):
+        """Sets the run_id of this TagCreateRequest.
+
+
+        :param run_id: The run_id of this TagCreateRequest.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._run_id = run_id
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/lightly/openapi_generated/swagger_client/models/tag_data.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_data.py
@@ -43,7 +43,8 @@ class TagData(object):
         'tot_size': 'int',
         'created_at': 'Timestamp',
         'last_modified_at': 'Timestamp',
-        'changes': 'TagChangeData'
+        'changes': 'TagChangeData',
+        'run_id': 'MongoObjectID'
     }
 
     attribute_map = {
@@ -57,10 +58,11 @@ class TagData(object):
         'tot_size': 'totSize',
         'created_at': 'createdAt',
         'last_modified_at': 'lastModifiedAt',
-        'changes': 'changes'
+        'changes': 'changes',
+        'run_id': 'runId'
     }
 
-    def __init__(self, id=None, dataset_id=None, prev_tag_id=None, query_tag_id=None, preselected_tag_id=None, name=None, bit_mask_data=None, tot_size=None, created_at=None, last_modified_at=None, changes=None, _configuration=None):  # noqa: E501
+    def __init__(self, id=None, dataset_id=None, prev_tag_id=None, query_tag_id=None, preselected_tag_id=None, name=None, bit_mask_data=None, tot_size=None, created_at=None, last_modified_at=None, changes=None, run_id=None, _configuration=None):  # noqa: E501
         """TagData - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -77,6 +79,7 @@ class TagData(object):
         self._created_at = None
         self._last_modified_at = None
         self._changes = None
+        self._run_id = None
         self.discriminator = None
 
         self.id = id
@@ -94,6 +97,8 @@ class TagData(object):
             self.last_modified_at = last_modified_at
         if changes is not None:
             self.changes = changes
+        if run_id is not None:
+            self.run_id = run_id
 
     @property
     def id(self):
@@ -339,6 +344,27 @@ class TagData(object):
         """
 
         self._changes = changes
+
+    @property
+    def run_id(self):
+        """Gets the run_id of this TagData.  # noqa: E501
+
+
+        :return: The run_id of this TagData.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._run_id
+
+    @run_id.setter
+    def run_id(self, run_id):
+        """Sets the run_id of this TagData.
+
+
+        :param run_id: The run_id of this TagData.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._run_id = run_id
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/lightly/openapi_generated/swagger_client/models/tag_upsize_request.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_upsize_request.py
@@ -34,15 +34,17 @@ class TagUpsizeRequest(object):
     """
     swagger_types = {
         'upsize_tag_name': 'TagName',
-        'upsize_tag_creator': 'TagCreator'
+        'upsize_tag_creator': 'TagCreator',
+        'run_id': 'MongoObjectID'
     }
 
     attribute_map = {
         'upsize_tag_name': 'upsizeTagName',
-        'upsize_tag_creator': 'upsizeTagCreator'
+        'upsize_tag_creator': 'upsizeTagCreator',
+        'run_id': 'runId'
     }
 
-    def __init__(self, upsize_tag_name=None, upsize_tag_creator=None, _configuration=None):  # noqa: E501
+    def __init__(self, upsize_tag_name=None, upsize_tag_creator=None, run_id=None, _configuration=None):  # noqa: E501
         """TagUpsizeRequest - a model defined in Swagger"""  # noqa: E501
         if _configuration is None:
             _configuration = Configuration()
@@ -50,10 +52,13 @@ class TagUpsizeRequest(object):
 
         self._upsize_tag_name = None
         self._upsize_tag_creator = None
+        self._run_id = None
         self.discriminator = None
 
         self.upsize_tag_name = upsize_tag_name
         self.upsize_tag_creator = upsize_tag_creator
+        if run_id is not None:
+            self.run_id = run_id
 
     @property
     def upsize_tag_name(self):
@@ -100,6 +105,27 @@ class TagUpsizeRequest(object):
             raise ValueError("Invalid value for `upsize_tag_creator`, must not be `None`")  # noqa: E501
 
         self._upsize_tag_creator = upsize_tag_creator
+
+    @property
+    def run_id(self):
+        """Gets the run_id of this TagUpsizeRequest.  # noqa: E501
+
+
+        :return: The run_id of this TagUpsizeRequest.  # noqa: E501
+        :rtype: MongoObjectID
+        """
+        return self._run_id
+
+    @run_id.setter
+    def run_id(self, run_id):
+        """Sets the run_id of this TagUpsizeRequest.
+
+
+        :param run_id: The run_id of this TagUpsizeRequest.  # noqa: E501
+        :type: MongoObjectID
+        """
+
+        self._run_id = run_id
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -601,7 +601,7 @@ def test_get_compute_worker_run_tags__multiple_tags(mocker: MockerFixture) -> No
     tag_1 = TagData(
         id="tag-1",
         dataset_id="dataset-0",
-        prev_tag_id=None,
+        prev_tag_id="tag-0",
         bit_mask_data="0x1",
         name="tag-1",
         tot_size=0,

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -26,16 +26,13 @@ from lightly.openapi_generated.swagger_client import (
     DockerWorkerConfig,
     DockerWorkerType,
     DockerRunArtifactData,
+    DockerRunArtifactType,
+    DockerRunData,
+    DockerRunScheduledData,
     DockerRunScheduledPriority,
     DockerRunScheduledState,
     DockerRunState,
-)
-from lightly.openapi_generated.swagger_client.models.docker_run_artifact_type import DockerRunArtifactType
-from lightly.openapi_generated.swagger_client.models.docker_run_data import (
-    DockerRunData,
-)
-from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_data import (
-    DockerRunScheduledData,
+    TagData,
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
@@ -556,6 +553,82 @@ def test_download_compute_worker_run_artifacts(mocker: MockerFixture) -> None:
     ]
     mock_download_compute_worker_run_artifact.assert_has_calls(calls=calls)
     assert mock_download_compute_worker_run_artifact.call_count == len(calls)
+
+def test_get_compute_worker_run_tags__no_tags(mocker: MockerFixture) -> None:
+    client = ApiWorkflowClient(token="123", dataset_id="dataset-0")
+    mock_compute_worker_api = mocker.create_autospec(DockerApi, spec_set=True).return_value
+    mock_compute_worker_api.get_docker_run_tags.return_value = []
+    client._compute_worker_api = mock_compute_worker_api
+    tags = client.get_compute_worker_run_tags(run_id="run-0")
+    assert len(tags) == 0
+    mock_compute_worker_api.get_docker_run_tags.assert_called_once_with(run_id="run-0")
+
+def test_get_compute_worker_run_tags__single_tag(mocker: MockerFixture) -> None:
+    client = ApiWorkflowClient(token="123", dataset_id="dataset-0")
+    mock_compute_worker_api = mocker.create_autospec(DockerApi, spec_set=True).return_value
+    mock_compute_worker_api.get_docker_run_tags.return_value = [
+        TagData(
+            id="tag-0",
+            dataset_id="dataset-0",
+            prev_tag_id=None,
+            bit_mask_data="0x1",
+            name="tag-0",
+            tot_size=0,
+            created_at=0,
+            changes=dict(),
+            run_id="run-0",
+        )
+    ]
+    client._compute_worker_api = mock_compute_worker_api
+    tags = client.get_compute_worker_run_tags(run_id="run-0")
+    assert len(tags) == 1
+    mock_compute_worker_api.get_docker_run_tags.assert_called_once_with(run_id="run-0")
+
+def test_get_compute_worker_run_tags__multiple_tags(mocker: MockerFixture) -> None:
+    client = ApiWorkflowClient(token="123", dataset_id="dataset-0")
+    mock_compute_worker_api = mocker.create_autospec(DockerApi, spec_set=True).return_value
+    tag_0 = TagData(
+        id="tag-0",
+        dataset_id="dataset-0",
+        prev_tag_id=None,
+        bit_mask_data="0x1",
+        name="tag-0",
+        tot_size=0,
+        created_at=0,
+        changes=dict(),
+        run_id="run-0",
+    )
+    tag_1 = TagData(
+        id="tag-1",
+        dataset_id="dataset-0",
+        prev_tag_id=None,
+        bit_mask_data="0x1",
+        name="tag-1",
+        tot_size=0,
+        created_at=1,
+        changes=dict(),
+        run_id="run-0",
+    )
+    # tag from a different dataset
+    tag_2 = TagData(
+        id="tag-2",
+        dataset_id="dataset-1",
+        prev_tag_id=None,
+        bit_mask_data="0x1",
+        name="tag-2",
+        tot_size=0,
+        created_at=2,
+        changes=dict(),
+        run_id="run-0",
+    )
+    # tags are returned ordered by decreasing creation date
+    mock_compute_worker_api.get_docker_run_tags.return_value = [tag_2, tag_1, tag_0]
+    client._compute_worker_api = mock_compute_worker_api
+    tags = client.get_compute_worker_run_tags(run_id="run-0")
+    assert len(tags) == 2
+    assert tags[0] == tag_1
+    assert tags[1] == tag_0
+    mock_compute_worker_api.get_docker_run_tags.assert_called_once_with(run_id="run-0")
 
 def test__download_compute_worker_run_artifact_by_type(
     mocker: MockerFixture,


### PR DESCRIPTION
## Changes

* Add `get_compute_worker_run_tags` endpoint

## How was it tested?

* Added unit tests
* Manual tests