### PR TITLE
Add key `categories` to selection config

### DIFF
--- a/lightly/openapi_generated/swagger_client/models/selection_config_entry_input.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_entry_input.py
@@ -41,7 +41,7 @@ class SelectionConfigEntryInput(object):
         'dataset_id': 'MongoObjectID',
         'tag_name': 'TagName',
         'random_seed': 'int',
-        'categories': 'list[str]'
+        'categories': 'list[CategoryName]'
     }
 
     attribute_map = {
@@ -267,7 +267,7 @@ class SelectionConfigEntryInput(object):
 
 
         :return: The categories of this SelectionConfigEntryInput.  # noqa: E501
-        :rtype: list[str]
+        :rtype: list[CategoryName]
         """
         return self._categories
 
@@ -277,7 +277,7 @@ class SelectionConfigEntryInput(object):
 
 
         :param categories: The categories of this SelectionConfigEntryInput.  # noqa: E501
-        :type: list[str]
+        :type: list[CategoryName]
         """
 
         self._categories = categories


### PR DESCRIPTION
Added a new key categories to selection config to support advanced selection. Only predictions matching the categories selected will be counted.

Note that some properties defined in the spec are not reflected in the generated code. This seems to be a problem for all generated code. Will investigate later.