### PR TITLE
Fix scheduling jobs with config v2

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -16,6 +16,8 @@ from lightly.openapi_generated.swagger_client import (
     DockerRunScheduledState,
     DockerRunState,
     DockerWorkerConfigV2,
+    DockerWorkerConfigV2Docker,
+    DockerWorkerConfigV2Lightly,
     DockerWorkerConfigV2CreateRequest,
     DockerWorkerType,
     SelectionConfig,
@@ -139,6 +141,10 @@ class _ComputeWorkerMixin:
             selection = selection_config_from_dict(cfg=selection_config)
         else:
             selection = selection_config
+
+        worker_config = DockerWorkerConfigV2Docker(**worker_config) if worker_config is not None else None
+        lightly_config = DockerWorkerConfigV2Lightly(**lightly_config) if worker_config is not None else None
+
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,
             docker=worker_config,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -152,8 +152,6 @@ class _ComputeWorkerMixin:
             deserialize=deserialize,
             lightly_config_dict=lightly_config
         )
-        print(worker_config)
-        print(lightly_config)
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,
@@ -847,7 +845,7 @@ def worker_config_from_dict(
 
 
 def lightly_config_from_dict(
-    deserialize: Callable,
+    deserialize: Callable[[Dict[str, Any], str], Any],
     lightly_config_dict: Optional[Dict[str, Any]]
 ) -> Optional[DockerWorkerConfigV2Lightly]:
     """Converts worker config to DockerWorkerConfigV2Lightly instance.
@@ -869,11 +867,14 @@ def lightly_config_from_dict(
     return deserialize(lightly_config_camel_case, DockerWorkerConfigV2Lightly)
 
 
-def _get_deserializer(api_client: ApiClient) -> Callable:
+def _get_deserializer(api_client: ApiClient) -> Callable[[Dict[str, Any], str], Any]:
     """Returns the deserializer of the ApiClient class. 
 
     TODO(Philipp, 02/23): We should replace this by our own deserializer which
     accepts snake case strings as input.
+
+    The deserializer takes a dictionary and a class-string and returns an instance
+    of the class.
 
     """
     return getattr(api_client, "_ApiClient__deserialize")

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -142,8 +142,8 @@ class _ComputeWorkerMixin:
         else:
             selection = selection_config
 
-        worker_config = self.api_client.deserialize(worker_config, "DockerWorkerConfigV2Docker") if worker_config is not None else None
-        lightly_config = self.api_client.deserialize(lightly_config, "DockerWorkerConfigV2Lightly") if lightly_config is not None else None
+        worker_config = self.api_client.__deserialize(worker_config, "DockerWorkerConfigV2Docker") if worker_config is not None else None
+        lightly_config = self.api_client.__deserialize(lightly_config, "DockerWorkerConfigV2Lightly") if lightly_config is not None else None
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -143,7 +143,7 @@ class _ComputeWorkerMixin:
             selection = selection_config
 
         worker_config = DockerWorkerConfigV2Docker(**worker_config) if worker_config is not None else None
-        lightly_config = DockerWorkerConfigV2Lightly(**lightly_config) if worker_config is not None else None
+        lightly_config = DockerWorkerConfigV2Lightly(**lightly_config) if lightly_config is not None else None
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -16,8 +16,6 @@ from lightly.openapi_generated.swagger_client import (
     DockerRunScheduledState,
     DockerRunState,
     DockerWorkerConfigV2,
-    DockerWorkerConfigV2Docker,
-    DockerWorkerConfigV2Lightly,
     DockerWorkerConfigV2CreateRequest,
     DockerWorkerType,
     SelectionConfig,
@@ -142,8 +140,9 @@ class _ComputeWorkerMixin:
         else:
             selection = selection_config
 
-        worker_config = self.api_client.__deserialize(worker_config, "DockerWorkerConfigV2Docker") if worker_config is not None else None
-        lightly_config = self.api_client.__deserialize(lightly_config, "DockerWorkerConfigV2Lightly") if lightly_config is not None else None
+        deserialize = self.api_client.__dict__["_ApiClient__deserialize"]
+        worker_config = deserialize(worker_config, "DockerWorkerConfigV2Docker") if worker_config is not None else None
+        lightly_config = deserialize(lightly_config, "DockerWorkerConfigV2Lightly") if lightly_config is not None else None
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -8,6 +8,7 @@ from lightly.api.utils import retry
 from lightly.api import download
 from lightly.api import utils
 from lightly.openapi_generated.swagger_client import (
+    ApiClient,
     CreateDockerWorkerRegistryEntryRequest,
     DockerRunData,
     DockerRunScheduledCreateRequest,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -15,7 +15,7 @@ from lightly.openapi_generated.swagger_client import (
     DockerRunScheduledPriority,
     DockerRunScheduledState,
     DockerRunState,
-    DockerWorkerConfig,
+    DockerWorkerConfigV2,
     DockerWorkerConfigV2CreateRequest,
     DockerWorkerType,
     SelectionConfig,
@@ -139,7 +139,7 @@ class _ComputeWorkerMixin:
             selection = selection_config_from_dict(cfg=selection_config)
         else:
             selection = selection_config
-        config = DockerWorkerConfig(
+        config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,
             docker=worker_config,
             lightly=lightly_config,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -142,8 +142,8 @@ class _ComputeWorkerMixin:
         else:
             selection = selection_config
 
-        worker_config = DockerWorkerConfigV2Docker(**worker_config) if worker_config is not None else None
-        lightly_config = DockerWorkerConfigV2Lightly(**lightly_config) if lightly_config is not None else None
+        worker_config = self.api_client.deserialize(worker_config, "DockerWorkerConfigV2Docker") if worker_config is not None else None
+        lightly_config = self.api_client.deserialize(lightly_config, "DockerWorkerConfigV2Lightly") if lightly_config is not None else None
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -143,6 +143,8 @@ class _ComputeWorkerMixin:
         deserialize = getattr(self.api_client, "_ApiClient__deserialize")
         worker_config = deserialize(worker_config, "DockerWorkerConfigV2Docker") if worker_config is not None else None
         lightly_config = deserialize(lightly_config, "DockerWorkerConfigV2Lightly") if lightly_config is not None else None
+        print(worker_config)
+        print(lightly_config)
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -140,7 +140,7 @@ class _ComputeWorkerMixin:
         else:
             selection = selection_config
 
-        deserialize = self.api_client.__dict__["_ApiClient__deserialize"]
+        deserialize = getattr(self.api_client, "_ApiClient__deserialize")
         worker_config = deserialize(worker_config, "DockerWorkerConfigV2Docker") if worker_config is not None else None
         lightly_config = deserialize(lightly_config, "DockerWorkerConfigV2Lightly") if lightly_config is not None else None
 

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -827,7 +827,18 @@ def worker_config_from_dict(
     deserialize: Callable,
     worker_config_dict: Optional[Dict[str, Any]]
 ) -> Optional[DockerWorkerConfigV2Docker]:
+    """Converts worker config to DockerWorkerConfigV2Docker instance.
 
+    Args:
+        deserialize:
+            Function to deserialize the worker_config_dict.
+        worker_config_dict:
+            Configuration dict with snake case keys or None.
+
+    Returns:
+        An instance of DockerWorkerConfigV2Docker or None if the input is None.
+        
+    """
     if worker_config_dict is None:
         return worker_config_dict
 
@@ -839,7 +850,18 @@ def lightly_config_from_dict(
     deserialize: Callable,
     lightly_config_dict: Optional[Dict[str, Any]]
 ) -> Optional[DockerWorkerConfigV2Lightly]:
+    """Converts worker config to DockerWorkerConfigV2Lightly instance.
 
+    Args:
+        deserialize:
+            Function to deserialize the worker_config_dict.
+        lightly_config_dict:
+            Configuration dict with snake case keys or None.
+
+    Returns:
+        An instance of DockerWorkerConfigV2Lightly or None if the input is None.
+        
+    """
     if lightly_config_dict is None:
         return lightly_config_dict
 
@@ -848,10 +870,17 @@ def lightly_config_from_dict(
 
 
 def _get_deserializer(api_client: ApiClient) -> Callable:
+    """Returns the deserializer of the ApiClient class. 
+
+    TODO(Philipp, 02/23): We should replace this by our own deserializer which
+    accepts snake case strings as input.
+
+    """
     return getattr(api_client, "_ApiClient__deserialize")
 
 
 def _config_to_camel_case(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Converts all keys in the cfg dictionary to camelCase. """
     cfg_camel_case = {}
     for key, value in cfg.items():
         key_camel_case = _snake_to_camel_case(key)
@@ -863,5 +892,8 @@ def _config_to_camel_case(cfg: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _snake_to_camel_case(snake: str) -> str:
+    """Converts the snake_case input to camelCase. """
     components = snake.split("_")
-    return components[0] + "".join(component.title() for component in components[1:])
+    return components[0] + "".join(
+        component.title() for component in components[1:]
+    )

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -852,11 +852,14 @@ def _get_deserializer(api_client: ApiClient) -> Callable:
 
 
 def _config_to_camel_case(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    cfg_camel_case = {}
     for key, value in cfg.items():
-        del cfg[key]
+        key_camel_case = _snake_to_camel_case(key)
         if isinstance(value, dict):
-            _config_to_camel_case(value)
-        cfg[_snake_to_camel_case(snake=key)] = value
+            cfg_camel_case[key_camel_case] = _config_to_camel_case(value)
+        else:
+            cfg_camel_case[key_camel_case] = value
+    return cfg_camel_case
 
 
 def _snake_to_camel_case(snake: str) -> str:

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -144,22 +144,26 @@ class _ComputeWorkerMixin:
         else:
             selection = selection_config
 
-        worker_config = _config_to_camel_case(cfg=worker_config)
-        deserialize_worker_config = _get_deserialize(
-            api_client=self.api_client,
-            klass=DockerWorkerConfigV2Docker,
-        )
+        if worker_config is not None:
+            worker_config = _config_to_camel_case(cfg=worker_config)
+            deserialize_worker_config = _get_deserialize(
+                api_client=self.api_client,
+                klass=DockerWorkerConfigV2Docker,
+            )
+            worker_config = deserialize_worker_config(worker_config)
 
-        lightly_config = _config_to_camel_case(cfg=lightly_config)
-        deserialize_lightly_config = _get_deserialize(
-            api_client=self.api_client,
-            klass=DockerWorkerConfigV2Lightly,
-        )
+        if lightly_config is not None:
+            lightly_config = _config_to_camel_case(cfg=lightly_config)
+            deserialize_lightly_config = _get_deserialize(
+                api_client=self.api_client,
+                klass=DockerWorkerConfigV2Lightly,
+            )
+            lightly_config = deserialize_lightly_config(lightly_config)
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,
-            docker=deserialize_worker_config(worker_config),
-            lightly=deserialize_lightly_config(lightly_config),
+            docker=worker_config,
+            lightly=lightly_config,
             selection=selection,
         )
         request = DockerWorkerConfigV2CreateRequest(config)

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -11,6 +11,8 @@ from lightly.api.api_workflow_compute_worker import (
     STATE_SCHEDULED_ID_NOT_FOUND,
     ArtifactNotExist,
     ComputeWorkerRunInfo,
+    _config_to_camel_case,
+    _snake_to_camel_case,
 )
 from lightly.openapi_generated.swagger_client import (
     SelectionConfig,
@@ -727,3 +729,24 @@ def test__download_compute_worker_run_artifact_by_type__no_artifact_with_type(
             output_path="output_dir/checkpoint.ckpt",
             timeout=0,
         )
+
+
+def test__config_to_camel_case() -> None:
+    assert _config_to_camel_case({
+        "lorem_ipsum": "dolor",
+        "lorem": {
+            "ipsum_dolor": "sit_amet",
+        }
+    }) == {
+        "loremIpsum": "dolor",
+        "lorem": {
+            "ipsumDolor": "sit_amet",
+        }
+    }
+
+def test__snake_to_camel_case() -> None:
+    
+    assert _snake_to_camel_case("lorem") == "lorem"
+    assert _snake_to_camel_case("lorem_ipsum") == "loremIpsum"
+    assert _snake_to_camel_case("lorem_ipsum_dolor") == "loremIpsumDolor"
+    assert _snake_to_camel_case("loremIpsum") == "loremIpsum" # do nothing


### PR DESCRIPTION
# Fix scheduling jobs with config v2

* Use config v2 when scheduling a Lightly Worker job.
* Convert the snake case dictionary input to a validated `DockerWorkerConfigV2` instance
    * Convert snake case to camel case.
    * Use openapi deserialize.

Please ignore the commit history. I was trying out different things.