### PR TITLE
Add CATEGORY_COUNT to SelectionInputPredictionsName

### DIFF
--- a/lightly/openapi_generated/swagger_client/models/selection_input_predictions_name.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_input_predictions_name.py
@@ -29,6 +29,7 @@ class SelectionInputPredictionsName(object):
     allowed enum values
     """
     CLASS_DISTRIBUTION = "CLASS_DISTRIBUTION"
+    CATEGORY_COUNT = "CATEGORY_COUNT"
 
     """
     Attributes:


### PR DESCRIPTION
Blocked by [lightly-core#2512](https://github.com/lightly-ai/lightly-core/pull/2512).

## What has changed and why?
Added one key `CATEGORY_COUNT` to enum `SelectionInputPredictionsName`.

## How was it tested?
N/A because there is no change in logic yet.