### PR TITLE
validate the config created by the api

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -16,7 +16,7 @@ from lightly.openapi_generated.swagger_client import (
     DockerRunScheduledState,
     DockerRunState,
     DockerWorkerConfig,
-    DockerWorkerConfigCreateRequest,
+    DockerWorkerConfigV2CreateRequest,
     DockerWorkerType,
     SelectionConfig,
     SelectionConfigEntry,
@@ -145,8 +145,8 @@ class _ComputeWorkerMixin:
             lightly=lightly_config,
             selection=selection,
         )
-        request = DockerWorkerConfigCreateRequest(config)
-        response = self._compute_worker_api.create_docker_worker_config(request)
+        request = DockerWorkerConfigV2CreateRequest(config)
+        response = self._compute_worker_api.create_docker_worker_config_v2(request)
         return response.id
 
     def schedule_compute_worker_run(

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -37,6 +37,9 @@ from lightly.openapi_generated.swagger_client.models.docker_run_state import (
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_create_request import (
     DockerWorkerConfigCreateRequest,
 )
+from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_create_request import (
+    DockerWorkerConfigV2CreateRequest,
+)
 from lightly.openapi_generated.swagger_client.models.docker_worker_registry_entry_data import (
     DockerWorkerRegistryEntryData,
 )
@@ -903,6 +906,10 @@ class MockedComputeWorkerApi(DockerApi):
     def create_docker_worker_config(self, body, **kwargs):
         assert isinstance(body, DockerWorkerConfigCreateRequest)
         return CreateEntityResponse(id="worker-config-id-123")
+    
+    def create_docker_worker_config_v2(self, body, **kwargs):
+        assert isinstance(body, DockerWorkerConfigV2CreateRequest)
+        return CreateEntityResponse(id="worker-configv2-id-123")
 
     def create_docker_run_scheduled_by_dataset_id(self, body, dataset_id, **kwargs):
         assert isinstance(body, DockerRunScheduledCreateRequest)


### PR DESCRIPTION
when creating a selection configuration we now only allow to use the v2 config supported by worker2.5 which is type safe