### PR TITLE
Catch more errors when doing version check

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -49,6 +49,7 @@ from lightly.openapi_generated.swagger_client import (
     ScoresApi,
     TagsApi,
 )
+from lightly.openapi_generated.swagger_client.rest import ApiException
 from lightly.utils.reordering import sort_items_by_keys
 
 # Env variable for server side encryption on S3
@@ -108,7 +109,12 @@ class ApiWorkflowClient(
                         )
                     )
                 )
-        except LightlyAPITimeoutException:
+        except (
+            ValueError,
+            ApiException,
+            LightlyAPITimeoutException,
+            AttributeError,
+        ):
             pass
 
         configuration = get_api_client_configuration(token=token)


### PR DESCRIPTION
# Catch more errors when doing version check

Catch the same errors as in `lightly/__init__.py` when doing the version check. The `AttributeError` resolves any Windows problems.

I have tested it by installing `lightly` on my Windows machine and initializing an `ApiWorkflowClient`.