### PR TITLE
Update LightningModule import

### DIFF
--- a/.github/workflows/weekly_dependency_test.yml
+++ b/.github/workflows/weekly_dependency_test.yml
@@ -7,7 +7,7 @@ name: Weekly Dependency Test
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 22 * * mon' # each Monday night, at 22:00 UTC
+    - cron: '0 22 * * THU' # each Thursday night, at 22:00 UTC
 
 jobs:
   test_fresh_install:
@@ -27,8 +27,8 @@ jobs:
       id: run_tests
       run: |
         pytest -n auto
-      continue-on-error: true
     - name: Slack notification
+      if: always()
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_NIGHTLY }}

--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -5,16 +5,14 @@
 import copy
 import os
 
-
 import omegaconf
 from omegaconf import DictConfig
-import pytorch_lightning as pl
-import pytorch_lightning.core.lightning as lightning
+from pytorch_lightning import LightningModule, Trainer
 
 from lightly.embedding import callbacks
 
 
-class BaseEmbedding(lightning.LightningModule):
+class BaseEmbedding(LightningModule):
     """All trainable embeddings must inherit from BaseEmbedding.
 
     """
@@ -109,7 +107,7 @@ class BaseEmbedding(lightning.LightningModule):
             with omegaconf.open_dict(trainer_config_copy):
                 del trainer_config_copy["weights_summary"]
 
-        trainer = pl.Trainer(**trainer_config_copy, callbacks=trainer_callbacks)
+        trainer = Trainer(**trainer_config_copy, callbacks=trainer_callbacks)
 
         trainer.fit(self)
 

--- a/lightly/utils/benchmarking.py
+++ b/lightly/utils/benchmarking.py
@@ -4,11 +4,11 @@
 # All Rights Reserved
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
-import torch.distributed as dist 
-from torch.utils.data import DataLoader
 import torch.nn.functional as F
-import pytorch_lightning as pl
+from pytorch_lightning import LightningModule
+from torch.utils.data import DataLoader
 
 # code for kNN prediction from here:
 # https://colab.research.google.com/github/facebookresearch/moco/blob/colab-notebook/colab/moco_cifar10_demo.ipynb
@@ -80,7 +80,7 @@ def knn_predict(feature: torch.Tensor,
     return pred_labels
 
 
-class BenchmarkModule(pl.LightningModule):
+class BenchmarkModule(LightningModule):
     """A PyTorch Lightning Module for automated kNN callback
 
     At the end of every training epoch we create a feature bank by feeding the


### PR DESCRIPTION
## Changes

* Import `LightningModule` from `pytorch_lightning` instead of `pytorch_lightning.core.lightning`
* Fix exit status of weekly dependency test action
* Move weekly dependency from Tuesday to Thursday

Old failing action with broken exit status: https://github.com/lightly-ai/lightly/actions/runs/3990939451/jobs/6845182937
New failing action with fixed exit status: https://github.com/lightly-ai/lightly/commit/0c147d32c1fd4736aff4fe214e42688a648ff2f5/checks
New passing action with fixed exit status and fixed imports: https://github.com/lightly-ai/lightly/actions/runs/3996313813
