### PR TITLE
drop host trailing slash

### DIFF
--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -192,11 +192,17 @@ def get_signed_url_destination(signed_url: str = "") -> DatasourceType:
     return DatasourceType.LOCAL
 
 
+def get_lightly_server_location_from_env() -> string:
+    return (
+        getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai").strip().rstrip("/")
+    )
+
+
 def get_api_client_configuration(
     token: Optional[str] = None,
     raise_if_no_token_specified: bool = True,
 ) -> Configuration:
-    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai").strip().rstrip("/")
+    host = get_lightly_server_location_from_env()
     ssl_ca_cert = getenv("LIGHTLY_CA_CERTS", None)
 
     if token is None:

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -196,7 +196,7 @@ def get_api_client_configuration(
     token: Optional[str] = None,
     raise_if_no_token_specified: bool = True,
 ) -> Configuration:
-    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai").rstrip("/")
+    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai").strip().rstrip("/")
     ssl_ca_cert = getenv("LIGHTLY_CA_CERTS", None)
 
     if token is None:

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -192,7 +192,7 @@ def get_signed_url_destination(signed_url: str = "") -> DatasourceType:
     return DatasourceType.LOCAL
 
 
-def get_lightly_server_location_from_env() -> string:
+def get_lightly_server_location_from_env() -> str:
     return (
         getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai").strip().rstrip("/")
     )

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -196,7 +196,7 @@ def get_api_client_configuration(
     token: Optional[str] = None,
     raise_if_no_token_specified: bool = True,
 ) -> Configuration:
-    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai")
+    host = getenv("LIGHTLY_SERVER_LOCATION", "https://api.lightly.ai").rstrip("/")
     ssl_ca_cert = getenv("LIGHTLY_CA_CERTS", None)
 
     if token is None:

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -86,6 +86,6 @@ class TestUtils(unittest.TestCase):
         )
 
     def test_get_lightly_server_location_from_env(self):
-        os.enfiron["LIGHTLY_SERVER_LOCATION"] = "https://api.dev.lightly.ai/ ")
+        os.enfiron["LIGHTLY_SERVER_LOCATION"] = "https://api.dev.lightly.ai/ "
         host = get_lightly_server_location_from_env()
-        self.assertEqual(host, "https://api.dev.lightly.ai"
+        self.assertEqual(host, "https://api.dev.lightly.ai")

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -84,3 +84,8 @@ class TestUtils(unittest.TestCase):
             get_signed_url_destination("http://someething.with.windows.in.it"),
             DatasourceType.AZURE,
         )
+
+    def test_get_lightly_server_location_from_env(self):
+        os.enfiron["LIGHTLY_SERVER_LOCATION"] = "https://api.dev.lightly.ai/ ")
+        host = get_lightly_server_location_from_env()
+        self.assertEqual(host, "https://api.dev.lightly.ai"

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -7,6 +7,7 @@ import lightly
 from lightly.api.utils import (
     DatasourceType,
     PIL_to_bytes,
+    get_lightly_server_location_from_env,
     get_signed_url_destination,
     getenv,
     retry,
@@ -86,6 +87,6 @@ class TestUtils(unittest.TestCase):
         )
 
     def test_get_lightly_server_location_from_env(self):
-        os.enfiron["LIGHTLY_SERVER_LOCATION"] = "https://api.dev.lightly.ai/ "
+        os.environ["LIGHTLY_SERVER_LOCATION"] = "https://api.dev.lightly.ai/ "
         host = get_lightly_server_location_from_env()
         self.assertEqual(host, "https://api.dev.lightly.ai")


### PR DESCRIPTION
Since k8s doesn't magically clean up double slashes, some of us hit problems by setting
```
export LIGHTLY_SERVER_LOCATION='https://api.dev.lightly.ai/'
```

With that, the ApiWorkflowClient would build urls like `https://api.dev.lightly.ai//v1/docker/runs/query/datasetId/6401d4534d2ed9112da782f5`.

Which is invalid. Resulting in a mix of 403 forbiddens and 404 not founds.

```
$ curl 'https://api.dev.lightly.ai/v1/versions/pip/minimum'
1.1.0
$ curl 'https://api.dev.lightly.ai//v1/versions/pip/minimum'
{
    "code": "FORBIDDEN",
    "error": "Not able to authenticate user. Please provide a valid token",
    "requestId": "f6f521264e78f1d8a575313f779fe1d9"
}
```

It does work with AppEngine magically stripping out double slashes. 

But we would rather the ApiWorkflowClient always build valid urls without the double slash after a hostname.

This PR just strips any user-defined trailing slash from a hostname.