### PR TITLE
Add deprecation warnings to tutorials

### DIFF
--- a/docs/source/tutorials/platform.rst
+++ b/docs/source/tutorials/platform.rst
@@ -3,6 +3,12 @@
 Platform
 ===================================
 
+.. warning::
+    **Tutorials are outdated**
+
+    These tutorials use a deprecated workflow of the Lightly Solution and will break.
+    Please refer to the `new documentation and tutorials <https://docs.lightly.ai>`_ instead.
+
 Lightly is more than just a framework for self-supervised learning. We built a complete data curation platform on top.
 Use the embeddings generated using the lightly framework and use them to curate your dataset. Collaborate with your friends
 and share the curated data with your favorite data labeling partner.

--- a/docs/source/tutorials/platform.rst
+++ b/docs/source/tutorials/platform.rst
@@ -6,7 +6,7 @@ Platform
 .. warning::
     **Tutorials are outdated**
 
-    These tutorials use a deprecated workflow of the Lightly Solution and will break.
+    These tutorials use a deprecated workflow of the Lightly Solution and will be removed in the future.
     Please refer to the `new documentation and tutorials <https://docs.lightly.ai>`_ instead.
 
 Lightly is more than just a framework for self-supervised learning. We built a complete data curation platform on top.

--- a/docs/source/tutorials_source/platform/tutorial_active_learning.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning.py
@@ -8,7 +8,7 @@ Tutorial 3: Active learning for classification
 .. warning::
     **Tutorial is outdated**
 
-    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    This tutorial uses a deprecated workflow of the Lightly Solution and will be removed in the future.
     Please use the tutorial to do `Active Learning Using YOLOv7 and Comma10k <https://docs.lightly.ai/docs/active-learning-yolov7>`_ instead.
 
 We provide the tutorial in a ready to use 

--- a/docs/source/tutorials_source/platform/tutorial_active_learning.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning.py
@@ -5,6 +5,12 @@
 Tutorial 3: Active learning for classification
 ==============================================
 
+.. warning::
+    **Tutorial is outdated**
+
+    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    Please use the tutorial to do `Active Learning Using YOLOv7 and Comma10k <https://docs.lightly.ai/docs/active-learning-yolov7>`_ instead.
+
 We provide the tutorial in a ready to use 
 `Google Colab <https://colab.research.google.com/drive/1E3rz7fY7UqXNI_VYNxSu6KvQINzotwrz?usp=sharing>`_ 
 notebook:

--- a/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
@@ -5,6 +5,12 @@
 Tutorial 4: Active Learning using Detectron2 on Comma10k
 =========================================================
 
+.. warning::
+    **Tutorial is outdated**
+
+    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    Please use the tutorial to do `Active Learning Using YOLOv7 and Comma10k <https://docs.lightly.ai/docs/active-learning-yolov7>`_ instead.
+
 Active learning is a process of using model predictions to find a new set of
 images to annotate. The images are chosen to have a maximal impact on the model
 performance. In this tutorial, we will use a pre-trained object detection model

--- a/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
+++ b/docs/source/tutorials_source/platform/tutorial_active_learning_detectron2.py
@@ -8,7 +8,7 @@ Tutorial 4: Active Learning using Detectron2 on Comma10k
 .. warning::
     **Tutorial is outdated**
 
-    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    This tutorial uses a deprecated workflow of the Lightly Solution and will be removed in the future.
     Please use the tutorial to do `Active Learning Using YOLOv7 and Comma10k <https://docs.lightly.ai/docs/active-learning-yolov7>`_ instead.
 
 Active learning is a process of using model predictions to find a new set of

--- a/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
+++ b/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
@@ -15,7 +15,7 @@ Tutorial 5: Custom Metadata and Rebalancing
     **Tutorial is outdated**
 
     This tutorial uses a deprecated workflow of the Lightly Solution and will break.
-    Please use the tutorial to do `Active Learning Using YOLOv7 for Waste Sorting <https://docs.lightly.ai/docs/active-learning-yolov7>`_ instead.
+    Please use the tutorial to do `Assertion-based Active Learning with YOLOv8 <https://docs.lightly.ai/docs/assertion-based-active-learning-tutorial>`_ instead.
 
 The addition of custom metadata to your dataset can lead to valuable insights which
 in turn can drastically improve your machine learning models. Lightly supports the upload

--- a/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
+++ b/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
@@ -11,6 +11,12 @@
 Tutorial 5: Custom Metadata and Rebalancing
 =============================================
 
+.. warning::
+    **Tutorial is outdated**
+
+    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    Please use the tutorial to do `Active Learning Using YOLOv7 for Waste Sorting <https://docs.lightly.ai/docs/active-learning-yolov7>`_ instead.
+
 The addition of custom metadata to your dataset can lead to valuable insights which
 in turn can drastically improve your machine learning models. Lightly supports the upload
 of categorical (e.g. weather scenario, road type, or copyright license) and numerical metadata (e.g.

--- a/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
+++ b/docs/source/tutorials_source/platform/tutorial_aquarium_custom_metadata.py
@@ -14,7 +14,7 @@ Tutorial 5: Custom Metadata and Rebalancing
 .. warning::
     **Tutorial is outdated**
 
-    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    This tutorial uses a deprecated workflow of the Lightly Solution and will be removed in the future.
     Please use the tutorial to do `Assertion-based Active Learning with YOLOv8 <https://docs.lightly.ai/docs/assertion-based-active-learning-tutorial>`_ instead.
 
 The addition of custom metadata to your dataset can lead to valuable insights which

--- a/docs/source/tutorials_source/platform/tutorial_cropped_objects_metadata.py
+++ b/docs/source/tutorials_source/platform/tutorial_cropped_objects_metadata.py
@@ -5,20 +5,25 @@
 Tutorial 6: Find false negatives of object detection
 ====================================================
 
-    In object detection applications, it can happen that the detector does not detect an object
-    because it did not see any examples of this or similar objects yet.
-    This is especially a problem in warehouse and retail applications,
-    as new products get added to the shelves every day. These new products with new appearence
-    often have a low so-called objectness score. Currently, finding such negative samples
-    requires a lot of manual labour, especially when having 1000s of new images coming
-    in every day. Lightly can make this work easier in a two-step approach:
+.. warning::
+    **Tutorial is outdated**
 
-    1. A human finds one false negative and adds it to the missing examples.
-    2. Lightly finds all similar images which are also false negatives.
-        Thus it can propose to directly also add them as missing examples.
+    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    Please use the tutorial to do `Active Learning Using YOLOv7 for Waste Sorting <https://docs.lightly.ai/docs/active-learning-for-waste-sorting>`_ instead.
 
-    If there are e.g. 9 similar images for each missing example found by a human,
-    Lightly can speed up the process by a factor of 10.
+In object detection applications, it can happen that the detector does not detect an object
+because it did not see any examples of this or similar objects yet.
+This is especially a problem in warehouse and retail applications,
+as new products get added to the shelves every day. These new products with new appearence
+often have a low so-called objectness score. Currently, finding such negative samples
+requires a lot of manual labour, especially when having 1000s of new images coming
+in every day. Lightly can make this work easier in a two-step approach:
+
+1. A human finds one false negative and adds it to the missing examples.
+2. Lightly finds all similar images which are also false negatives. Thus it can propose to directly also add them as missing examples.
+
+If there are e.g. 9 similar images for each missing example found by a human,
+Lightly can speed up the process by a factor of 10.
 
 What you will learn
 --------------------

--- a/docs/source/tutorials_source/platform/tutorial_cropped_objects_metadata.py
+++ b/docs/source/tutorials_source/platform/tutorial_cropped_objects_metadata.py
@@ -8,7 +8,7 @@ Tutorial 6: Find false negatives of object detection
 .. warning::
     **Tutorial is outdated**
 
-    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    This tutorial uses a deprecated workflow of the Lightly Solution and will be removed in the future.
     Please use the tutorial to do `Active Learning Using YOLOv7 for Waste Sorting <https://docs.lightly.ai/docs/active-learning-for-waste-sorting>`_ instead.
 
 In object detection applications, it can happen that the detector does not detect an object

--- a/docs/source/tutorials_source/platform/tutorial_label_studio_export.py
+++ b/docs/source/tutorials_source/platform/tutorial_label_studio_export.py
@@ -5,6 +5,12 @@
 Tutorial 10: Export to LabelStudio
 =============================================
 
+.. warning::
+    **Tutorial is outdated**
+
+    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    Please refer to the `Labelbox export documentation <https://docs.lightly.ai/docs/labelbox>`_ instead.
+
 This tutorial shows how you can easily label all images of a tag from Lightly
 using the open-source data labeling tool `LabelStudio <https://labelstud.io>`_.
 

--- a/docs/source/tutorials_source/platform/tutorial_label_studio_export.py
+++ b/docs/source/tutorials_source/platform/tutorial_label_studio_export.py
@@ -5,11 +5,6 @@
 Tutorial 10: Export to LabelStudio
 =============================================
 
-.. warning::
-    **Tutorial is outdated**
-
-    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
-    Please refer to the `Labelbox export documentation <https://docs.lightly.ai/docs/labelbox>`_ instead.
 
 This tutorial shows how you can easily label all images of a tag from Lightly
 using the open-source data labeling tool `LabelStudio <https://labelstud.io>`_.
@@ -27,9 +22,7 @@ and optionally already chosen a subset of it and created a tag for it.
 Now you want to label all images of this tag using LabelStudio.
 
 If you have not created your own dataset yet, you can use any dataset
-(e.g. the playground dataset) or follow one of the other tutorials to create one.
-The :ref:`lightly-tutorial-sunflowers`
-is particularly well-suited.
+(e.g. the playground dataset) or follow the `docs <https://docs.lightly.ai>`_ to create one.
 
 Launch LabelStudio
 ------------------

--- a/docs/source/tutorials_source/platform/tutorial_pizza_filter.py
+++ b/docs/source/tutorials_source/platform/tutorial_pizza_filter.py
@@ -10,6 +10,12 @@ This documentation accompanies the video tutorial: `youtube link <https://youtu.
 Tutorial 1: Curate Pizza Images
 ===============================
 
+.. warning::
+    **Tutorial is outdated**
+
+    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    Please refer to the `new documentation and tutorials <https://docs.lightly.ai>`_ instead.
+
 In this tutorial, you will learn how to upload a dataset to the Lightly platform,
 curate the data, and finally use the curated data to train a model.
 

--- a/docs/source/tutorials_source/platform/tutorial_pizza_filter.py
+++ b/docs/source/tutorials_source/platform/tutorial_pizza_filter.py
@@ -13,7 +13,7 @@ Tutorial 1: Curate Pizza Images
 .. warning::
     **Tutorial is outdated**
 
-    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    This tutorial uses a deprecated workflow of the Lightly Solution and will be removed in the future.
     Please refer to the `new documentation and tutorials <https://docs.lightly.ai>`_ instead.
 
 In this tutorial, you will learn how to upload a dataset to the Lightly platform,

--- a/docs/source/tutorials_source/platform/tutorial_sunflowers.py
+++ b/docs/source/tutorials_source/platform/tutorial_sunflowers.py
@@ -5,6 +5,12 @@
 Tutorial 2: Diversify the Sunflowers Dataset
 =============================================
 
+.. warning::
+    **Tutorial is outdated**
+
+    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    Please refer to the ``new documentation and tutorials <https://docs.lightly.ai>`_ instead.
+
 This tutorial highlights the basic functionality of selecting a subset in the web-app.
 You can use the CORESET selection strategy to choose a diverse subset of your dataset.
 This can be useful many purposes, e.g. for having a good subset of data to label

--- a/docs/source/tutorials_source/platform/tutorial_sunflowers.py
+++ b/docs/source/tutorials_source/platform/tutorial_sunflowers.py
@@ -9,7 +9,7 @@ Tutorial 2: Diversify the Sunflowers Dataset
     **Tutorial is outdated**
 
     This tutorial uses a deprecated workflow of the Lightly Solution and will break.
-    Please refer to the ``new documentation and tutorials <https://docs.lightly.ai>`_ instead.
+    Please refer to the `new documentation and tutorials <https://docs.lightly.ai>`_ instead.
 
 This tutorial highlights the basic functionality of selecting a subset in the web-app.
 You can use the CORESET selection strategy to choose a diverse subset of your dataset.

--- a/docs/source/tutorials_source/platform/tutorial_sunflowers.py
+++ b/docs/source/tutorials_source/platform/tutorial_sunflowers.py
@@ -8,7 +8,7 @@ Tutorial 2: Diversify the Sunflowers Dataset
 .. warning::
     **Tutorial is outdated**
 
-    This tutorial uses a deprecated workflow of the Lightly Solution and will break.
+    This tutorial uses a deprecated workflow of the Lightly Solution and will be removed in the future.
     Please refer to the `new documentation and tutorials <https://docs.lightly.ai>`_ instead.
 
 This tutorial highlights the basic functionality of selecting a subset in the web-app.


### PR DESCRIPTION
## Add deprecation warnings to all tutorials

- `platform.rst `-> refer to general new docs
- AL tutorials -> refer to `Active Learning Using YOLOv7 and Comma10k`
- Custom metadata tutorial -> refer to `Assertion-based Active Learning with YOLOv8`
- Cropped objects tutorial -> refer to `Active Learning Using YOLOv7 for Waste Sorting`
- Label studio export tutorial -> NO deprecation warning, but linked different docs to create a dataset.
- pizza & sunflowers tutorial -> refer to general new docs

- Tutorial 7: Active Learning with Nvidia TLT -> Already has a [deprecation note](https://github.com/lightly-ai/NvidiaTLTActiveLearning/tree/main).
- Tutorial 8: Integration with LabelStudio for Active Learning -> Please approve the separate PR: https://github.com/lightly-ai/Lightly_LabelStudio_AL/pull/4/files
- Tutorial 9: Embedded COVID mask detection -> Kept as it is
