### PR TITLE
Fix Gaussian Blur 

### DIFF
--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -505,7 +505,7 @@ class SwaVCollateFunction(MultiCropCollateFunction):
         cj_prob: float = 0.8,
         cj_strength: float = 0.8,
         random_gray_scale: float = 0.2,
-        gaussian_blur: float = 0.0,
+        gaussian_blur: float = .5,
         kernel_size: float = 1.0,
         normalize: dict = imagenet_normalize,
     ):

--- a/lightly/transforms/gaussian_blur.py
+++ b/lightly/transforms/gaussian_blur.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 from PIL import ImageFilter
+from typing import Tuple
 
 
 class GaussianBlur(object):
@@ -21,19 +22,16 @@ class GaussianBlur(object):
         prob:
             Probability with which the blur is applied.
         scale:
-            Fraction of the kernel size which is used for upper and lower
-            limits of the randomized kernel size.
+            Old unused parameters kept for compatibility
+        sigmas:
+            Tuple of min and max value from which the std of the gaussian kernel is sampled
 
     """
 
     def __init__(self, kernel_size: float, prob: float = 0.5,
-                 scale: float = 0.2):
+                 scale: float = 0.2, sigmas: Tuple[float, float] = (.2, 2)):
         self.prob = prob
-        self.scale = scale
-        # limits for random kernel sizes
-        self.min_size = (1 - scale) * kernel_size
-        self.max_size = (1 + scale) * kernel_size
-        self.kernel_size = kernel_size
+        self.sigmas = sigmas
 
     def __call__(self, sample):
         """Blurs the image with a given probability.
@@ -48,14 +46,8 @@ class GaussianBlur(object):
         """
         prob = np.random.random_sample()
         if prob < self.prob:
-            # choose randomized kernel size
-            kernel_size = np.random.normal(
-                self.kernel_size, self.scale * self.kernel_size
-            )
-            kernel_size = max(self.min_size, kernel_size)
-            kernel_size = min(self.max_size, kernel_size)
-            radius = int(kernel_size / 2)
-            # return blurred image
-            return sample.filter(ImageFilter.GaussianBlur(radius=radius))
+            # choose randomized std for Gaussian filtering
+            sigma = np.random.uniform(self.sigmas[0], self.sigmas[1])
+            return sample.filter(ImageFilter.GaussianBlur(radius=sigma))
         # return original image
         return sample

--- a/lightly/transforms/gaussian_blur.py
+++ b/lightly/transforms/gaussian_blur.py
@@ -13,8 +13,8 @@ class GaussianBlur(object):
 
     Utilizes the built-in ImageFilter method from PIL to apply a Gaussian 
     blur to the input image with a certain probability. The blur is further
-    randomized as the kernel size is chosen randomly around a mean specified
-    by the user.
+    randomized by sampling uniformly the values of the standard deviation of
+    the Gaussian kernel.
 
     Attributes:
         kernel_size:
@@ -42,7 +42,6 @@ class GaussianBlur(object):
         
         Returns:
             Blurred image or original image.
-
         """
         prob = np.random.random_sample()
         if prob < self.prob:


### PR DESCRIPTION
Fix the Gaussian Blur as detailed in #1051. This is just a quick fix example, feel free to reject this PR and write your own clean implementation, although I would love to help if I can. 

In particular, this is probably a classical problem, but I am not sure how to handle cleanly the old parameters of [GaussianBlur](https://github.com/lightly-ai/lightly/blob/93db513650a1dcc5a9d791c99519ed77269ead11/lightly/transforms/gaussian_blur.py#L10) filter as scale or kernel_size that we don't need anymore with this fix : either one can delete these two parameters, but it does not ensure compatibility with older version of Lightly (if a user happened to use the Gaussian Blur function, this will lead to an issue), or one can leave these two unused parameters as is with default values, resulting in a not very clean implementation having useless parameters (current state of the PR). 

One important question would be about using the Gaussian Blur either from PIL or from TorchVision.
