### PR TITLE
Remove extra pooling layers from benchmarks.

### DIFF
--- a/docs/source/getting_started/benchmarks/cifar10_benchmark.py
+++ b/docs/source/getting_started/benchmarks/cifar10_benchmark.py
@@ -240,7 +240,8 @@ class MocoModel(BenchmarkModule):
         num_splits = 0 if sync_batchnorm else 8
         resnet = lightly.models.ResNetGenerator('resnet-18', num_splits=num_splits)
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
 
         # create a moco model based on ResNet
@@ -305,6 +306,7 @@ class SimCLRModel(BenchmarkModule):
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
             *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
         self.projection_head = heads.SimCLRProjectionHead(512, 512, 128)
         self.criterion = lightly.loss.NTXentLoss()
@@ -339,7 +341,8 @@ class SimSiamModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
         self.prediction_head = heads.SimSiamPredictionHead(2048, 512, 2048)
         # use a 2-layer projection head for cifar10 as described in the paper
@@ -390,7 +393,8 @@ class BarlowTwinsModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
         # use a 2-layer projection head for cifar10 as described in the paper
         self.projection_head = heads.ProjectionHead([
@@ -439,7 +443,8 @@ class BYOLModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
 
         # create a byol model based on ResNet
@@ -497,7 +502,8 @@ class SwaVModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
 
         self.projection_head = heads.SwaVProjectionHead(512, 512, 128)
@@ -550,7 +556,8 @@ class NNCLRModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
         self.prediction_head = heads.NNCLRPredictionHead(256, 4096, 256)
         # use only a 2-layer projection head for cifar10
@@ -605,7 +612,8 @@ class DINOModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
         self.head = self._build_projection_head()
         self.teacher_backbone = copy.deepcopy(self.backbone)
@@ -666,7 +674,8 @@ class DCL(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
         self.projection_head = heads.SimCLRProjectionHead(512, 512, 128)
         self.criterion = lightly.loss.DCLLoss()
@@ -701,7 +710,8 @@ class DCLW(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
         self.projection_head = heads.SimCLRProjectionHead(512, 512, 128)
         self.criterion = lightly.loss.DCLWLoss()
@@ -740,7 +750,8 @@ class SMoGModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
 
         # create a model based on ResNet

--- a/docs/source/getting_started/benchmarks/cifar10_benchmark.py
+++ b/docs/source/getting_started/benchmarks/cifar10_benchmark.py
@@ -240,8 +240,7 @@ class MocoModel(BenchmarkModule):
         num_splits = 0 if sync_batchnorm else 8
         resnet = lightly.models.ResNetGenerator('resnet-18', num_splits=num_splits)
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a moco model based on ResNet
@@ -306,7 +305,6 @@ class SimCLRModel(BenchmarkModule):
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
             *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
         )
         self.projection_head = heads.SimCLRProjectionHead(512, 512, 128)
         self.criterion = lightly.loss.NTXentLoss()
@@ -341,8 +339,7 @@ class SimSiamModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.prediction_head = heads.SimSiamPredictionHead(2048, 512, 2048)
         # use a 2-layer projection head for cifar10 as described in the paper
@@ -393,8 +390,7 @@ class BarlowTwinsModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         # use a 2-layer projection head for cifar10 as described in the paper
         self.projection_head = heads.ProjectionHead([
@@ -443,8 +439,7 @@ class BYOLModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a byol model based on ResNet
@@ -502,8 +497,7 @@ class SwaVModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         self.projection_head = heads.SwaVProjectionHead(512, 512, 128)
@@ -556,8 +550,7 @@ class NNCLRModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.prediction_head = heads.NNCLRPredictionHead(256, 4096, 256)
         # use only a 2-layer projection head for cifar10
@@ -612,8 +605,7 @@ class DINOModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.head = self._build_projection_head()
         self.teacher_backbone = copy.deepcopy(self.backbone)
@@ -674,8 +666,7 @@ class DCL(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.SimCLRProjectionHead(512, 512, 128)
         self.criterion = lightly.loss.DCLLoss()
@@ -710,8 +701,7 @@ class DCLW(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.SimCLRProjectionHead(512, 512, 128)
         self.criterion = lightly.loss.DCLWLoss()
@@ -750,8 +740,7 @@ class SMoGModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator('resnet-18')
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a model based on ResNet

--- a/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
@@ -163,8 +163,7 @@ class MocoModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a moco model based on ResNet
@@ -228,8 +227,7 @@ class SimCLRModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.SimCLRProjectionHead(feature_dim, feature_dim, 128)
         self.criterion = lightly.loss.NTXentLoss(temperature=0.1)
@@ -275,8 +273,7 @@ class SimSiamModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.prediction_head = heads.SimSiamPredictionHead(2048, 512, 2048)
         self.projection_head = heads.SimSiamProjectionHead(feature_dim, 512, 2048)
@@ -314,8 +311,7 @@ class BarlowTwinsModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         # use a 2-layer projection head for cifar10 as described in the paper
         self.projection_head = heads.BarlowTwinsProjectionHead(feature_dim, 2048, 2048)
@@ -363,8 +359,7 @@ class BYOLModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a byol model based on ResNet
@@ -435,8 +430,7 @@ class NNCLRModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.prediction_head = heads.NNCLRPredictionHead(256, 4096, 256)
         self.projection_head = heads.NNCLRProjectionHead(feature_dim, 4096, 256)
@@ -478,8 +472,7 @@ class SwaVModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         self.projection_head = heads.SwaVProjectionHead(feature_dim, 2048, 128)
@@ -546,8 +539,7 @@ class DINOModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.head = heads.DINOProjectionHead(feature_dim, 2048, 256, 2048, batch_norm=True)
         self.teacher_backbone = copy.deepcopy(self.backbone)

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -54,7 +54,7 @@ Results (5.3.2022):
 (*): Different runtime and memory requirements due to different hardware settings
 and pytorch version. Runtime and memory requirements are comparable to SimCLR
 with the default settings.
-(**): Test run with old lightly resnet18 implementation
+(**): Uses outdated ResNetGenerator architecture.
 
 """
 import copy

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -26,7 +26,7 @@ Results (5.3.2022):
 | SimCLR           |        256 |    200 |              0.771 |   82.2 Min |      3.9 GByte |
 | SimMIM (ViT-B32) |        256 |    200 |              0.342 |   98.8 Min |     10.5 GByte |
 | SimSiam          |        256 |    200 |              0.669 |   78.6 Min |      3.9 GByte |
-| SMoG             |        128 |    200 |              0.698 |  220.9 Min |     14.3 GByte |
+| SMoG (**)        |        128 |    200 |              0.698 |  220.9 Min |     14.3 GByte |
 | SwaV             |        256 |    200 |              0.748 |   77.6 Min |      4.0 GByte |
 | SwaVQueue        |        256 |    200 |              0.845 |   68.8 Min |      6.4 GByte |
 | TiCo             |        256 |    200 |              0.531 |   78.2 Min |      4.3 GByte |
@@ -54,6 +54,7 @@ Results (5.3.2022):
 (*): Different runtime and memory requirements due to different hardware settings
 and pytorch version. Runtime and memory requirements are comparable to SimCLR
 with the default settings.
+(**): Test run with old lightly resnet18 implementation
 
 """
 import copy
@@ -860,10 +861,9 @@ class SMoGModel(BenchmarkModule):
         super().__init__(dataloader_kNN, num_classes)
 
         # create a ResNet backbone and remove the classification head
-        resnet = lightly.models.ResNetGenerator("resnet-18")
+        resnet = torchvision.models.resnet18()
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1],
-            nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a model based on ResNet

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -862,7 +862,8 @@ class SMoGModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator("resnet-18")
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1]
+            *list(resnet.children())[:-1],
+            nn.AdaptiveAvgPool2d(1)
         )
 
         # create a model based on ResNet

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -247,7 +247,7 @@ class MocoModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a moco model based on ResNet
@@ -313,7 +313,7 @@ class SimCLRModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.SimCLRProjectionHead(feature_dim, feature_dim, 128)
         self.criterion = lightly.loss.NTXentLoss()
@@ -346,7 +346,7 @@ class SimSiamModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.SimSiamProjectionHead(feature_dim, 2048, 2048)
         self.prediction_head = heads.SimSiamPredictionHead(2048, 512, 2048)
@@ -385,7 +385,7 @@ class BarlowTwinsModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         # use a 2-layer projection head for cifar10 as described in the paper
         self.projection_head = heads.BarlowTwinsProjectionHead(feature_dim, 2048, 2048)
@@ -422,7 +422,7 @@ class BYOLModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a byol model based on ResNet
@@ -486,7 +486,7 @@ class NNCLRModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.NNCLRProjectionHead(feature_dim, 2048, 256)
         self.prediction_head = heads.NNCLRPredictionHead(256, 4096, 256)
@@ -528,7 +528,7 @@ class SwaVModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         self.projection_head = heads.SwaVProjectionHead(feature_dim, 2048, 128)
@@ -582,7 +582,7 @@ class DINOModel(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.head = heads.DINOProjectionHead(
             feature_dim, 2048, 256, 2048, batch_norm=True
@@ -638,7 +638,7 @@ class DCL(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.SimCLRProjectionHead(feature_dim, feature_dim, 128)
         self.criterion = lightly.loss.DCLLoss()
@@ -671,7 +671,7 @@ class DCLW(BenchmarkModule):
         resnet = torchvision.models.resnet18()
         feature_dim = list(resnet.children())[-1].in_features
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
         self.projection_head = heads.SimCLRProjectionHead(feature_dim, feature_dim, 128)
         self.criterion = lightly.loss.DCLWLoss()
@@ -862,7 +862,7 @@ class SMoGModel(BenchmarkModule):
         # create a ResNet backbone and remove the classification head
         resnet = lightly.models.ResNetGenerator("resnet-18")
         self.backbone = nn.Sequential(
-            *list(resnet.children())[:-1], nn.AdaptiveAvgPool2d(1)
+            *list(resnet.children())[:-1]
         )
 
         # create a model based on ResNet


### PR DESCRIPTION
Removes extra nn.AdaptiveAvgPool2d from the benchmarking modules. Follows up from https://github.com/lightly-ai/lightly/issues/1042.