### PR TITLE
Add a Link to Lightly Worker docs from SSL docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,11 @@
 Documentation
 ===================================
 
+.. note:: These pages document the Lightly self-supervised learning library.
+          If you looking for Lightly Worker Solution to easily process millions
+          of samples and run powerful active learning algorithms on your data
+          please follow `Lightly Documentation here <https://lightly-docs.readme.io/>`_.
+
 Lightly is a computer vision framework for self-supervised learning.
 
 With Lightly you can train deep learning models using self-supervision. 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,9 +13,10 @@ Documentation
 ===================================
 
 .. note:: These pages document the Lightly self-supervised learning library.
-          If you looking for Lightly Worker Solution to easily process millions
+          If you are looking for Lightly Worker Solution to easily process millions
           of samples and run powerful active learning algorithms on your data
-          please follow `Lightly Documentation here <https://lightly-docs.readme.io/>`_.
+          please follow
+          `Lightly Worker documentation <https://lightly-docs.readme.io/>`_.
 
 Lightly is a computer vision framework for self-supervised learning.
 


### PR DESCRIPTION
Added a callout to the main page:

![Screenshot 2023-03-07 at 13 54 04](https://user-images.githubusercontent.com/105644579/223428396-4dfbf597-2f29-4b85-82c7-39986a34d24f.png)
