### PR TITLE
add user agent header with lightly version

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -97,7 +97,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
 
         configuration = get_api_client_configuration(token=token)
         self.api_client = ApiClient(configuration=configuration)
-        self.user_agent = f"Lightly/{__version__}/python ({platform.platform()})"
+        self.api_client.user_agent = f"Lightly/{__version__}/python ({platform.platform()})"
         self.set_request_timeout(DEFAULT_API_TIMEOUT)
 
         self.token = configuration.api_key["token"]

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -97,7 +97,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
 
         configuration = get_api_client_configuration(token=token)
         self.api_client = ApiClient(configuration=configuration)
-        self.api_client.user_agent = f"Lightly/{__version__}/python/{platform.python_version()} (platform; {platform.platform()})"
+        self.api_client.user_agent = f"Lightly/{__version__} ({platform.system()}/{platform.release()}; {platform.platform()}; {platform.processor()};) python/{platform.python_version()}"
         self.set_request_timeout(DEFAULT_API_TIMEOUT)
 
         self.token = configuration.api_key["token"]

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -97,7 +97,7 @@ class ApiWorkflowClient(_UploadEmbeddingsMixin,
 
         configuration = get_api_client_configuration(token=token)
         self.api_client = ApiClient(configuration=configuration)
-        self.api_client.user_agent = f"Lightly/{__version__}/python ({platform.platform()})"
+        self.api_client.user_agent = f"Lightly/{__version__}/python/{platform.python_version()} (platform; {platform.platform()})"
         self.set_request_timeout(DEFAULT_API_TIMEOUT)
 
         self.token = configuration.api_key["token"]

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -1037,7 +1037,6 @@ class MockedApiWorkflowClient(ApiWorkflowClient):
 
     def __init__(self, *args, **kwargs):
         lightly.api.version_checking.VersioningApi = MockedVersioningApi
-
         ApiWorkflowClient.__init__(self, *args, **kwargs)
 
         self._selection_api = MockedSamplingsApi(api_client=self.api_client)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -987,13 +987,6 @@ class MockedComputeWorkerApi(DockerApi):
     def update_scheduled_docker_run_state_by_id(self, body, dataset_id, worker_id, scheduled_id, **kwargs):
         raise NotImplementedError()
 
-class MockedVersioningApi(VersioningApi):
-    def get_latest_pip_version(self, **kwargs):
-        return "1.2.8"
-
-    def get_minimum_compatible_pip_version(self, **kwargs):
-        return "1.2.1"
-
 
 class MockedQuotaApi(QuotaApi):
     def get_quota_maximum_dataset_size(self, **kwargs):
@@ -1008,45 +1001,6 @@ def mocked_request_put(dst_url: str, data=IOBase) -> Response:
     response_ = Response()
     response_.status_code = 200
     return response_
-
-
-class MockedApiClient(ApiClient):
-    def request(
-        self,
-        method,
-        url,
-        query_params=None,
-        headers=None,
-        post_params=None,
-        body=None,
-        _preload_content=True,
-        _request_timeout=None,
-    ):
-        raise ValueError(
-            "ERROR: calling ApiClient.request(), but this should be mocked."
-        )
-
-    def call_api(
-        self,
-        resource_path,
-        method,
-        path_params=None,
-        query_params=None,
-        header_params=None,
-        body=None,
-        post_params=None,
-        files=None,
-        response_type=None,
-        auth_settings=None,
-        async_req=None,
-        _return_http_data_only=None,
-        collection_formats=None,
-        _preload_content=True,
-        _request_timeout=None,
-    ):
-        raise ValueError(
-            "ERROR: calling ApiClient.call_api(), but this should be mocked."
-        )
 
 
 class MockedAPICollaboration(CollaborationApi):
@@ -1075,8 +1029,7 @@ class MockedApiWorkflowClient(ApiWorkflowClient):
     n_embedding_rows_on_server = N_FILES_ON_SERVER
 
     def __init__(self, *args, **kwargs):
-        lightly.api.api_workflow_client.ApiClient = MockedApiClient
-        lightly.api.version_checking.VersioningApi = MockedVersioningApi
+
         ApiWorkflowClient.__init__(self, *args, **kwargs)
 
         self._selection_api = MockedSamplingsApi(api_client=self.api_client)

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -1036,6 +1036,7 @@ class MockedApiWorkflowClient(ApiWorkflowClient):
     n_embedding_rows_on_server = N_FILES_ON_SERVER
 
     def __init__(self, *args, **kwargs):
+        lightly.api.version_checking.VersioningApi = MockedVersioningApi
 
         ApiWorkflowClient.__init__(self, *args, **kwargs)
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -987,6 +987,13 @@ class MockedComputeWorkerApi(DockerApi):
     def update_scheduled_docker_run_state_by_id(self, body, dataset_id, worker_id, scheduled_id, **kwargs):
         raise NotImplementedError()
 
+class MockedVersioningApi(VersioningApi):
+    def get_latest_pip_version(self, **kwargs):
+        return "1.2.8"
+
+    def get_minimum_compatible_pip_version(self, **kwargs):
+        return "1.2.1"
+
 
 class MockedQuotaApi(QuotaApi):
     def get_quota_maximum_dataset_size(self, **kwargs):

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -95,6 +95,6 @@ def test_user_agent(mocker: MockerFixture) -> None:
     # and mocking it properly is complicated,
     # thus we just stop API call after the patched request function is called.
     with pytest.raises(TypeError, match="the JSON object must be str, bytes or bytearray, not MagicMock"):
-        client._mappings_api.get_sample_mappings_by_dataset_id(dataset_id="")
+        client._mappings_api.get_sample_mappings_by_dataset_id(dataset_id="", field="")
 
     assert patched_request.call_args.kwargs["headers"]["User-Agent"] == f"Lightly/{__version__}/python ({platform.platform()})"

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -84,16 +84,7 @@ class TestApiWorkflowClient(unittest.TestCase):
                     signed_write_url='',
                 )
 
-def test_user_agent_header(mocker: MockerFixture) -> None:
+def test_user_agent_header() -> None:
     client = ApiWorkflowClient(token="")
-    patched_request = mocker.patch.object(client._mappings_api.api_client, "request")
 
-    # We use get_sample_mappings_by_dataset_id as one test method to ensure that
-    # it includes the user agent in the header.
-    # After calling the patched request, we don't care about the RESTResponse
-    # and mocking it properly is complicated,
-    # thus we just stop API call after the patched request function is called.
-    with pytest.raises(TypeError, match="the JSON object must be str, bytes or bytearray, not MagicMock"):
-        client._mappings_api.get_sample_mappings_by_dataset_id(dataset_id="", field="")
-
-    assert patched_request.call_args.kwargs["headers"]["User-Agent"] == f"Lightly/{__version__}/python ({platform.platform()})"
+    assert client.api_client.user_agent == f"Lightly/{__version__}/python ({platform.platform()})"

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -2,11 +2,13 @@ import platform
 import unittest
 from unittest import mock
 
+import lightly
 import requests
 import os
 
+from pytest_mock import MockerFixture
+
 from lightly.api.api_workflow_client import ApiWorkflowClient, LIGHTLY_S3_SSE_KMS_KEY
-from lightly.__init__ import __version__
 
 class TestApiWorkflowClient(unittest.TestCase):
 
@@ -81,7 +83,17 @@ class TestApiWorkflowClient(unittest.TestCase):
                     signed_write_url='',
                 )
 
-def test_user_agent_header() -> None:
+def test_user_agent_header(mocker: MockerFixture) -> None:
+    mocker.patch.object(lightly.api.api_workflow_client, "__version__", new="VERSION")
+    mocker.patch.object(lightly.api.api_workflow_client, "is_compatible_version", new=lambda _: True)
+    mocked_platform = mocker.patch.object(lightly.api.api_workflow_client, "platform", spec_set=platform)
+    mocked_platform.system.return_value = "SYSTEM"
+    mocked_platform.release.return_value = "RELEASE"
+    mocked_platform.platform.return_value = "PLATFORM"
+    mocked_platform.processor.return_value = "PROCESSOR"
+    mocked_platform.python_version.return_value = "PYTHON_VERSION"
+
+
     client = ApiWorkflowClient(token="")
 
-    assert client.api_client.user_agent == f"Lightly/{__version__} ({platform.system()}/{platform.release()}; {platform.platform()}; {platform.processor()};) python/{platform.python_version()}"
+    assert client.api_client.user_agent == f"Lightly/VERSION (SYSTEM/RELEASE; PLATFORM; PROCESSOR;) python/PYTHON_VERSION"

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -2,11 +2,8 @@ import platform
 import unittest
 from unittest import mock
 
-import pytest
 import requests
 import os
-
-from pytest_mock import MockerFixture
 
 from lightly.api.api_workflow_client import ApiWorkflowClient, LIGHTLY_S3_SSE_KMS_KEY
 from lightly.__init__ import __version__

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -8,8 +8,7 @@ import os
 
 from pytest_mock import MockerFixture
 
-from lightly.api import ApiWorkflowClient
-from lightly.api.api_workflow_client import LIGHTLY_S3_SSE_KMS_KEY
+from lightly.api.api_workflow_client import ApiWorkflowClient, LIGHTLY_S3_SSE_KMS_KEY
 from lightly.__init__ import __version__
 
 class TestApiWorkflowClient(unittest.TestCase):
@@ -85,7 +84,7 @@ class TestApiWorkflowClient(unittest.TestCase):
                     signed_write_url='',
                 )
 
-def test_user_agent(mocker: MockerFixture) -> None:
+def test_user_agent_header(mocker: MockerFixture) -> None:
     client = ApiWorkflowClient(token="")
     patched_request = mocker.patch.object(client._mappings_api.api_client, "request")
 

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -84,4 +84,4 @@ class TestApiWorkflowClient(unittest.TestCase):
 def test_user_agent_header() -> None:
     client = ApiWorkflowClient(token="")
 
-    assert client.api_client.user_agent == f"Lightly/{__version__}/python ({platform.platform()})"
+    assert client.api_client.user_agent == f"Lightly/{__version__} ({platform.system()}/{platform.release()}; {platform.platform()}; {platform.processor()};) python/{platform.python_version()}"


### PR DESCRIPTION
## Description
- When using the ApiWorkflowClient, any API calls include the Lightly version and platform in the user agent of the header.
- Added unittest for this.

This does NOT finish the complete issue, but only the pip part of it. However, I need to merge it to then use it in the docker.

## How was it tested?
- New unittest.
- Ensuring through manual debugging, that the header is passed through all the connection functions:
![image](https://user-images.githubusercontent.com/20324507/215430153-799f9ae7-e6ec-4fa1-9a5f-538e15bdcda7.jpeg)![image](https://user-images.githubusercontent.com/20324507/215431260-4d0ece19-5faf-407f-b8bd-673d663654fb.jpeg)