### PR TITLE
Fix config creation when passing None as config

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -147,7 +147,6 @@ class _ComputeWorkerMixin:
             selection = selection_config_from_dict(cfg=selection_config)
         else:
             selection = selection_config
-        _validate_config(cfg=selection_config, obj=selection)
 
         if worker_config is not None:
             worker_config_cc = _config_to_camel_case(cfg=worker_config)
@@ -157,6 +156,8 @@ class _ComputeWorkerMixin:
             )
             docker = deserialize_worker_config(worker_config_cc)
             _validate_config(cfg=worker_config, obj=docker)
+        else:
+            docker = None
 
         if lightly_config is not None:
             lightly_config_cc = _config_to_camel_case(cfg=lightly_config)
@@ -166,6 +167,8 @@ class _ComputeWorkerMixin:
             )
             lightly = deserialize_lightly_config(lightly_config_cc)
             _validate_config(cfg=lightly_config, obj=lightly)
+        else:
+            lightly = None
 
         config = DockerWorkerConfigV2(
             worker_type=DockerWorkerType.FULL,

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -86,6 +86,44 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
         )
         assert config_id
 
+    def test_create_compute_worker_config__selection_config_is_class(self) -> None:
+        config_id = self.api_workflow_client.create_compute_worker_config(
+            worker_config={
+                "stopping_condition": {
+                    "n_samples": 10,
+                },
+            },
+            lightly_config={
+                "loader": {
+                    "batch_size": 64,
+                },
+            },
+            selection_config=SelectionConfig(
+                n_samples=20,
+                strategies=[
+                    SelectionConfigEntry(
+                        input=SelectionConfigEntryInput(
+                            type=SelectionInputType.EMBEDDINGS,
+                            dataset_id="some-dataset-id",
+                            tag_name="some-tag-name",
+                        ),
+                        strategy=SelectionConfigEntryStrategy(
+                            type=SelectionStrategyType.SIMILARITY,
+                        ),
+                    )
+                ],
+            ),
+        )
+        assert config_id
+
+    def test_create_compute_worker_config__all_none(self) -> None:
+        config_id = self.api_workflow_client.create_compute_worker_config(
+            worker_config=None,
+            lightly_config=None,
+            selection_config=None,
+        )
+        assert config_id
+
     def test_schedule_compute_worker_run(self):
         scheduled_run_id = self.api_workflow_client.schedule_compute_worker_run(
             worker_config={
@@ -668,7 +706,7 @@ def test__snake_to_camel_case() -> None:
     assert _snake_to_camel_case("loremIpsum") == "loremIpsum"  # do nothing
 
 
-def test__validate_config__docker(mocker: MockerFixture) -> None:
+def test__validate_config__docker() -> None:
     obj = DockerWorkerConfigV2Docker(
         enable_training=False,
         corruptness_check=DockerWorkerConfigV2DockerCorruptnessCheck(
@@ -686,7 +724,7 @@ def test__validate_config__docker(mocker: MockerFixture) -> None:
     )
 
 
-def test__validate_config__docker_typo(mocker: MockerFixture) -> None:
+def test__validate_config__docker_typo() -> None:
     obj = DockerWorkerConfigV2Docker(
         enable_training=False,
         corruptness_check=DockerWorkerConfigV2DockerCorruptnessCheck(
@@ -709,7 +747,7 @@ def test__validate_config__docker_typo(mocker: MockerFixture) -> None:
         )
 
 
-def test__validate_config__docker_typo_nested(mocker: MockerFixture) -> None:
+def test__validate_config__docker_typo_nested() -> None:
     obj = DockerWorkerConfigV2Docker(
         enable_training=False,
         corruptness_check=DockerWorkerConfigV2DockerCorruptnessCheck(
@@ -732,7 +770,7 @@ def test__validate_config__docker_typo_nested(mocker: MockerFixture) -> None:
         )
 
 
-def test__validate_config__lightly(mocker: MockerFixture) -> None:
+def test__validate_config__lightly() -> None:
     obj = DockerWorkerConfigV2Lightly(
         loader=DockerWorkerConfigV2LightlyLoader(
             num_workers=-1,
@@ -752,7 +790,7 @@ def test__validate_config__lightly(mocker: MockerFixture) -> None:
     )
 
 
-def test__validate_config__lightly_typo(mocker: MockerFixture) -> None:
+def test__validate_config__lightly_typo() -> None:
     obj = DockerWorkerConfigV2Lightly(
         loader=DockerWorkerConfigV2LightlyLoader(
             num_workers=-1,
@@ -776,7 +814,7 @@ def test__validate_config__lightly_typo(mocker: MockerFixture) -> None:
         )
 
 
-def test__validate_config__lightly_typo_nested(mocker: MockerFixture) -> None:
+def test__validate_config__lightly_typo_nested() -> None:
     obj = DockerWorkerConfigV2Lightly(
         loader=DockerWorkerConfigV2LightlyLoader(
             num_workers=-1,


### PR DESCRIPTION
## What has changed and why?

* Fix bug when `None` was passed as `lightly` or `worker` config.
* Fix bug when a `SelectionConfig` class was passed as `selection` config.