### PR TITLE
Raise error for non existing config options

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -498,8 +498,12 @@ def _snake_to_camel_case(snake: str) -> str:
     )
 
 
-def _validate_config(cfg: Dict[str, Any], obj: Any) -> None:
+def _validate_config(cfg: Optional[Dict[str, Any]], obj: Any) -> None:
     """Validates that all keys in cfg are legit configuration options. """
+
+    if cfg is None:
+        return
+
     for key, item in cfg.items():
         if not hasattr(obj, key):
             error_msg = f"Option `{key}` does not exist!"


### PR DESCRIPTION
# Raise error for non existing config options

Do basic validation of configuration options such that there's no silent failure when an argument is misspelled (e.g. `relevant_filenames` vs `relevant_filenames_file`.


A few examples:
___ 
```python
client.schedule_compute_worker_run(
    worker_config={
        "relevant_filenames": "my_relevant_filenames.txt"
    }
)
```

```
Traceback (most recent call last):
  File "/home/ubuntu/lightly-ai/lightly/test_deserialize.py", line 9, in <module>
    client.schedule_compute_worker_run(
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 210, in schedule_compute_worker_run
    config_id = self.create_compute_worker_config(
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 158, in create_compute_worker_config
    _validate_config(cfg=worker_config, obj=docker)
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 519, in _validate_config
    raise InvalidConfigurationError(error_msg)
lightly.api.api_workflow_compute_worker.InvalidConfigurationError: Option `relevant_filenames` does not exist! Did you mean `relevant_filenames_file`?
```
___ 
```python
client.schedule_compute_worker_run(
    worker_config={
        "corruptness_check": {
            "threshold": 1.0
        }
    }
)
```
```
Traceback (most recent call last):
  File "/home/ubuntu/lightly-ai/lightly/test_deserialize.py", line 9, in <module>
    client.schedule_compute_worker_run(
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 210, in schedule_compute_worker_run
    config_id = self.create_compute_worker_config(
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 158, in create_compute_worker_config
    _validate_config(cfg=worker_config, obj=docker)
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 521, in _validate_config
    _validate_config(item, getattr(obj, key))
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 519, in _validate_config
    raise InvalidConfigurationError(error_msg)
lightly.api.api_workflow_compute_worker.InvalidConfigurationError: Option `threshold` does not exist! Did you mean `corruption_threshold`?
```
___ 
```python
client.schedule_compute_worker_run(
    lightly_config={
        "modelx": {
            "name": "resnet-18"
        }
    }
)
```
```
Traceback (most recent call last):
  File "/home/ubuntu/lightly-ai/lightly/test_deserialize.py", line 9, in <module>
    client.schedule_compute_worker_run(
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 210, in schedule_compute_worker_run
    config_id = self.create_compute_worker_config(
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 167, in create_compute_worker_config
    _validate_config(cfg=lightly_config, obj=lightly)
  File "/home/ubuntu/lightly-ai/lightly/lightly/api/api_workflow_compute_worker.py", line 519, in _validate_config
    raise InvalidConfigurationError(error_msg)
lightly.api.api_workflow_compute_worker.InvalidConfigurationError: Option `modelx` does not exist! Did you mean `model`
```
