### PR TITLE
Fix VICRegL

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ One epoch on cifar10 takes ~35 seconds on a V100 GPU. [Learn more about the cifa
 | SMoG             |    800 |        256 |         0.782 |
 | TiCo             |    800 |        256 |         0.857 |
 | VICReg           |    800 |        256 |         0.843 |
-| VICRegL          |    800 |        256 |         0.799 |
+| VICRegL          |    800 |        256 |         0.781 |
 
 
 #### Cifar10

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -62,7 +62,7 @@ The current benchmark contains the following models:
   "SMoG", "800", "256", "0.782", "250.2 Min", "2.5 GByte"
   "TiCo", "800", "256", "0.857", "184.7 Min", "2.5 GByte"
   "VICReg", "800", "256", "0.843", "192.9 Min", "5.7 GByte"
-  "VICRegL", "800", "256", "0.799", "180.0 Min", "2.6 GByte"
+  "VICRegL", "800", "256", "0.781", "207.4 Min", "5.7 GByte"
 
 You can reproduce the benchmarks using the following script:
 :download:`imagenette_benchmark.py <benchmarks/imagenette_benchmark.py>` 

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1192,7 +1192,7 @@ class VICRegLModel(BenchmarkModule):
         views_and_grids = batch[0]
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]
-        features = [model(view) for view in views]
+        features = [self.forward(view) for view in views]
         z_a, z_a_local_features = features[0]
         grid_a = grids[0]
         loss = 0

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1205,8 +1205,8 @@ class VICRegLModel(BenchmarkModule):
         # Training diverges without LARS
         optim = LARS(
             self.parameters(),
-            lr=0.1 * lr_factor,
-            weight_decay=1e-6,
+            lr=0.3 * lr_factor,
+            weight_decay=1e-4,
             momentum=0.9,
         )
         cosine_scheduler = scheduler.CosineWarmupScheduler(

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1193,18 +1193,12 @@ class VICRegLModel(BenchmarkModule):
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]
         features = [self.forward(view) for view in views]
-        z_a, z_a_local_features = features[0]
-        grid_a = grids[0]
-        loss = 0
-        for (z_b, z_b_local_features), grid_b in zip(features[1:], grids[1:]):
-            loss += self.criterion(
-                z_a=z_a,
-                z_b=z_b,
-                z_a_local_features=z_a_local_features,
-                z_b_local_features=z_b_local_features,
-                grid_a=grid_a,
-                grid_b=grid_b,
-            )
+        loss = self.criterion(
+            global_view_features=features[:2],
+            global_view_grids=grids[:2],
+            local_view_features=features[2:],
+            local_view_grids=grids[2:],
+        )
         return loss
 
     def configure_optimizers(self):

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -51,7 +51,7 @@ Results (20.3.2023):
 | SMoG             |        256 |    800 |              0.782 |  250.2 Min |      2.5 GByte |
 | TiCo             |        256 |    800 |              0.857 |  184.7 Min |      2.5 GByte |
 | VICReg           |        256 |    800 |              0.843 |  192.9 Min |      5.7 GByte |
-| VICRegL          |        256 |    800 |              0.799 |  180.0 Min |      2.6 GByte |
+| VICRegL          |        256 |    800 |              0.781 |  207.4 Min |      5.7 GByte |
 ---------------------------------------------------------------------------------------------
 
 """
@@ -1176,7 +1176,7 @@ class VICRegLModel(BenchmarkModule):
         self.projection_head = heads.BarlowTwinsProjectionHead(512, 2048, 2048)
         self.local_projection_head = heads.VicRegLLocalProjectionHead(512, 128, 128)
         self.average_pool = nn.AdaptiveAvgPool2d(output_size=(1, 1))
-        self.criterion = VICRegLLoss(num_matches=(8, 4))
+        self.criterion = VICRegLLoss(num_matches=(16, 4))
         self.backbone = nn.Sequential(self.train_backbone, self.average_pool)
         self.warmup_epochs = 20 if max_epochs >= 800 else 10
 

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -199,9 +199,8 @@ vicreg_transform = VICRegTransform(
 # Transform  passing geometrical transformation for VICRegL
 vicregl_transform = VICRegLTransform(
     global_crop_size=128,
-    local_crop_size=64,
+    n_local_views=0,
     global_grid_size=4,
-    local_grid_size=2,
     cj_strength=0.5,
 )
 

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1189,17 +1189,22 @@ class VICRegLModel(BenchmarkModule):
         return z, z_local
 
     def training_step(self, batch, batch_index):
-        (view_global, view_local, grid_global, grid_local), _, _ = batch
-        z_global, z_global_local_features = self.forward(view_global)
-        z_local, z_local_local_features = self.forward(view_local)
-        loss = self.criterion(
-            z_global=z_global,
-            z_local=z_local,
-            z_global_local_features=z_global_local_features,
-            z_local_local_features=z_local_local_features,
-            grid_global=grid_global,
-            grid_local=grid_local,
-        )
+        views_and_grids = batch[0]
+        views = views_and_grids[: len(views_and_grids) // 2]
+        grids = views_and_grids[len(views_and_grids) // 2 :]
+        features = [model(view) for view in views]
+        z_a, z_a_local_features = features[0]
+        grid_a = grids[0]
+        loss = 0
+        for (z_b, z_b_local_features), grid_b in zip(features[1:], grids[1:]):
+            loss += self.criterion(
+                z_a=z_a,
+                z_b=z_b,
+                z_a_local_features=z_a_local_features,
+                z_b_local_features=z_b_local_features,
+                grid_a=grid_a,
+                grid_b=grid_b,
+            )
         return loss
 
     def configure_optimizers(self):

--- a/examples/pytorch/vicregl.py
+++ b/examples/pytorch/vicregl.py
@@ -56,7 +56,7 @@ dataloader = torch.utils.data.DataLoader(
 )
 
 criterion = VICRegLLoss()
-optimizer = torch.optim.SGD(model.parameters(), lr=0.06, momentum=0.9)
+optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
 
 print("Starting Training")
 for epoch in range(10):
@@ -66,18 +66,12 @@ for epoch in range(10):
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]
         features = [model(view) for view in views]
-        z_a, z_a_local_features = features[0]
-        grid_a = grids[0]
-        loss = 0
-        for (z_b, z_b_local_features), grid_b in zip(features[1:], grids[1:]):
-            loss += criterion(
-                z_a=z_a,
-                z_b=z_b,
-                z_a_local_features=z_a_local_features,
-                z_b_local_features=z_b_local_features,
-                grid_a=grid_a,
-                grid_b=grid_b,
-            )
+        loss = criterion(
+            global_view_features=features[:2],
+            global_view_grids=grids[:2],
+            local_view_features=features[2:],
+            local_view_grids=grids[2:],
+        )
         total_loss += loss.detach()
         loss.backward()
         optimizer.step()

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -40,18 +40,12 @@ class VICRegL(pl.LightningModule):
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]
         features = [self.forward(view) for view in views]
-        z_a, z_a_local_features = features[0]
-        grid_a = grids[0]
-        loss = 0
-        for (z_b, z_b_local_features), grid_b in zip(features[1:], grids[1:]):
-            loss += self.criterion(
-                z_a=z_a,
-                z_b=z_b,
-                z_a_local_features=z_a_local_features,
-                z_b_local_features=z_b_local_features,
-                grid_a=grid_a,
-                grid_b=grid_b,
-            )
+        loss = self.criterion(
+            global_view_features=features[:2],
+            global_view_grids=grids[:2],
+            local_view_features=features[2:],
+            local_view_grids=grids[2:],
+        )
         return loss
 
     def configure_optimizers(self):

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -49,7 +49,7 @@ class VICRegL(pl.LightningModule):
         return loss
 
     def configure_optimizers(self):
-        optim = torch.optim.SGD(model.parameters(), momentum=0.9, lr=0.06)
+        optim = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
         return optim
 
 

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -36,17 +36,22 @@ class VICRegL(pl.LightningModule):
         return z, z_local
 
     def training_step(self, batch, batch_index):
-        (view_global, view_local, grid_global, grid_local), _, _ = batch
-        z_global, z_global_local_features = self.forward(view_global)
-        z_local, z_local_local_features = self.forward(view_local)
-        loss = self.criterion(
-            z_global=z_global,
-            z_local=z_local,
-            z_global_local_features=z_global_local_features,
-            z_local_local_features=z_local_local_features,
-            grid_global=grid_global,
-            grid_local=grid_local,
-        )
+        views_and_grids = batch[0]
+        views = views_and_grids[: len(views_and_grids) // 2]
+        grids = views_and_grids[len(views_and_grids) // 2 :]
+        features = [model(view) for view in views]
+        z_a, z_a_local_features = features[0]
+        grid_a = grids[0]
+        loss = 0
+        for (z_b, z_b_local_features), grid_b in zip(features[1:], grids[1:]):
+            loss += self.criterion(
+                z_a=z_a,
+                z_b=z_b,
+                z_a_local_features=z_a_local_features,
+                z_b_local_features=z_b_local_features,
+                grid_a=grid_a,
+                grid_b=grid_b,
+            )
         return loss
 
     def configure_optimizers(self):
@@ -59,7 +64,7 @@ model = VICRegL()
 pascal_voc = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc", download=True, target_transform=lambda t: 0
 )
-transform = VICRegLTransform()
+transform = VICRegLTransform(n_local_views=0)
 dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -39,7 +39,7 @@ class VICRegL(pl.LightningModule):
         views_and_grids = batch[0]
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]
-        features = [model(view) for view in views]
+        features = [self.forward(view) for view in views]
         z_a, z_a_local_features = features[0]
         grid_a = grids[0]
         loss = 0

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -40,18 +40,12 @@ class VICRegL(pl.LightningModule):
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]
         features = [self.forward(view) for view in views]
-        z_a, z_a_local_features = features[0]
-        grid_a = grids[0]
-        loss = 0
-        for (z_b, z_b_local_features), grid_b in zip(features[1:], grids[1:]):
-            loss += self.criterion(
-                z_a=z_a,
-                z_b=z_b,
-                z_a_local_features=z_a_local_features,
-                z_b_local_features=z_b_local_features,
-                grid_a=grid_a,
-                grid_b=grid_b,
-            )
+        loss = self.criterion(
+            global_view_features=features[:2],
+            global_view_grids=grids[:2],
+            local_view_features=features[2:],
+            local_view_grids=grids[2:],
+        )
         return loss
 
     def configure_optimizers(self):

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -49,7 +49,7 @@ class VICRegL(pl.LightningModule):
         return loss
 
     def configure_optimizers(self):
-        optim = torch.optim.SGD(model.parameters(), momentum=0.9, lr=0.06)
+        optim = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
         return optim
 
 

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -36,17 +36,22 @@ class VICRegL(pl.LightningModule):
         return z, z_local
 
     def training_step(self, batch, batch_index):
-        (view_global, view_local, grid_global, grid_local), _, _ = batch
-        z_global, z_global_local_features = self.forward(view_global)
-        z_local, z_local_local_features = self.forward(view_local)
-        loss = self.criterion(
-            z_global=z_global,
-            z_local=z_local,
-            z_global_local_features=z_global_local_features,
-            z_local_local_features=z_local_local_features,
-            grid_global=grid_global,
-            grid_local=grid_local,
-        )
+        views_and_grids = batch[0]
+        views = views_and_grids[: len(views_and_grids) // 2]
+        grids = views_and_grids[len(views_and_grids) // 2 :]
+        features = [model(view) for view in views]
+        z_a, z_a_local_features = features[0]
+        grid_a = grids[0]
+        loss = 0
+        for (z_b, z_b_local_features), grid_b in zip(features[1:], grids[1:]):
+            loss += self.criterion(
+                z_a=z_a,
+                z_b=z_b,
+                z_a_local_features=z_a_local_features,
+                z_b_local_features=z_b_local_features,
+                grid_a=grid_a,
+                grid_b=grid_b,
+            )
         return loss
 
     def configure_optimizers(self):
@@ -59,7 +64,7 @@ model = VICRegL()
 pascal_voc = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc", download=True, target_transform=lambda t: 0
 )
-transform = VICRegLTransform()
+transform = VICRegLTransform(n_local_views=0)
 dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -39,7 +39,7 @@ class VICRegL(pl.LightningModule):
         views_and_grids = batch[0]
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]
-        features = [model(view) for view in views]
+        features = [self.forward(view) for view in views]
         z_a, z_a_local_features = features[0]
         grid_a = grids[0]
         loss = 0

--- a/lightly/loss/vicreg_loss.py
+++ b/lightly/loss/vicreg_loss.py
@@ -65,7 +65,7 @@ class VICRegLoss(torch.nn.Module):
     def forward(self, z_a: torch.Tensor, z_b: torch.Tensor) -> torch.Tensor:
         assert (
             z_a.shape[0] > 1 and z_b.shape[0] > 1
-        ), f"z_a and z_b must have batch size > 1 but found {z_a.shape[0]} and  {z_b.shape[0]}"
+        ), f"z_a and z_b must have batch size > 1 but found {z_a.shape[0]} and {z_b.shape[0]}"
         assert (
             z_a.shape == z_b.shape
         ), f"z_a and z_b must have same shape but found {z_a.shape} and {z_b.shape}."

--- a/lightly/loss/vicreg_loss.py
+++ b/lightly/loss/vicreg_loss.py
@@ -25,7 +25,7 @@ class VICRegLoss(torch.nn.Module):
             If True then the cross-correlation matrices from all gpus are gathered and
             summed before the loss calculation.
         eps:
-            Numerical epsilon.
+            Epsilon for numerical stability.
 
     Examples:
 
@@ -59,6 +59,14 @@ class VICRegLoss(torch.nn.Module):
         self.eps = eps
 
     def forward(self, z_a: torch.Tensor, z_b: torch.Tensor) -> torch.Tensor:
+        """Returns VICReg loss.
+
+        Args:
+            z_a:
+                Tensor with shape (batch_size, ..., dim).
+            z_b:
+                Tensor with shape (batch_size, ..., dim).
+        """
         assert (
             z_a.shape[0] > 1 and z_b.shape[0] > 1
         ), f"z_a and z_b must have batch size > 1 but found {z_a.shape[0]} and {z_b.shape[0]}"
@@ -90,10 +98,26 @@ class VICRegLoss(torch.nn.Module):
 
 
 def invariance_loss(x: Tensor, y: Tensor) -> Tensor:
+    """Returns VICReg invariance loss.
+
+    Args:
+        x:
+            Tensor with shape (batch_size, ..., dim).
+        y:
+            Tensor with shape (batch_size, ..., dim).
+    """
     return F.mse_loss(x, y)
 
 
 def variance_loss(x: Tensor, eps: float = 0.0001) -> Tensor:
+    """Returns VICReg variance loss.
+
+    Args:
+        x:
+            Tensor with shape (batch_size, ..., dim).
+        eps:
+            Epsilon for numerical stability.
+    """
     x = x - x.mean(dim=0)
     std = torch.sqrt(x.var(dim=0) + eps)
     loss = torch.mean(F.relu(1.0 - std))
@@ -101,10 +125,22 @@ def variance_loss(x: Tensor, eps: float = 0.0001) -> Tensor:
 
 
 def covariance_loss(x: Tensor) -> Tensor:
+    """Returns VICReg covariance loss.
+
+    Generalized version of the covariance loss with support for tensors with more than
+    two dimensions. Adapted from VICRegL:
+    https://github.com/facebookresearch/VICRegL/blob/803ae4c8cd1649a820f03afb4793763e95317620/main_vicregl.py#L299
+
+    Args:
+        x:
+            Tensor with shape (batch_size, ..., dim).
+    """
     x = x - x.mean(dim=0)
     batch_size = x.size(0)
     dim = x.size(-1)
+    # nondiag_mask has shape (dim, dim) with 1s on all non-diagonal entries.
     nondiag_mask = ~torch.eye(dim, device=x.device, dtype=torch.bool)
+    # cov has shape (..., dim, dim)
     cov = torch.einsum("b...c,b...d->...cd", x, x) / (batch_size - 1)
     loss = cov[..., nondiag_mask].pow(2).sum(-1) / dim
     return loss.mean()

--- a/lightly/loss/vicreg_loss.py
+++ b/lightly/loss/vicreg_loss.py
@@ -6,11 +6,25 @@ from lightly.utils.dist import gather
 
 
 class VICRegLoss(torch.nn.Module):
-    """Implementation of the VICReg Loss from VICReg[0] paper.
-    This implementation follows the code published by the authors. [1]
+    """Implementation of the VICReg loss [0].
 
-    [0] Bardes, A. et. al, 2022, VICReg... https://arxiv.org/abs/2105.04906
-    [1] https://github.com/facebookresearch/vicreg/
+    This implementation is based on the code published by the authors [1].
+
+    - [0] VICReg, 2022, https://arxiv.org/abs/2105.04906
+    - [1] https://github.com/facebookresearch/vicreg/
+
+    Attributes:
+        lambda_param:
+            Scaling coefficient for the invariance term of the loss.
+        mu_param:
+            Scaling coefficient for the variance term of the loss.
+        nu_param:
+            Scaling coefficient for the covariance term of the loss.
+        gather_distributed:
+            If True then the cross-correlation matrices from all gpus are gathered and
+            summed before the loss calculation.
+        eps:
+            Numerical epsilon.
 
     Examples:
 
@@ -36,30 +50,11 @@ class VICRegLoss(torch.nn.Module):
         gather_distributed: bool = False,
         eps=0.0001,
     ):
-        """Lambda, mu and nu params configuration with default value like in [0]
-        Args:
-            lambda_param:
-                Coefficient for the invariance term of the loss
-                Defaults to 25.0 [0].
-            mu_param:
-                Coefficient for the variance term of the loss
-                Defaults to 25.0 [0].
-            nu_param:
-                Coefficient for the covariance term of the loss
-                Defaults to 1.0 [0].
-            gather_distributed:
-                If True then the cross-correlation matrices from all gpus are
-                gathered and summed before the loss calculation.
-            eps:
-                Numerical epsilon
-                Defaults to 0.0001 [1].
-        """
         super(VICRegLoss, self).__init__()
         self.lambda_param = lambda_param
         self.mu_param = mu_param
         self.nu_param = nu_param
         self.gather_distributed = gather_distributed
-
         self.eps = eps
 
     def forward(self, z_a: torch.Tensor, z_b: torch.Tensor) -> torch.Tensor:

--- a/lightly/loss/vicreg_loss.py
+++ b/lightly/loss/vicreg_loss.py
@@ -86,12 +86,6 @@ class VICRegLoss(torch.nn.Module):
             + self.mu_param * var_loss
             + self.nu_param * cov_loss
         )
-        print(
-            "vic",
-            self.lambda_param * inv_loss,
-            self.mu_param * var_loss,
-            self.nu_param * cov_loss,
-        )
         return loss
 
 
@@ -100,7 +94,6 @@ def invariance_loss(x: Tensor, y: Tensor) -> Tensor:
 
 
 def variance_loss(x: Tensor, eps: float = 0.0001) -> Tensor:
-    print("x", x, x.sum())
     x = x - x.mean(dim=0)
     std = torch.sqrt(x.var(dim=0) + eps)
     loss = torch.mean(F.relu(1.0 - std))

--- a/lightly/loss/vicregl_loss.py
+++ b/lightly/loss/vicregl_loss.py
@@ -1,11 +1,16 @@
 from typing import Optional, Sequence, Tuple
 
 import torch
-import torch.nn.functional as F
-from torch import Tensor
+from torch import Tensor, dist
 
-from lightly.loss.vicreg_loss import VICRegLoss
+from lightly.loss.vicreg_loss import (
+    VICRegLoss,
+    covariance_loss,
+    invariance_loss,
+    variance_loss,
+)
 from lightly.models.utils import nearest_neighbors
+from lightly.utils.dist import gather
 
 
 class VICRegLLoss(torch.nn.Module):
@@ -63,122 +68,18 @@ class VICRegLLoss(torch.nn.Module):
         super(VICRegLLoss, self).__init__()
         self.alpha = alpha
         self.num_matches = num_matches
-        self.vicregloss = VICRegLoss(
+        self.lambda_param = lambda_param
+        self.mu_param = mu_param
+        self.nu_param = nu_param
+        self.eps = eps
+        self.gather_distributed = gather_distributed
+        self.vicreg_loss = VICRegLoss(
             lambda_param=lambda_param,
             mu_param=mu_param,
-            nu_param=nu_param,
+            nu_param=0.5 * nu_param,
             eps=eps,
             gather_distributed=gather_distributed,
         )
-
-    def _nearest_neighbors_on_l2(
-        self, input_maps: Tensor, candidate_maps: Tensor, num_matches: int
-    ) -> Tuple[Tensor, Tensor]:
-        """
-        input_maps: (B, H * W, C)
-        candidate_maps: (B, H * W, C)
-
-        Returns:
-            (nn_input, nn_candidate) tuple containing two tensors with shape
-            (B * num_matches, C).
-        """
-        distances = torch.cdist(input_maps, candidate_maps)
-        nn_input, nn_candidate = nearest_neighbors(
-            input_maps, candidate_maps, distances, num_matches
-        )
-        return nn_input.flatten(end_dim=1), nn_candidate.flatten(end_dim=1)
-
-    def _nearest_neighbors_on_grid(
-        self,
-        input_grid: Tensor,
-        candidate_grid: Tensor,
-        input_maps: Tensor,
-        candidate_maps: Tensor,
-        num_matches: int,
-    ) -> Tuple[Tensor, Tensor]:
-        """
-        input_grid: (B, H * W, 2)
-        candidate_grid: (B, H * W, 2)
-        input_maps: (B, H * W, C)
-        candidate_maps: (B, H * W, C)
-
-        Returns:
-            (nn_input, nn_candidate) tuple containing two tensors with shape
-            (B * num_matches, C).
-        """
-        distances = torch.cdist(input_grid, candidate_grid)
-        nn_input, nn_candidate = nearest_neighbors(
-            input_maps, candidate_maps, distances, num_matches
-        )
-        return nn_input.flatten(end_dim=1), nn_candidate.flatten(end_dim=1)
-
-    def local_loss(
-        self,
-        z_a: Tensor,
-        z_b: Tensor,
-        grid_a: Tensor,
-        grid_b: Tensor,
-        num_matches: int,
-    ) -> Tensor:
-        """Computes the local loss between two sets of local features using nearest
-        neighbors.
-
-        Args:
-            z_a:
-                A local features tensor from a global view. Must have size:
-                (batch_size, global_view_height, global_view_width, global_feature_dim).
-            z_b:
-                A local features tensor from a global or local view. Must have
-                size: (batch_size, height, width, global_feature_dim) where height and
-                width depend on the view type.
-            grid_a:
-                A tensor of grids from a global view. Must have size:
-                (batch_size, grid_size, grid_size, 2).
-            grid_b:
-                A tensor of grids from a global or local  view. Musth have size:
-                (batch_size, grid_size, grid_size, 2).
-            num_matches:
-                Number of features to match using nearest neighbors.
-
-        Returns:
-            The local loss.
-        """
-        z_a = z_a.flatten(start_dim=1, end_dim=2)
-        z_b = z_b.flatten(start_dim=1, end_dim=2)
-
-        # L2 based loss
-        z_a_filtered, z_a_nn = self._nearest_neighbors_on_l2(
-            input_maps=z_a, candidate_maps=z_b, num_matches=num_matches
-        )
-        z_b_filtered, z_b_nn = self._nearest_neighbors_on_l2(
-            input_maps=z_b, candidate_maps=z_a, num_matches=num_matches
-        )
-        l2_loss_a = self.vicregloss.forward(z_a=z_a_filtered, z_b=z_a_nn)
-        l2_loss_b = self.vicregloss.forward(z_a=z_b_filtered, z_b=z_b_nn)
-        l2_loss = (l2_loss_a + l2_loss_b) / 2
-
-        # Grid based loss
-        grid_a = grid_a.flatten(start_dim=1, end_dim=2)
-        grid_b = grid_b.flatten(start_dim=1, end_dim=2)
-        z_a_filtered, z_a_nn = self._nearest_neighbors_on_grid(
-            input_grid=grid_a,
-            candidate_grid=grid_b,
-            input_maps=z_a,
-            candidate_maps=z_b,
-            num_matches=num_matches,
-        )
-        z_b_filtered, z_b_nn = self._nearest_neighbors_on_grid(
-            input_grid=grid_b,
-            candidate_grid=grid_a,
-            input_maps=z_b,
-            candidate_maps=z_a,
-            num_matches=num_matches,
-        )
-
-        grid_loss_a = self.vicregloss.forward(z_a=z_a_filtered, z_b=z_a_nn)
-        grid_loss_b = self.vicregloss.forward(z_a=z_b_filtered, z_b=z_b_nn)
-        grid_loss = (grid_loss_a + grid_loss_b) / 2
-        return l2_loss + grid_loss
 
     def forward(
         self,
@@ -236,30 +137,95 @@ class VICRegLLoss(torch.nn.Module):
                 f"None but found {type(local_view_features)} and {type(local_view_grids)}."
             )
 
-        # calculate global features loss
-        global_features_loss = 0
-        global_loss_count = 0
-        for z_a_global_features, _ in global_view_features:
+        # calculate loss from global features
+        global_loss = self._global_loss(
+            global_view_features=global_view_features,
+            local_view_features=local_view_features,
+        )
+
+        # calculate loss from local features
+        local_loss = self._local_loss(
+            global_view_features=global_view_features,
+            global_view_grids=global_view_grids,
+            local_view_features=local_view_features,
+            local_view_grids=local_view_grids,
+        )
+
+        loss = self.alpha * global_loss + (1 - self.alpha) * local_loss
+        return loss
+
+    def _global_loss(
+        self,
+        global_view_features: Sequence[Tuple[Tensor, Tensor]],
+        local_view_features: Optional[Sequence[Tuple[Tensor, Tensor]]] = None,
+    ) -> Tensor:
+        inv_loss = self._global_invariance_loss(
+            global_view_features=global_view_features,
+            local_view_features=local_view_features,
+        )
+        var_loss, cov_loss = self._global_variance_and_covariance_loss(
+            global_view_features=global_view_features,
+            local_view_features=local_view_features,
+        )
+        return (
+            self.lambda_param * inv_loss
+            + self.mu_param * var_loss
+            + self.nu_param * cov_loss
+        )
+
+    def _global_invariance_loss(
+        self,
+        global_view_features: Sequence[Tuple[Tensor, Tensor]],
+        local_view_features: Optional[Sequence[Tuple[Tensor, Tensor]]] = None,
+    ) -> Tensor:
+        loss = 0
+        loss_count = 0
+        for global_features_a, _ in global_view_features:
             # global views
-            for z_b_global_features, _ in global_view_features:
-                if z_a_global_features is not z_b_global_features:
-                    global_features_loss += self.vicregloss.forward(
-                        z_a=z_a_global_features, z_b=z_b_global_features
-                    )
-                    global_loss_count += 1
+            for global_features_b, _ in global_view_features:
+                if global_features_a is not global_features_b:
+                    loss += invariance_loss(global_features_a, global_features_b)
+                    loss_count += 1
 
             # local views
             if local_view_features is not None:
-                for z_b_global_features, _ in local_view_features:
-                    global_features_loss += self.vicregloss.forward(
-                        z_a=z_a_global_features, z_b=z_b_global_features
-                    )
-                    global_loss_count += 1
-        global_features_loss /= global_loss_count
+                for global_features_b, _ in local_view_features:
+                    loss += invariance_loss(global_features_a, global_features_b)
+                    loss_count += 1
+        return loss / loss_count
 
-        # calculate local features loss
-        local_features_loss = 0
-        local_loss_count = 0
+    def _global_variance_and_covariance_loss(
+        self,
+        global_view_features: Sequence[Tuple[Tensor, Tensor]],
+        local_view_features: Optional[Sequence[Tuple[Tensor, Tensor]]] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        view_features = list(global_view_features)
+        if local_view_features is not None:
+            view_features = view_features + list(local_view_features)
+
+        var_loss = 0
+        cov_loss = 0
+        loss_count = 0
+        for global_features, _ in view_features:
+            if self.gather_distributed and dist.is_initialized():
+                world_size = dist.get_world_size()
+                if world_size > 1:
+                    global_features = torch.cat(gather(global_features), dim=0)
+
+            var_loss += variance_loss(x=global_features, eps=self.eps)
+            cov_loss += covariance_loss(x=global_features)
+            loss_count += 1
+        return var_loss / loss_count, cov_loss / loss_count
+
+    def _local_loss(
+        self,
+        global_view_features: Sequence[Tuple[Tensor, Tensor]],
+        global_view_grids: Sequence[Tensor],
+        local_view_features: Optional[Sequence[Tuple[Tensor, Tensor]]] = None,
+        local_view_grids: Optional[Sequence[Tensor]] = None,
+    ) -> Tensor:
+        loss = 0
+        loss_count = 0
         for (_, z_a_local_features), grid_a in zip(
             global_view_features, global_view_grids
         ):
@@ -268,30 +234,117 @@ class VICRegLLoss(torch.nn.Module):
                 global_view_features, global_view_grids
             ):
                 if z_a_local_features is not z_b_local_features:
-                    local_features_loss += self.local_loss(
+                    loss += self._local_l2_loss(
+                        z_a=z_a_local_features,
+                        z_b=z_b_local_features,
+                    )
+                    loss += self._local_location_loss(
                         z_a=z_a_local_features,
                         z_b=z_b_local_features,
                         grid_a=grid_a,
                         grid_b=grid_b,
-                        num_matches=self.num_matches[0],
                     )
-                    local_loss_count += 1
+                    loss_count += 1
+
             # local views
             if local_view_features is not None and local_view_grids is not None:
                 for (_, z_b_local_features), grid_b in zip(
                     local_view_features, local_view_grids
                 ):
-                    local_features_loss += self.local_loss(
+                    loss += self._local_l2_loss(
+                        z_a=z_a_local_features,
+                        z_b=z_b_local_features,
+                    )
+                    loss += self._local_location_loss(
                         z_a=z_a_local_features,
                         z_b=z_b_local_features,
                         grid_a=grid_a,
                         grid_b=grid_b,
-                        num_matches=self.num_matches[1],
                     )
-                    local_loss_count += 1
-        local_features_loss /= local_loss_count
+                    loss_count += 1
+        return loss / loss_count
 
-        loss = (
-            self.alpha * global_features_loss + (1 - self.alpha) * local_features_loss
+    def _local_l2_loss(
+        self,
+        z_a: Tensor,
+        z_b: Tensor,
+    ) -> Tensor:
+        z_a = z_a.flatten(start_dim=1, end_dim=2)
+        z_b = z_b.flatten(start_dim=1, end_dim=2)
+
+        z_a_filtered, z_a_nn = self._nearest_neighbors_on_l2(
+            input_maps=z_a, candidate_maps=z_b, num_matches=self.num_matches[0]
         )
-        return loss
+        z_b_filtered, z_b_nn = self._nearest_neighbors_on_l2(
+            input_maps=z_b, candidate_maps=z_a, num_matches=self.num_matches[1]
+        )
+        # print('l2 sum', (z_a_filtered - z_a_nn).sum())
+        loss_a = self.vicreg_loss.forward(z_a=z_a_filtered, z_b=z_a_nn)
+        loss_b = self.vicreg_loss.forward(z_a=z_b_filtered, z_b=z_b_nn)
+        # print('l2', 0.5 * (loss_a + loss_b))
+        return 0.5 * (loss_a + loss_b)
+
+    def _local_location_loss(
+        self,
+        z_a: Tensor,
+        z_b: Tensor,
+        grid_a: Tensor,
+        grid_b: Tensor,
+    ) -> Tensor:
+        z_a = z_a.flatten(start_dim=1, end_dim=2)
+        z_b = z_b.flatten(start_dim=1, end_dim=2)
+        grid_a = grid_a.flatten(start_dim=1, end_dim=2)
+        grid_b = grid_b.flatten(start_dim=1, end_dim=2)
+        z_a_filtered, z_a_nn = self._nearest_neighbors_on_grid(
+            input_grid=grid_a,
+            candidate_grid=grid_b,
+            input_maps=z_a,
+            candidate_maps=z_b,
+            num_matches=self.num_matches[0],
+        )
+        z_b_filtered, z_b_nn = self._nearest_neighbors_on_grid(
+            input_grid=grid_b,
+            candidate_grid=grid_a,
+            input_maps=z_b,
+            candidate_maps=z_a,
+            num_matches=self.num_matches[1],
+        )
+
+        loss_a = self.vicreg_loss.forward(z_a=z_a_filtered, z_b=z_a_nn)
+        loss_b = self.vicreg_loss.forward(z_a=z_b_filtered, z_b=z_b_nn)
+        return 0.5 * (loss_a + loss_b)
+
+    def _nearest_neighbors_on_l2(
+        self, input_maps: Tensor, candidate_maps: Tensor, num_matches: int
+    ) -> Tuple[Tensor, Tensor]:
+        """
+        input_maps: (B, H * W, C)
+        candidate_maps: (B, H * W, C)
+
+        Returns:
+            (nn_input, nn_candidate) tuple containing two tensors with shape
+            (B * num_matches, C).
+        """
+        distances = torch.cdist(input_maps, candidate_maps)
+        return nearest_neighbors(input_maps, candidate_maps, distances, num_matches)
+
+    def _nearest_neighbors_on_grid(
+        self,
+        input_grid: Tensor,
+        candidate_grid: Tensor,
+        input_maps: Tensor,
+        candidate_maps: Tensor,
+        num_matches: int,
+    ) -> Tuple[Tensor, Tensor]:
+        """
+        input_grid: (B, H * W, 2)
+        candidate_grid: (B, H * W, 2)
+        input_maps: (B, H * W, C)
+        candidate_maps: (B, H * W, C)
+
+        Returns:
+            (nn_input, nn_candidate) tuple containing two tensors with shape
+            (B * num_matches, C).
+        """
+        distances = torch.cdist(input_grid, candidate_grid)
+        return nearest_neighbors(input_maps, candidate_maps, distances, num_matches)

--- a/lightly/loss/vicregl_loss.py
+++ b/lightly/loss/vicregl_loss.py
@@ -278,10 +278,8 @@ class VICRegLLoss(torch.nn.Module):
         z_b_filtered, z_b_nn = self._nearest_neighbors_on_l2(
             input_maps=z_b, candidate_maps=z_a, num_matches=self.num_matches[1]
         )
-        # print('l2 sum', (z_a_filtered - z_a_nn).sum())
         loss_a = self.vicreg_loss.forward(z_a=z_a_filtered, z_b=z_a_nn)
         loss_b = self.vicreg_loss.forward(z_a=z_b_filtered, z_b=z_b_nn)
-        # print('l2', 0.5 * (loss_a + loss_b))
         return 0.5 * (loss_a + loss_b)
 
     def _local_location_loss(

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -14,45 +14,50 @@ from lightly.transforms.utils import IMAGENET_NORMALIZE
 class VICRegLTransform(ImageGridTransform):
     """Transforms images for VICRegL.
 
+    - [0]: VICRegL, 2022, https://arxiv.org/abs/2210.01571
+
     Attributes:
         global_crop_size:
-            Size of the input image in pixels for the global crop category.
+            Size of the input image in pixels for the global crop views.
         local_crop_size:
-            Size of the input image in pixels for the local crop category.
+            Size of the input image in pixels for the local crop views.
+        n_local_views:
+            Number of local crop views to generate. For ResNet backbones it is
+            recommended to set this to 0, see [0].
         global_crop_scale:
-            Min and max scales for the global crop category.
+            Min and max scales for the global crop views.
         local_crop_scale:
-            Min and max scales for the local crop category.
+            Min and max scales for the local crop views.
         global_grid_size:
-            Grid size for the global crop category.
+            Grid size for the global crop views.
         local_grid_size:
-            Grid size for the local crop category.
+            Grid size for the local crop views.
         global_gaussian_blur_prob:
-            Probability of Gaussian blur for the global crop category.
+            Probability of Gaussian blur for the global crop views.
         local_gaussian_blur_prob:
-            Probability of Gaussian blur for the local crop category.
+            Probability of Gaussian blur for the local crop views.
         global_gaussian_blur_kernel_size:
             Will be deprecated in favor of `global_gaussian_blur_sigmas` argument.
             If set, the old behavior applies and `global_gaussian_blur_sigmas`
             is ignored. Used to calculate sigma of gaussian blur with
-            global_gaussian_blur_kernel_size * input_size. Applied to global crop category.
+            global_gaussian_blur_kernel_size * input_size. Applied to global crop views.
         local_gaussian_blur_kernel_size:
             Will be deprecated in favor of `local_gaussian_blur_sigmas` argument.
             If set, the old behavior applies and `local_gaussian_blur_sigmas`
             is ignored. Used to calculate sigma of gaussian blur with
-            local_gaussian_blur_kernel_size * input_size. Applied to local crop category.
+            local_gaussian_blur_kernel_size * input_size. Applied to local crop views.
         global_gaussian_blur_sigmas:
             Tuple of min and max value from which the std of the gaussian kernel
             is sampled. It is ignored if `global_gaussian_blur_kernel_size` is set.
-            Applied to global crop category.
+            Applied to global crop views.
         local_gaussian_blur_sigmas:
             Tuple of min and max value from which the std of the gaussian kernel
             is sampled. It is ignored if `local_gaussian_blur_kernel_size` is set.
-            Applied to local crop category.
+            Applied to local crop views.
         global_solarize_prob:
-            Probability of solarization for the global crop category.
+            Probability of solarization for the global crop views.
         local_solarize_prob:
-            Probability of solarization for the local crop category.
+            Probability of solarization for the local crop views.
         hf_prob:
             Probability that horizontal flip is applied.
         cj_prob:
@@ -78,6 +83,7 @@ class VICRegLTransform(ImageGridTransform):
         self,
         global_crop_size: int = 224,
         local_crop_size: int = 96,
+        n_local_views: int = 6,
         global_crop_scale: Tuple[float, float] = (0.2, 1.0),
         local_crop_scale: Tuple[float, float] = (0.05, 0.2),
         global_grid_size: int = 7,
@@ -100,54 +106,50 @@ class VICRegLTransform(ImageGridTransform):
         random_gray_scale: float = 0.2,
         normalize: Union[None, dict] = IMAGENET_NORMALIZE,
     ):
-        transforms = []
+        global_transform = (
+            RandomResizedCropAndFlip(
+                crop_size=global_crop_size,
+                crop_min_scale=global_crop_scale[0],
+                crop_max_scale=global_crop_scale[1],
+                hf_prob=hf_prob,
+                grid_size=global_grid_size,
+            ),
+            VICRegLViewTransform(
+                gaussian_blur_prob=global_gaussian_blur_prob,
+                gaussian_blur_kernel_size=global_gaussian_blur_kernel_size,
+                gaussian_blur_sigmas=global_gaussian_blur_sigmas,
+                solarize_prob=global_solarize_prob,
+                cj_prob=cj_prob,
+                cj_strength=cj_strength,
+                cj_bright=cj_bright,
+                cj_contrast=cj_contrast,
+                cj_sat=cj_sat,
+                cj_hue=cj_hue,
+                random_gray_scale=random_gray_scale,
+                normalize=normalize,
+            ),
+        )
+        local_transform = (
+            RandomResizedCropAndFlip(
+                crop_size=local_crop_size,
+                crop_min_scale=local_crop_scale[0],
+                crop_max_scale=local_crop_scale[1],
+                hf_prob=hf_prob,
+                grid_size=local_grid_size,
+            ),
+            VICRegLViewTransform(
+                gaussian_blur_prob=local_gaussian_blur_prob,
+                gaussian_blur_kernel_size=local_gaussian_blur_kernel_size,
+                gaussian_blur_sigmas=local_gaussian_blur_sigmas,
+                solarize_prob=local_solarize_prob,
+                cj_prob=cj_prob,
+                cj_strength=cj_strength,
+                random_gray_scale=random_gray_scale,
+                normalize=normalize,
+            ),
+        )
 
-        transforms.append(
-            (
-                RandomResizedCropAndFlip(
-                    crop_size=global_crop_size,
-                    crop_min_scale=global_crop_scale[0],
-                    crop_max_scale=global_crop_scale[1],
-                    hf_prob=hf_prob,
-                    grid_size=global_grid_size,
-                ),
-                VICRegLViewTransform(
-                    gaussian_blur_prob=global_gaussian_blur_prob,
-                    gaussian_blur_kernel_size=global_gaussian_blur_kernel_size,
-                    gaussian_blur_sigmas=global_gaussian_blur_sigmas,
-                    solarize_prob=global_solarize_prob,
-                    cj_prob=cj_prob,
-                    cj_strength=cj_strength,
-                    cj_bright=cj_bright,
-                    cj_contrast=cj_contrast,
-                    cj_sat=cj_sat,
-                    cj_hue=cj_hue,
-                    random_gray_scale=random_gray_scale,
-                    normalize=normalize,
-                ),
-            )
-        )
-        transforms.append(
-            (
-                RandomResizedCropAndFlip(
-                    crop_size=local_crop_size,
-                    crop_min_scale=local_crop_scale[0],
-                    crop_max_scale=local_crop_scale[1],
-                    hf_prob=hf_prob,
-                    grid_size=local_grid_size,
-                ),
-                VICRegLViewTransform(
-                    gaussian_blur_prob=local_gaussian_blur_prob,
-                    gaussian_blur_kernel_size=local_gaussian_blur_kernel_size,
-                    gaussian_blur_sigmas=local_gaussian_blur_sigmas,
-                    solarize_prob=local_solarize_prob,
-                    cj_prob=cj_prob,
-                    cj_strength=cj_strength,
-                    random_gray_scale=random_gray_scale,
-                    normalize=normalize,
-                ),
-            )
-        )
+        transforms = [global_transform] * 2 + [local_transform] * n_local_views
         super().__init__(transforms=transforms)
 
 
@@ -190,8 +192,7 @@ class VICRegLViewTransform:
         self.transform = T.Compose(transforms=transforms)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:
@@ -199,6 +200,5 @@ class VICRegLViewTransform:
 
         Returns:
             The transformed image.
-
         """
         return self.transform(image)

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -152,7 +152,9 @@ class VICRegLTransform(ImageGridTransform):
             ),
         )
 
-        transforms = [global_transform] * n_global_views + [local_transform] * n_local_views
+        transforms = [global_transform] * n_global_views + [
+            local_transform
+        ] * n_local_views
         super().__init__(transforms=transforms)
 
 

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -21,6 +21,8 @@ class VICRegLTransform(ImageGridTransform):
             Size of the input image in pixels for the global crop views.
         local_crop_size:
             Size of the input image in pixels for the local crop views.
+        n_global_views:
+            Number of global crop views to generate.
         n_local_views:
             Number of local crop views to generate. For ResNet backbones it is
             recommended to set this to 0, see [0].
@@ -83,6 +85,7 @@ class VICRegLTransform(ImageGridTransform):
         self,
         global_crop_size: int = 224,
         local_crop_size: int = 96,
+        n_global_views: int = 2,
         n_local_views: int = 6,
         global_crop_scale: Tuple[float, float] = (0.2, 1.0),
         local_crop_scale: Tuple[float, float] = (0.05, 0.2),
@@ -149,7 +152,7 @@ class VICRegLTransform(ImageGridTransform):
             ),
         )
 
-        transforms = [global_transform] * 2 + [local_transform] * n_local_views
+        transforms = [global_transform] * n_global_views + [local_transform] * n_local_views
         super().__init__(transforms=transforms)
 
 

--- a/tests/loss/test_VICRegLLoss.py
+++ b/tests/loss/test_VICRegLLoss.py
@@ -6,46 +6,91 @@ from lightly.loss import VICRegLLoss
 
 
 class TestVICRegLLoss(unittest.TestCase):
-    def test_forward_pass(self):
-        loss = VICRegLLoss()
-        x0 = torch.randn((2, 32))
-        x1 = torch.randn((2, 32))
-        x0_L = torch.randn((2, 7, 7, 8))
-        x1_L = torch.randn((2, 7, 7, 8))
-        grid0 = torch.randn((2, 7, 7, 2))
-        grid1 = torch.randn((2, 7, 7, 2))
-        assert loss(x0, x1, x0_L, x1_L, grid0, grid1)
+    def test_forward(self) -> None:
+        torch.manual_seed(0)
+        criterion = VICRegLLoss()
+        global_view_features = [(torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)]
+        global_view_grids = [torch.randn((2, 7, 7, 2)) for _ in range(2)]
+        local_view_features = [(torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(6)]
+        local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(6)]
+        loss = criterion.forward(
+            global_view_features=global_view_features,
+            global_view_grids=global_view_grids,
+            local_view_features=local_view_features,
+            local_view_grids=local_view_grids,
+        )
+        assert loss > 0
 
     @unittest.skipUnless(torch.cuda.is_available(), "Cuda not available")
-    def test_forward_pass_cuda(self):
-        loss = VICRegLLoss()
-        loss = VICRegLLoss()
-        x0 = torch.randn((2, 32)).cuda()
-        x1 = torch.randn((2, 32)).cuda()
-        x0_L = torch.randn((2, 7, 7, 8)).cuda()
-        x1_L = torch.randn((2, 7, 7, 8)).cuda()
-        grid0 = torch.randn((2, 7, 7, 2)).cuda()
-        grid1 = torch.randn((2, 7, 7, 2)).cuda()
-        assert loss(x0, x1, x0_L, x1_L, grid0, grid1)
+    def test_forward__cuda(self) -> None:
+        torch.manual_seed(0)
+        criterion = VICRegLLoss()
+        global_view_features = [(torch.randn((2, 32)).cuda(), torch.randn((2, 7, 7, 8)).cuda()) for _ in range(2)]
+        global_view_grids = [torch.randn((2, 7, 7, 2)).cuda() for _ in range(2)]
+        local_view_features = [(torch.randn((2, 32)).cuda(), torch.randn((2, 4, 4, 8)).cuda()) for _ in range(6)]
+        local_view_grids = [torch.randn((2, 4, 4, 2)).cuda() for _ in range(6)]
+        loss = criterion.forward(
+            global_view_features=global_view_features,
+            global_view_grids=global_view_grids,
+            local_view_features=local_view_features,
+            local_view_grids=local_view_grids,
+        )
+        assert loss > 0
 
-    def test_forward_pass__error_batch_size_1(self):
-        loss = VICRegLLoss()
-        x0 = torch.randn((1, 32))
-        x1 = torch.randn((1, 32))
-        x0_L = torch.randn((1, 7, 7, 8))
-        x1_L = torch.randn((1, 7, 7, 8))
-        grid0 = torch.randn((1, 7, 7, 2))
-        grid1 = torch.randn((1, 7, 7, 2))
-        with self.assertRaises(AssertionError):
-            loss(x0, x1, x0_L, x1_L, grid0, grid1)
+    def test_forward__error_global_view_features_and_grids_not_same_length(self) -> None:
+        criterion = VICRegLLoss()
+        global_view_features = [(torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)]
+        global_view_grids = [torch.randn((2, 7, 7, 2)) for _ in range(1)]
+        error_msg = (
+            "global_view_features and global_view_grids must have same length but "
+            "found 2 and 1."
+        )
+        with self.assertRaisesRegex(ValueError, error_msg):
+            criterion.forward(
+                global_view_features=global_view_features,
+                global_view_grids=global_view_grids,
+            )
 
-    def test_forward_pass__error_different_shapes(self):
-        loss = VICRegLLoss()
-        x0 = torch.randn((1, 32))
-        x1 = torch.randn((1, 16))
-        x0_L = torch.randn((1, 7, 7, 8))
-        x1_L = torch.randn((1, 7, 7, 8))
-        grid0 = torch.randn((1, 7, 7, 2))
-        grid1 = torch.randn((1, 7, 7, 2))
-        with self.assertRaises(AssertionError):
-            loss(x0, x1, x0_L, x1_L, grid0, grid1)
+    def test_forward__error_local_view_features_and_grids_not_same_length(self) -> None:
+        criterion = VICRegLLoss()
+        local_view_features = [(torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(2)]
+        local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(1)]
+        error_msg = (
+            "local_view_features and local_view_grids must have same length but found "
+            "2 and 1."
+        )
+        with self.assertRaisesRegex(ValueError, error_msg):
+            criterion.forward(
+                global_view_features=[],
+                global_view_grids=[],
+                local_view_features=local_view_features,
+                local_view_grids=local_view_grids,
+            )
+
+    def test_forward__error_local_view_features_and_grids_must_both_be_set(self) -> None:
+        criterion = VICRegLLoss()
+        local_view_features = [(torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(2)]
+        local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(2)]
+        error_msg = (
+            "local_view_features and local_view_grids must either both be set or None "
+            "but found <class 'list'> and <class 'NoneType'>."
+        )
+        with self.assertRaisesRegex(ValueError, error_msg):
+            criterion.forward(
+                global_view_features=[],
+                global_view_grids=[],
+                local_view_features=local_view_features,
+                local_view_grids=None,
+            )
+
+        error_msg = (
+            "local_view_features and local_view_grids must either both be set or None "
+            "but found <class 'NoneType'> and <class 'list'>."
+        )
+        with self.assertRaisesRegex(ValueError, error_msg):
+            criterion.forward(
+                global_view_features=[],
+                global_view_grids=[],
+                local_view_features=None,
+                local_view_grids=local_view_grids,
+            )

--- a/tests/loss/test_VICRegLLoss.py
+++ b/tests/loss/test_VICRegLLoss.py
@@ -1,6 +1,9 @@
 import unittest
 
+import numpy as np
 import torch
+import torch.nn.functional as F
+from torch import Tensor
 
 from lightly.loss import VICRegLLoss
 
@@ -114,3 +117,496 @@ class TestVICRegLLoss(unittest.TestCase):
                 local_view_features=None,
                 local_view_grids=local_view_grids,
             )
+
+    def test_global_loss(self) -> None:
+        torch.manual_seed(0)
+        criterion = VICRegLLoss()
+        reference_criterion = _ReferenceLoss()
+        global_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)
+        ]
+        local_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(6)
+        ]
+        loss = criterion._global_loss(
+            global_view_features=global_view_features,
+            local_view_features=local_view_features,
+        )
+
+        embedding = [x for x, _ in global_view_features + local_view_features]
+        expected_loss = reference_criterion.global_loss(embedding=embedding)
+        assert loss == sum(expected_loss)
+
+    def test_local_loss(self) -> None:
+        torch.manual_seed(0)
+        criterion = VICRegLLoss(num_matches=(3, 2))
+        reference_criterion = _ReferenceLoss(num_matches=(3, 2))
+        global_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 3, 3, 2))) for _ in range(2)
+        ]
+        global_view_grids = [torch.randn((2, 3, 3, 2)) for _ in range(2)]
+        local_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 2, 2, 2))) for _ in range(0)
+        ]
+        local_view_grids = [torch.randn((2, 2, 2, 2)) for _ in range(0)]
+        loss = criterion._local_loss(
+            global_view_features=global_view_features,
+            global_view_grids=global_view_grids,
+            local_view_features=local_view_features,
+            local_view_grids=local_view_grids,
+        )
+
+        maps_embedding = [
+            x.flatten(1, 2) for _, x in global_view_features + local_view_features
+        ]
+        locations = [x for x in global_view_grids + local_view_grids]
+        expected_loss = reference_criterion.local_loss(
+            maps_embedding=maps_embedding,
+            locations=locations,
+        )
+        assert loss == sum(expected_loss)
+
+    def test_loss(self) -> None:
+        torch.manual_seed(0)
+        criterion = VICRegLLoss()
+        reference_criterion = _ReferenceLoss()
+        global_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)
+        ]
+        global_view_grids = [torch.randn((2, 7, 7, 2)) for _ in range(2)]
+        local_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(6)
+        ]
+        local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(6)]
+        loss = criterion.forward(
+            global_view_features=global_view_features,
+            global_view_grids=global_view_grids,
+            local_view_features=local_view_features,
+            local_view_grids=local_view_grids,
+        )
+
+        embedding = [x for x, _ in global_view_features + local_view_features]
+        maps_embedding = [
+            x.flatten(1, 2) for _, x in global_view_features + local_view_features
+        ]
+        locations = [x for x in global_view_grids + local_view_grids]
+        expected_loss = reference_criterion.loss(
+            embedding=embedding,
+            maps_embedding=maps_embedding,
+            locations=locations,
+        )
+        assert loss == expected_loss
+
+
+class _ReferenceLoss:
+    def __init__(
+        self,
+        alpha: float = 0.75,
+        inv_coeff: float = 25.0,
+        var_coeff: float = 25.0,
+        cov_coeff: float = 1.0,
+        num_matches=(20, 4),
+    ) -> None:
+        self.alpha = alpha
+        self.inv_coeff = inv_coeff
+        self.var_coeff = var_coeff
+        self.cov_coeff = cov_coeff
+        self.num_matches = num_matches
+        self.l2_all_matches = False
+        self.fast_vc_reg = False
+
+    def loss(self, embedding, maps_embedding, locations):
+        loss = 0
+        if self.alpha > 0.0:
+            inv_loss, var_loss, cov_loss = self.global_loss(embedding=embedding)
+            loss = loss + self.alpha * (inv_loss + var_loss + cov_loss)
+        if self.alpha < 1.0:
+            inv_loss, var_loss, cov_loss = self.local_loss(
+                maps_embedding=maps_embedding,
+                locations=locations,
+            )
+            loss = loss + (1 - self.alpha) * (inv_loss + var_loss + cov_loss)
+        return loss
+
+    def _vicreg_loss(self, x, y):
+        print("-x", x, x.sum())
+        print("-y", y, y.sum())
+        repr_loss = self.inv_coeff * F.mse_loss(x, y)
+
+        x = self.center(x)
+        y = self.center(y)
+
+        std_x = torch.sqrt(x.var(dim=0) + 0.0001)
+        std_y = torch.sqrt(y.var(dim=0) + 0.0001)
+        std_loss = self.var_coeff * (
+            torch.mean(F.relu(1.0 - std_x)) / 2 + torch.mean(F.relu(1.0 - std_y)) / 2
+        )
+
+        x = x.permute((1, 0, 2))
+        y = y.permute((1, 0, 2))
+
+        *_, sample_size, num_channels = x.shape
+        non_diag_mask = ~torch.eye(num_channels, device=x.device, dtype=torch.bool)
+        # Center features
+        # centered.shape = NC
+        # x = x - x.mean(dim=-2, keepdim=True)
+        # y = y - y.mean(dim=-2, keepdim=True)
+
+        cov_x = torch.einsum("...nc,...nd->...cd", x, x) / (sample_size - 1)
+        cov_y = torch.einsum("...nc,...nd->...cd", y, y) / (sample_size - 1)
+        cov_loss = (cov_x[..., non_diag_mask].pow(2).sum(-1) / num_channels) / 2 + (
+            cov_y[..., non_diag_mask].pow(2).sum(-1) / num_channels
+        ) / 2
+        cov_loss = cov_loss.mean()
+        cov_loss = self.cov_coeff * cov_loss
+        print("-vic", repr_loss, std_loss, cov_loss)
+        return repr_loss, std_loss, cov_loss
+
+    def _local_loss(self, maps_1, maps_2, location_1, location_2):
+        inv_loss = 0.0
+        var_loss = 0.0
+        cov_loss = 0.0
+
+        # L2 distance based bacthing
+        if self.l2_all_matches:
+            num_matches_on_l2 = [None, None]
+        else:
+            num_matches_on_l2 = self.num_matches
+
+        maps_1_filtered, maps_1_nn = self.neirest_neighbores_on_l2(
+            maps_1, maps_2, num_matches=num_matches_on_l2[0]
+        )
+        maps_2_filtered, maps_2_nn = self.neirest_neighbores_on_l2(
+            maps_2, maps_1, num_matches=num_matches_on_l2[1]
+        )
+        # print('-l2 sum', (maps_1_filtered - maps_1_nn).sum())
+
+        if self.fast_vc_reg:
+            inv_loss_1 = F.mse_loss(maps_1_filtered, maps_1_nn)
+            inv_loss_2 = F.mse_loss(maps_2_filtered, maps_2_nn)
+        else:
+            inv_loss_1, var_loss_1, cov_loss_1 = self._vicreg_loss(
+                maps_1_filtered, maps_1_nn
+            )
+            inv_loss_2, var_loss_2, cov_loss_2 = self._vicreg_loss(
+                maps_2_filtered, maps_2_nn
+            )
+            var_loss = var_loss + (var_loss_1 / 2 + var_loss_2 / 2)
+            cov_loss = cov_loss + (cov_loss_1 / 2 + cov_loss_2 / 2)
+
+        inv_loss = inv_loss + (inv_loss_1 / 2 + inv_loss_2 / 2)
+        # print('-l2', (inv_loss + var_loss + cov_loss))
+
+        # Location based matching
+        location_1 = location_1.flatten(1, 2)
+        location_2 = location_2.flatten(1, 2)
+
+        maps_1_filtered, maps_1_nn = self.neirest_neighbores_on_location(
+            location_1,
+            location_2,
+            maps_1,
+            maps_2,
+            num_matches=self.num_matches[0],
+        )
+        maps_2_filtered, maps_2_nn = self.neirest_neighbores_on_location(
+            location_2,
+            location_1,
+            maps_2,
+            maps_1,
+            num_matches=self.num_matches[1],
+        )
+        # print('-loc sum', (maps_1_filtered - maps_1_nn).sum())
+
+        if self.fast_vc_reg:
+            inv_loss_1 = F.mse_loss(maps_1_filtered, maps_1_nn)
+            inv_loss_2 = F.mse_loss(maps_2_filtered, maps_2_nn)
+        else:
+            inv_loss_1, var_loss_1, cov_loss_1 = self._vicreg_loss(
+                maps_1_filtered, maps_1_nn
+            )
+            inv_loss_2, var_loss_2, cov_loss_2 = self._vicreg_loss(
+                maps_2_filtered, maps_2_nn
+            )
+            var_loss = var_loss + (var_loss_1 / 2 + var_loss_2 / 2)
+            cov_loss = cov_loss + (cov_loss_1 / 2 + cov_loss_2 / 2)
+
+        inv_loss = inv_loss + (inv_loss_1 / 2 + inv_loss_2 / 2)
+        # print('-loc', ((var_loss_1 / 2 + var_loss_2 / 2) + (cov_loss_1 / 2 + cov_loss_2 / 2) + (inv_loss_1 / 2 + inv_loss_2 / 2)))
+        return inv_loss, var_loss, cov_loss
+
+    def local_loss(self, maps_embedding, locations):
+        num_views = len(maps_embedding)
+        inv_loss = 0.0
+        var_loss = 0.0
+        cov_loss = 0.0
+        iter_ = 0
+        for i in range(2):
+            for j in np.delete(np.arange(np.sum(num_views)), i):
+                inv_loss_this, var_loss_this, cov_loss_this = self._local_loss(
+                    maps_embedding[i],
+                    maps_embedding[j],
+                    locations[i],
+                    locations[j],
+                )
+                inv_loss = inv_loss + inv_loss_this
+                var_loss = var_loss + var_loss_this
+                cov_loss = cov_loss + cov_loss_this
+                # print('-- local', inv_loss_this + var_loss_this + cov_loss_this)
+                iter_ += 1
+
+        inv_loss = inv_loss / iter_
+        var_loss = var_loss / iter_
+        cov_loss = cov_loss / iter_
+
+        return inv_loss, var_loss, cov_loss
+
+    def global_loss(self, embedding):
+        num_views = len(embedding)
+        inv_loss = 0.0
+        iter_ = 0
+        for i in range(2):
+            for j in np.delete(np.arange(np.sum(num_views)), i):
+                inv_loss = inv_loss + F.mse_loss(embedding[i], embedding[j])
+                iter_ = iter_ + 1
+        inv_loss = self.inv_coeff * inv_loss / iter_
+
+        var_loss = 0.0
+        cov_loss = 0.0
+        iter_ = 0
+        embedding_dim = embedding[0].shape[1]
+        for i in range(num_views):
+            x = self.center(embedding[i])
+            std_x = torch.sqrt(x.var(dim=0) + 0.0001)
+            var_loss = var_loss + torch.mean(torch.relu(1.0 - std_x))
+            cov_x = (x.T @ x) / (x.size(0) - 1)
+            cov_loss = cov_loss + self.off_diagonal(cov_x).pow_(2).sum().div(
+                embedding_dim
+            )
+            iter_ = iter_ + 1
+        var_loss = self.var_coeff * var_loss / iter_
+        cov_loss = self.cov_coeff * cov_loss / iter_
+
+        return inv_loss, var_loss, cov_loss
+
+    def batched_index_select(self, input, dim, index):
+        for ii in range(1, len(input.shape)):
+            if ii != dim:
+                index = index.unsqueeze(ii)
+        expanse = list(input.shape)
+        expanse[0] = -1
+        expanse[dim] = -1
+        index = index.expand(expanse)
+        return torch.gather(input, dim, index)
+
+    def nearest_neighbors(self, input_maps, candidate_maps, distances, num_matches):
+        batch_size = input_maps.size(0)
+
+        if num_matches is None or num_matches == -1:
+            num_matches = input_maps.size(1)
+
+        topk_values, topk_indices = distances.topk(k=1, largest=False)
+        topk_values = topk_values.squeeze(-1)
+        topk_indices = topk_indices.squeeze(-1)
+
+        sorted_values, sorted_values_indices = torch.sort(topk_values, dim=1)
+        sorted_indices, sorted_indices_indices = torch.sort(
+            sorted_values_indices, dim=1
+        )
+
+        mask = torch.stack(
+            [
+                torch.where(sorted_indices_indices[i] < num_matches, True, False)
+                for i in range(batch_size)
+            ]
+        )
+        topk_indices_selected = topk_indices.masked_select(mask)
+        topk_indices_selected = topk_indices_selected.reshape(batch_size, num_matches)
+
+        indices = (
+            torch.arange(0, topk_values.size(1))
+            .unsqueeze(0)
+            .repeat(batch_size, 1)
+            .to(topk_values.device)
+        )
+        indices_selected = indices.masked_select(mask)
+        indices_selected = indices_selected.reshape(batch_size, num_matches)
+
+        filtered_input_maps = self.batched_index_select(input_maps, 1, indices_selected)
+        filtered_candidate_maps = self.batched_index_select(
+            candidate_maps, 1, topk_indices_selected
+        )
+
+        return filtered_input_maps, filtered_candidate_maps
+
+    def neirest_neighbores_on_l2(self, input_maps, candidate_maps, num_matches):
+        """
+        input_maps: (B, H * W, C)
+        candidate_maps: (B, H * W, C)
+        """
+        distances = torch.cdist(input_maps, candidate_maps)
+        return self.nearest_neighbors(
+            input_maps, candidate_maps, distances, num_matches
+        )
+
+    def neirest_neighbores_on_location(
+        self,
+        input_location,
+        candidate_location,
+        input_maps,
+        candidate_maps,
+        num_matches,
+    ):
+        """
+        input_location: (B, H * W, 2)
+        candidate_location: (B, H * W, 2)
+        input_maps: (B, H * W, C)
+        candidate_maps: (B, H * W, C)
+        """
+        distances = torch.cdist(input_location, candidate_location)
+        return self.nearest_neighbors(
+            input_maps, candidate_maps, distances, num_matches
+        )
+
+    def exclude_bias_and_norm(self, p):
+        return p.ndim == 1
+
+    def center(self, x):
+        return x - x.mean(dim=0)
+
+    def off_diagonal(self, x: Tensor) -> Tensor:
+        n, m = x.shape
+        assert n == m
+        return x.flatten()[:-1].view(n - 1, n + 1)[:, 1:].flatten()
+
+
+def test_nn():
+    criterion = _ReferenceLoss()
+
+    input_maps = torch.Tensor(
+        [
+            [[1], [2], [3]],
+        ]
+    )
+    candidate_maps = torch.Tensor(
+        [
+            [[11], [22], [33]],
+        ]
+    )
+    distances = torch.Tensor([[[1, 3, 5], [0, 8, 4], [2, 6, 7]]])
+    nn_input, nn_candidate = criterion.nearest_neighbors(
+        input_maps=input_maps,
+        candidate_maps=candidate_maps,
+        distances=distances,
+        num_matches=2,
+    )
+    assert nn_input.tolist() == [[[1], [2]]]
+    assert nn_candidate.tolist() == [[[11], [11]]]
+
+    input_maps = torch.Tensor(
+        [
+            [[1], [2]],
+        ]
+    )
+    candidate_maps = torch.Tensor(
+        [
+            [[11], [22]],
+        ]
+    )
+    distances = torch.Tensor([[[0, 1], [3, 2]]])
+    nn_input, nn_candidate = criterion.nearest_neighbors(
+        input_maps=input_maps,
+        candidate_maps=candidate_maps,
+        distances=distances,
+        num_matches=2,
+    )
+    assert nn_input.tolist() == [[[1], [2]]]
+    assert nn_candidate.tolist() == [[[11], [22]]]
+
+    distances = torch.Tensor([[[2, 3], [1, 0]]])
+    nn_input, nn_candidate = criterion.nearest_neighbors(
+        input_maps=input_maps,
+        candidate_maps=candidate_maps,
+        distances=distances,
+        num_matches=2,
+    )
+    assert nn_input.tolist() == [[[2], [1]]]
+    assert nn_candidate.tolist() == [[[22], [11]]]
+
+    distances = torch.Tensor([[[0, 2], [1, 3]]])
+    nn_input, nn_candidate = criterion.nearest_neighbors(
+        input_maps=input_maps,
+        candidate_maps=candidate_maps,
+        distances=distances,
+        num_matches=2,
+    )
+    assert nn_input.tolist() == [[[1], [2]]]
+    assert nn_candidate.tolist() == [[[11], [11]]]
+    criterion.nearest_neighbors(
+        input_maps=input_maps,
+        candidate_maps=candidate_maps,
+        distances=distances,
+        num_matches=6,
+    )
+
+
+def vicreg_invariance_loss(x: Tensor, y: Tensor) -> Tensor:
+    return F.mse_loss(x, y)
+
+
+def vicreg_variance_loss(x: Tensor, eps: float = 0.0001) -> Tensor:
+    x = x - x.mean(dim=0)
+    std = torch.sqrt(x.var(dim=0) + eps)
+    loss = torch.mean(F.relu(1 - std))
+    return loss
+
+
+def vicreg_covariance_loss(x: Tensor) -> Tensor:
+    x = x - x.mean(dim=0)
+    batch_size = x.size(0)
+    dim = x.size(-1)
+    nondiag_mask = ~torch.eye(dim, device=x.device, dtype=torch.bool)
+    cov = torch.einsum("b...c,b...d->...cd", x, x) / (batch_size - 1)
+    loss = cov[..., nondiag_mask].pow(2).sum(-1) / dim
+    return loss.mean()
+
+
+def vicreg_loss(x, y, inv_coeff=25.0, var_coeff=25.0, cov_coeff=1.0) -> Tensor:
+    inv_loss = vicreg_invariance_loss(x, y)
+    var_loss = 0.5 * (vicreg_variance_loss(x) + vicreg_variance_loss(y))
+    cov_loss = 0.5 * (vicreg_covariance_loss(x) + vicreg_covariance_loss(y))
+    return inv_coeff * inv_loss + var_coeff * var_loss + cov_coeff * cov_loss
+
+
+def test_vicreg_covariance_loss():
+    vicreg_covariance_loss(torch.rand(3, 10))
+    vicreg_covariance_loss(torch.rand(3, 4, 10))
+
+
+def test_vicreg_loss():
+    torch.manual_seed(0)
+    x = torch.rand(3, 10)
+    y = torch.rand(3, 10)
+    loss = vicreg_loss(x, y)
+    from lightly.loss import VICRegLoss
+
+    criterion = VICRegLoss(nu_param=0.5)
+    assert criterion(x, y) == loss
+
+
+def test_vicreg_large_loss():
+    x = torch.rand(3, 4, 10)
+    y = torch.rand(3, 4, 10)
+    criterion = _ReferenceLoss()
+    assert sum(criterion._vicreg_loss(x, y)) == vicreg_loss(x, y)
+
+
+def test_vicreg_large_loss_():
+    x = torch.rand(3, 4, 10)
+    y = torch.rand(3, 4, 10)
+    criterion = _ReferenceLoss()
+    from lightly.loss import VICRegLoss
+
+    c = VICRegLoss(nu_param=0.5)
+    assert sum(criterion._vicreg_loss(x, y)) == c(
+        x[:, [1, 0, 3, 2]], y[:, [1, 0, 3, 2]]
+    )

--- a/tests/loss/test_VICRegLLoss.py
+++ b/tests/loss/test_VICRegLLoss.py
@@ -9,9 +9,13 @@ class TestVICRegLLoss(unittest.TestCase):
     def test_forward(self) -> None:
         torch.manual_seed(0)
         criterion = VICRegLLoss()
-        global_view_features = [(torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)]
+        global_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)
+        ]
         global_view_grids = [torch.randn((2, 7, 7, 2)) for _ in range(2)]
-        local_view_features = [(torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(6)]
+        local_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(6)
+        ]
         local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(6)]
         loss = criterion.forward(
             global_view_features=global_view_features,
@@ -25,9 +29,15 @@ class TestVICRegLLoss(unittest.TestCase):
     def test_forward__cuda(self) -> None:
         torch.manual_seed(0)
         criterion = VICRegLLoss()
-        global_view_features = [(torch.randn((2, 32)).cuda(), torch.randn((2, 7, 7, 8)).cuda()) for _ in range(2)]
+        global_view_features = [
+            (torch.randn((2, 32)).cuda(), torch.randn((2, 7, 7, 8)).cuda())
+            for _ in range(2)
+        ]
         global_view_grids = [torch.randn((2, 7, 7, 2)).cuda() for _ in range(2)]
-        local_view_features = [(torch.randn((2, 32)).cuda(), torch.randn((2, 4, 4, 8)).cuda()) for _ in range(6)]
+        local_view_features = [
+            (torch.randn((2, 32)).cuda(), torch.randn((2, 4, 4, 8)).cuda())
+            for _ in range(6)
+        ]
         local_view_grids = [torch.randn((2, 4, 4, 2)).cuda() for _ in range(6)]
         loss = criterion.forward(
             global_view_features=global_view_features,
@@ -37,9 +47,13 @@ class TestVICRegLLoss(unittest.TestCase):
         )
         assert loss > 0
 
-    def test_forward__error_global_view_features_and_grids_not_same_length(self) -> None:
+    def test_forward__error_global_view_features_and_grids_not_same_length(
+        self,
+    ) -> None:
         criterion = VICRegLLoss()
-        global_view_features = [(torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)]
+        global_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)
+        ]
         global_view_grids = [torch.randn((2, 7, 7, 2)) for _ in range(1)]
         error_msg = (
             "global_view_features and global_view_grids must have same length but "
@@ -53,7 +67,9 @@ class TestVICRegLLoss(unittest.TestCase):
 
     def test_forward__error_local_view_features_and_grids_not_same_length(self) -> None:
         criterion = VICRegLLoss()
-        local_view_features = [(torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(2)]
+        local_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(2)
+        ]
         local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(1)]
         error_msg = (
             "local_view_features and local_view_grids must have same length but found "
@@ -67,9 +83,13 @@ class TestVICRegLLoss(unittest.TestCase):
                 local_view_grids=local_view_grids,
             )
 
-    def test_forward__error_local_view_features_and_grids_must_both_be_set(self) -> None:
+    def test_forward__error_local_view_features_and_grids_must_both_be_set(
+        self,
+    ) -> None:
         criterion = VICRegLLoss()
-        local_view_features = [(torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(2)]
+        local_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(2)
+        ]
         local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(2)]
         error_msg = (
             "local_view_features and local_view_grids must either both be set or None "

--- a/tests/loss/test_VICRegLLoss.py
+++ b/tests/loss/test_VICRegLLoss.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import List
 
 import numpy as np
 import torch
@@ -118,10 +119,10 @@ class TestVICRegLLoss(unittest.TestCase):
                 local_view_grids=local_view_grids,
             )
 
-    def test_global_loss(self) -> None:
+    def test_global_loss__compare(self):
+        # Compare against original implementation.
         torch.manual_seed(0)
         criterion = VICRegLLoss()
-        reference_criterion = _ReferenceLoss()
         global_view_features = [
             (torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)
         ]
@@ -134,479 +135,51 @@ class TestVICRegLLoss(unittest.TestCase):
         )
 
         embedding = [x for x, _ in global_view_features + local_view_features]
-        expected_loss = reference_criterion.global_loss(embedding=embedding)
-        assert loss == sum(expected_loss)
-
-    def test_local_loss(self) -> None:
-        torch.manual_seed(0)
-        criterion = VICRegLLoss(num_matches=(3, 2))
-        reference_criterion = _ReferenceLoss(num_matches=(3, 2))
-        global_view_features = [
-            (torch.randn((2, 32)), torch.randn((2, 3, 3, 2))) for _ in range(2)
-        ]
-        global_view_grids = [torch.randn((2, 3, 3, 2)) for _ in range(2)]
-        local_view_features = [
-            (torch.randn((2, 32)), torch.randn((2, 2, 2, 2))) for _ in range(0)
-        ]
-        local_view_grids = [torch.randn((2, 2, 2, 2)) for _ in range(0)]
-        loss = criterion._local_loss(
-            global_view_features=global_view_features,
-            global_view_grids=global_view_grids,
-            local_view_features=local_view_features,
-            local_view_grids=local_view_grids,
-        )
-
-        maps_embedding = [
-            x.flatten(1, 2) for _, x in global_view_features + local_view_features
-        ]
-        locations = [x for x in global_view_grids + local_view_grids]
-        expected_loss = reference_criterion.local_loss(
-            maps_embedding=maps_embedding,
-            locations=locations,
-        )
-        assert loss == sum(expected_loss)
-
-    def test_loss(self) -> None:
-        torch.manual_seed(0)
-        criterion = VICRegLLoss()
-        reference_criterion = _ReferenceLoss()
-        global_view_features = [
-            (torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)
-        ]
-        global_view_grids = [torch.randn((2, 7, 7, 2)) for _ in range(2)]
-        local_view_features = [
-            (torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(6)
-        ]
-        local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(6)]
-        loss = criterion.forward(
-            global_view_features=global_view_features,
-            global_view_grids=global_view_grids,
-            local_view_features=local_view_features,
-            local_view_grids=local_view_grids,
-        )
-
-        embedding = [x for x, _ in global_view_features + local_view_features]
-        maps_embedding = [
-            x.flatten(1, 2) for _, x in global_view_features + local_view_features
-        ]
-        locations = [x for x in global_view_grids + local_view_grids]
-        expected_loss = reference_criterion.loss(
-            embedding=embedding,
-            maps_embedding=maps_embedding,
-            locations=locations,
-        )
+        expected_loss = _reference_global_loss(embedding=embedding)
         assert loss == expected_loss
 
+    # Note: We cannot compare our local loss implementation against the original code
+    # because the resulting values slightly differ. See VICRegLLoss._local_loss for
+    # details.
 
-class _ReferenceLoss:
-    def __init__(
-        self,
-        alpha: float = 0.75,
-        inv_coeff: float = 25.0,
-        var_coeff: float = 25.0,
-        cov_coeff: float = 1.0,
-        num_matches=(20, 4),
-    ) -> None:
-        self.alpha = alpha
-        self.inv_coeff = inv_coeff
-        self.var_coeff = var_coeff
-        self.cov_coeff = cov_coeff
-        self.num_matches = num_matches
-        self.l2_all_matches = False
-        self.fast_vc_reg = False
 
-    def loss(self, embedding, maps_embedding, locations):
-        loss = 0
-        if self.alpha > 0.0:
-            inv_loss, var_loss, cov_loss = self.global_loss(embedding=embedding)
-            loss = loss + self.alpha * (inv_loss + var_loss + cov_loss)
-        if self.alpha < 1.0:
-            inv_loss, var_loss, cov_loss = self.local_loss(
-                maps_embedding=maps_embedding,
-                locations=locations,
-            )
-            loss = loss + (1 - self.alpha) * (inv_loss + var_loss + cov_loss)
-        return loss
-
-    def _vicreg_loss(self, x, y):
-        print("-x", x, x.sum())
-        print("-y", y, y.sum())
-        repr_loss = self.inv_coeff * F.mse_loss(x, y)
-
-        x = self.center(x)
-        y = self.center(y)
-
-        std_x = torch.sqrt(x.var(dim=0) + 0.0001)
-        std_y = torch.sqrt(y.var(dim=0) + 0.0001)
-        std_loss = self.var_coeff * (
-            torch.mean(F.relu(1.0 - std_x)) / 2 + torch.mean(F.relu(1.0 - std_y)) / 2
-        )
-
-        x = x.permute((1, 0, 2))
-        y = y.permute((1, 0, 2))
-
-        *_, sample_size, num_channels = x.shape
-        non_diag_mask = ~torch.eye(num_channels, device=x.device, dtype=torch.bool)
-        # Center features
-        # centered.shape = NC
-        # x = x - x.mean(dim=-2, keepdim=True)
-        # y = y - y.mean(dim=-2, keepdim=True)
-
-        cov_x = torch.einsum("...nc,...nd->...cd", x, x) / (sample_size - 1)
-        cov_y = torch.einsum("...nc,...nd->...cd", y, y) / (sample_size - 1)
-        cov_loss = (cov_x[..., non_diag_mask].pow(2).sum(-1) / num_channels) / 2 + (
-            cov_y[..., non_diag_mask].pow(2).sum(-1) / num_channels
-        ) / 2
-        cov_loss = cov_loss.mean()
-        cov_loss = self.cov_coeff * cov_loss
-        print("-vic", repr_loss, std_loss, cov_loss)
-        return repr_loss, std_loss, cov_loss
-
-    def _local_loss(self, maps_1, maps_2, location_1, location_2):
-        inv_loss = 0.0
-        var_loss = 0.0
-        cov_loss = 0.0
-
-        # L2 distance based bacthing
-        if self.l2_all_matches:
-            num_matches_on_l2 = [None, None]
-        else:
-            num_matches_on_l2 = self.num_matches
-
-        maps_1_filtered, maps_1_nn = self.neirest_neighbores_on_l2(
-            maps_1, maps_2, num_matches=num_matches_on_l2[0]
-        )
-        maps_2_filtered, maps_2_nn = self.neirest_neighbores_on_l2(
-            maps_2, maps_1, num_matches=num_matches_on_l2[1]
-        )
-        # print('-l2 sum', (maps_1_filtered - maps_1_nn).sum())
-
-        if self.fast_vc_reg:
-            inv_loss_1 = F.mse_loss(maps_1_filtered, maps_1_nn)
-            inv_loss_2 = F.mse_loss(maps_2_filtered, maps_2_nn)
-        else:
-            inv_loss_1, var_loss_1, cov_loss_1 = self._vicreg_loss(
-                maps_1_filtered, maps_1_nn
-            )
-            inv_loss_2, var_loss_2, cov_loss_2 = self._vicreg_loss(
-                maps_2_filtered, maps_2_nn
-            )
-            var_loss = var_loss + (var_loss_1 / 2 + var_loss_2 / 2)
-            cov_loss = cov_loss + (cov_loss_1 / 2 + cov_loss_2 / 2)
-
-        inv_loss = inv_loss + (inv_loss_1 / 2 + inv_loss_2 / 2)
-        # print('-l2', (inv_loss + var_loss + cov_loss))
-
-        # Location based matching
-        location_1 = location_1.flatten(1, 2)
-        location_2 = location_2.flatten(1, 2)
-
-        maps_1_filtered, maps_1_nn = self.neirest_neighbores_on_location(
-            location_1,
-            location_2,
-            maps_1,
-            maps_2,
-            num_matches=self.num_matches[0],
-        )
-        maps_2_filtered, maps_2_nn = self.neirest_neighbores_on_location(
-            location_2,
-            location_1,
-            maps_2,
-            maps_1,
-            num_matches=self.num_matches[1],
-        )
-        # print('-loc sum', (maps_1_filtered - maps_1_nn).sum())
-
-        if self.fast_vc_reg:
-            inv_loss_1 = F.mse_loss(maps_1_filtered, maps_1_nn)
-            inv_loss_2 = F.mse_loss(maps_2_filtered, maps_2_nn)
-        else:
-            inv_loss_1, var_loss_1, cov_loss_1 = self._vicreg_loss(
-                maps_1_filtered, maps_1_nn
-            )
-            inv_loss_2, var_loss_2, cov_loss_2 = self._vicreg_loss(
-                maps_2_filtered, maps_2_nn
-            )
-            var_loss = var_loss + (var_loss_1 / 2 + var_loss_2 / 2)
-            cov_loss = cov_loss + (cov_loss_1 / 2 + cov_loss_2 / 2)
-
-        inv_loss = inv_loss + (inv_loss_1 / 2 + inv_loss_2 / 2)
-        # print('-loc', ((var_loss_1 / 2 + var_loss_2 / 2) + (cov_loss_1 / 2 + cov_loss_2 / 2) + (inv_loss_1 / 2 + inv_loss_2 / 2)))
-        return inv_loss, var_loss, cov_loss
-
-    def local_loss(self, maps_embedding, locations):
-        num_views = len(maps_embedding)
-        inv_loss = 0.0
-        var_loss = 0.0
-        cov_loss = 0.0
-        iter_ = 0
-        for i in range(2):
-            for j in np.delete(np.arange(np.sum(num_views)), i):
-                inv_loss_this, var_loss_this, cov_loss_this = self._local_loss(
-                    maps_embedding[i],
-                    maps_embedding[j],
-                    locations[i],
-                    locations[j],
-                )
-                inv_loss = inv_loss + inv_loss_this
-                var_loss = var_loss + var_loss_this
-                cov_loss = cov_loss + cov_loss_this
-                # print('-- local', inv_loss_this + var_loss_this + cov_loss_this)
-                iter_ += 1
-
-        inv_loss = inv_loss / iter_
-        var_loss = var_loss / iter_
-        cov_loss = cov_loss / iter_
-
-        return inv_loss, var_loss, cov_loss
-
-    def global_loss(self, embedding):
-        num_views = len(embedding)
-        inv_loss = 0.0
-        iter_ = 0
-        for i in range(2):
-            for j in np.delete(np.arange(np.sum(num_views)), i):
-                inv_loss = inv_loss + F.mse_loss(embedding[i], embedding[j])
-                iter_ = iter_ + 1
-        inv_loss = self.inv_coeff * inv_loss / iter_
-
-        var_loss = 0.0
-        cov_loss = 0.0
-        iter_ = 0
-        embedding_dim = embedding[0].shape[1]
-        for i in range(num_views):
-            x = self.center(embedding[i])
-            std_x = torch.sqrt(x.var(dim=0) + 0.0001)
-            var_loss = var_loss + torch.mean(torch.relu(1.0 - std_x))
-            cov_x = (x.T @ x) / (x.size(0) - 1)
-            cov_loss = cov_loss + self.off_diagonal(cov_x).pow_(2).sum().div(
-                embedding_dim
-            )
-            iter_ = iter_ + 1
-        var_loss = self.var_coeff * var_loss / iter_
-        cov_loss = self.cov_coeff * cov_loss / iter_
-
-        return inv_loss, var_loss, cov_loss
-
-    def batched_index_select(self, input, dim, index):
-        for ii in range(1, len(input.shape)):
-            if ii != dim:
-                index = index.unsqueeze(ii)
-        expanse = list(input.shape)
-        expanse[0] = -1
-        expanse[dim] = -1
-        index = index.expand(expanse)
-        return torch.gather(input, dim, index)
-
-    def nearest_neighbors(self, input_maps, candidate_maps, distances, num_matches):
-        batch_size = input_maps.size(0)
-
-        if num_matches is None or num_matches == -1:
-            num_matches = input_maps.size(1)
-
-        topk_values, topk_indices = distances.topk(k=1, largest=False)
-        topk_values = topk_values.squeeze(-1)
-        topk_indices = topk_indices.squeeze(-1)
-
-        sorted_values, sorted_values_indices = torch.sort(topk_values, dim=1)
-        sorted_indices, sorted_indices_indices = torch.sort(
-            sorted_values_indices, dim=1
-        )
-
-        mask = torch.stack(
-            [
-                torch.where(sorted_indices_indices[i] < num_matches, True, False)
-                for i in range(batch_size)
-            ]
-        )
-        topk_indices_selected = topk_indices.masked_select(mask)
-        topk_indices_selected = topk_indices_selected.reshape(batch_size, num_matches)
-
-        indices = (
-            torch.arange(0, topk_values.size(1))
-            .unsqueeze(0)
-            .repeat(batch_size, 1)
-            .to(topk_values.device)
-        )
-        indices_selected = indices.masked_select(mask)
-        indices_selected = indices_selected.reshape(batch_size, num_matches)
-
-        filtered_input_maps = self.batched_index_select(input_maps, 1, indices_selected)
-        filtered_candidate_maps = self.batched_index_select(
-            candidate_maps, 1, topk_indices_selected
-        )
-
-        return filtered_input_maps, filtered_candidate_maps
-
-    def neirest_neighbores_on_l2(self, input_maps, candidate_maps, num_matches):
-        """
-        input_maps: (B, H * W, C)
-        candidate_maps: (B, H * W, C)
-        """
-        distances = torch.cdist(input_maps, candidate_maps)
-        return self.nearest_neighbors(
-            input_maps, candidate_maps, distances, num_matches
-        )
-
-    def neirest_neighbores_on_location(
-        self,
-        input_location,
-        candidate_location,
-        input_maps,
-        candidate_maps,
-        num_matches,
-    ):
-        """
-        input_location: (B, H * W, 2)
-        candidate_location: (B, H * W, 2)
-        input_maps: (B, H * W, C)
-        candidate_maps: (B, H * W, C)
-        """
-        distances = torch.cdist(input_location, candidate_location)
-        return self.nearest_neighbors(
-            input_maps, candidate_maps, distances, num_matches
-        )
-
-    def exclude_bias_and_norm(self, p):
-        return p.ndim == 1
-
-    def center(self, x):
+def _reference_global_loss(
+    embedding: List[Tensor],
+    inv_coeff: float = 25.0,
+    var_coeff: float = 25.0,
+    cov_coeff: float = 1.0,
+) -> Tensor:
+    # Original global loss from VICRegL:
+    # https://github.com/facebookresearch/VICRegL/blob/803ae4c8cd1649a820f03afb4793763e95317620/main_vicregl.py#L421
+    def center(x):
         return x - x.mean(dim=0)
 
-    def off_diagonal(self, x: Tensor) -> Tensor:
+    def off_diagonal(x: Tensor) -> Tensor:
         n, m = x.shape
         assert n == m
         return x.flatten()[:-1].view(n - 1, n + 1)[:, 1:].flatten()
 
+    num_views = len(embedding)
+    inv_loss = 0.0
+    iter_ = 0
+    for i in range(2):
+        for j in np.delete(np.arange(np.sum(num_views)), i):
+            inv_loss = inv_loss + F.mse_loss(embedding[i], embedding[j])
+            iter_ = iter_ + 1
+    inv_loss = inv_coeff * inv_loss / iter_
 
-def test_nn():
-    criterion = _ReferenceLoss()
+    var_loss = 0.0
+    cov_loss = 0.0
+    iter_ = 0
+    embedding_dim = embedding[0].shape[1]
+    for i in range(num_views):
+        x = center(embedding[i])
+        std_x = torch.sqrt(x.var(dim=0) + 0.0001)
+        var_loss = var_loss + torch.mean(torch.relu(1.0 - std_x))
+        cov_x = (x.T @ x) / (x.size(0) - 1)
+        cov_loss = cov_loss + off_diagonal(cov_x).pow_(2).sum().div(embedding_dim)
+        iter_ = iter_ + 1
+    var_loss = var_coeff * var_loss / iter_
+    cov_loss = cov_coeff * cov_loss / iter_
 
-    input_maps = torch.Tensor(
-        [
-            [[1], [2], [3]],
-        ]
-    )
-    candidate_maps = torch.Tensor(
-        [
-            [[11], [22], [33]],
-        ]
-    )
-    distances = torch.Tensor([[[1, 3, 5], [0, 8, 4], [2, 6, 7]]])
-    nn_input, nn_candidate = criterion.nearest_neighbors(
-        input_maps=input_maps,
-        candidate_maps=candidate_maps,
-        distances=distances,
-        num_matches=2,
-    )
-    assert nn_input.tolist() == [[[1], [2]]]
-    assert nn_candidate.tolist() == [[[11], [11]]]
-
-    input_maps = torch.Tensor(
-        [
-            [[1], [2]],
-        ]
-    )
-    candidate_maps = torch.Tensor(
-        [
-            [[11], [22]],
-        ]
-    )
-    distances = torch.Tensor([[[0, 1], [3, 2]]])
-    nn_input, nn_candidate = criterion.nearest_neighbors(
-        input_maps=input_maps,
-        candidate_maps=candidate_maps,
-        distances=distances,
-        num_matches=2,
-    )
-    assert nn_input.tolist() == [[[1], [2]]]
-    assert nn_candidate.tolist() == [[[11], [22]]]
-
-    distances = torch.Tensor([[[2, 3], [1, 0]]])
-    nn_input, nn_candidate = criterion.nearest_neighbors(
-        input_maps=input_maps,
-        candidate_maps=candidate_maps,
-        distances=distances,
-        num_matches=2,
-    )
-    assert nn_input.tolist() == [[[2], [1]]]
-    assert nn_candidate.tolist() == [[[22], [11]]]
-
-    distances = torch.Tensor([[[0, 2], [1, 3]]])
-    nn_input, nn_candidate = criterion.nearest_neighbors(
-        input_maps=input_maps,
-        candidate_maps=candidate_maps,
-        distances=distances,
-        num_matches=2,
-    )
-    assert nn_input.tolist() == [[[1], [2]]]
-    assert nn_candidate.tolist() == [[[11], [11]]]
-    criterion.nearest_neighbors(
-        input_maps=input_maps,
-        candidate_maps=candidate_maps,
-        distances=distances,
-        num_matches=6,
-    )
-
-
-def vicreg_invariance_loss(x: Tensor, y: Tensor) -> Tensor:
-    return F.mse_loss(x, y)
-
-
-def vicreg_variance_loss(x: Tensor, eps: float = 0.0001) -> Tensor:
-    x = x - x.mean(dim=0)
-    std = torch.sqrt(x.var(dim=0) + eps)
-    loss = torch.mean(F.relu(1 - std))
-    return loss
-
-
-def vicreg_covariance_loss(x: Tensor) -> Tensor:
-    x = x - x.mean(dim=0)
-    batch_size = x.size(0)
-    dim = x.size(-1)
-    nondiag_mask = ~torch.eye(dim, device=x.device, dtype=torch.bool)
-    cov = torch.einsum("b...c,b...d->...cd", x, x) / (batch_size - 1)
-    loss = cov[..., nondiag_mask].pow(2).sum(-1) / dim
-    return loss.mean()
-
-
-def vicreg_loss(x, y, inv_coeff=25.0, var_coeff=25.0, cov_coeff=1.0) -> Tensor:
-    inv_loss = vicreg_invariance_loss(x, y)
-    var_loss = 0.5 * (vicreg_variance_loss(x) + vicreg_variance_loss(y))
-    cov_loss = 0.5 * (vicreg_covariance_loss(x) + vicreg_covariance_loss(y))
-    return inv_coeff * inv_loss + var_coeff * var_loss + cov_coeff * cov_loss
-
-
-def test_vicreg_covariance_loss():
-    vicreg_covariance_loss(torch.rand(3, 10))
-    vicreg_covariance_loss(torch.rand(3, 4, 10))
-
-
-def test_vicreg_loss():
-    torch.manual_seed(0)
-    x = torch.rand(3, 10)
-    y = torch.rand(3, 10)
-    loss = vicreg_loss(x, y)
-    from lightly.loss import VICRegLoss
-
-    criterion = VICRegLoss(nu_param=0.5)
-    assert criterion(x, y) == loss
-
-
-def test_vicreg_large_loss():
-    x = torch.rand(3, 4, 10)
-    y = torch.rand(3, 4, 10)
-    criterion = _ReferenceLoss()
-    assert sum(criterion._vicreg_loss(x, y)) == vicreg_loss(x, y)
-
-
-def test_vicreg_large_loss_():
-    x = torch.rand(3, 4, 10)
-    y = torch.rand(3, 4, 10)
-    criterion = _ReferenceLoss()
-    from lightly.loss import VICRegLoss
-
-    c = VICRegLoss(nu_param=0.5)
-    assert sum(criterion._vicreg_loss(x, y)) == c(
-        x[:, [1, 0, 3, 2]], y[:, [1, 0, 3, 2]]
-    )
+    return inv_loss + var_loss + cov_loss

--- a/tests/loss/test_VICRegLoss.py
+++ b/tests/loss/test_VICRegLoss.py
@@ -1,6 +1,8 @@
 import unittest
 
 import torch
+import torch.nn.functional as F
+from torch import Tensor
 
 from lightly.loss import VICRegLoss
 
@@ -42,3 +44,96 @@ class TestVICRegLoss(unittest.TestCase):
         x1 = torch.randn((2, 16))
         with self.assertRaises(AssertionError):
             loss(x0, x1)
+
+    def test_forward__compare(self) -> None:
+        # Compare against original implementation.
+        loss = VICRegLoss()
+        x0 = torch.randn((2, 32))
+        x1 = torch.randn((2, 32))
+        assert loss(x0, x1).item() == _reference_vicreg_loss(x0, x1).item()
+
+    def test_forward__compare_vicregl(self) -> None:
+        # Compare against implementation in VICRegL.
+        # Note: nu_param is set to 0.5 because our loss implementation follows the
+        # original VICReg implementation and there is a slight difference between the
+        # implementations in VICReg and VICRegL.
+        loss = VICRegLoss(nu_param=0.5)
+        x0 = torch.randn((2, 10, 32))
+        x1 = torch.randn((2, 10, 32))
+        assert loss(x0, x1).item() == _reference_vicregl_vicreg_loss(x0, x1).item()
+
+
+def _reference_vicreg_loss(
+    x: Tensor,
+    y: Tensor,
+    sim_coeff: float = 25.0,
+    std_coeff: float = 25.0,
+    cov_coeff: float = 1.0,
+):
+    # Original VICReg loss from:
+    # https://github.com/facebookresearch/vicreg/blob/4e12602fd495af83efd1631fbe82523e6db092e0/main_vicreg.py#L194
+    def off_diagonal(x):
+        n, m = x.shape
+        assert n == m
+        return x.flatten()[:-1].view(n - 1, n + 1)[:, 1:].flatten()
+
+    batch_size = x.shape[0]
+    num_features = x.shape[-1]
+    repr_loss = F.mse_loss(x, y)
+
+    x = x - x.mean(dim=0)
+    y = y - y.mean(dim=0)
+
+    std_x = torch.sqrt(x.var(dim=0) + 0.0001)
+    std_y = torch.sqrt(y.var(dim=0) + 0.0001)
+    std_loss = torch.mean(F.relu(1 - std_x)) / 2 + torch.mean(F.relu(1 - std_y)) / 2
+
+    cov_x = (x.T @ x) / (batch_size - 1)
+    cov_y = (y.T @ y) / (batch_size - 1)
+    cov_loss = off_diagonal(cov_x).pow_(2).sum().div(num_features) + off_diagonal(
+        cov_y
+    ).pow_(2).sum().div(num_features)
+
+    loss = sim_coeff * repr_loss + std_coeff * std_loss + cov_coeff * cov_loss
+    return loss
+
+
+def _reference_vicregl_vicreg_loss(
+    x: Tensor,
+    y: Tensor,
+    inv_coeff: float = 25.0,
+    var_coeff: float = 25.0,
+    cov_coeff: float = 1.0,
+) -> Tensor:
+    # Loss implementation from VICRegL:
+    # https://github.com/facebookresearch/VICRegL/blob/803ae4c8cd1649a820f03afb4793763e95317620/main_vicregl.py#L284
+    repr_loss = inv_coeff * F.mse_loss(x, y)
+
+    x = x - x.mean(0)
+    y = y - y.mean(0)
+
+    std_x = torch.sqrt(x.var(dim=0) + 0.0001)
+    std_y = torch.sqrt(y.var(dim=0) + 0.0001)
+    std_loss = var_coeff * (
+        torch.mean(F.relu(1.0 - std_x)) / 2 + torch.mean(F.relu(1.0 - std_y)) / 2
+    )
+
+    x = x.permute((1, 0, 2))
+    y = y.permute((1, 0, 2))
+
+    *_, sample_size, num_channels = x.shape
+    non_diag_mask = ~torch.eye(num_channels, device=x.device, dtype=torch.bool)
+    # Center features
+    # centered.shape = NC
+    x = x - x.mean(dim=-2, keepdim=True)
+    y = y - y.mean(dim=-2, keepdim=True)
+
+    cov_x = torch.einsum("...nc,...nd->...cd", x, x) / (sample_size - 1)
+    cov_y = torch.einsum("...nc,...nd->...cd", y, y) / (sample_size - 1)
+    cov_loss = (cov_x[..., non_diag_mask].pow(2).sum(-1) / num_channels) / 2 + (
+        cov_y[..., non_diag_mask].pow(2).sum(-1) / num_channels
+    ) / 2
+    cov_loss = cov_loss.mean()
+    cov_loss = cov_coeff * cov_loss
+
+    return repr_loss + std_loss + cov_loss

--- a/tests/transforms/test_vicregl_transform.py
+++ b/tests/transforms/test_vicregl_transform.py
@@ -12,12 +12,20 @@ def test_view_on_pil_image():
 
 def test_multi_view_on_pil_image():
     multi_view_transform = VICRegLTransform(
-        global_crop_size=32, local_crop_size=8, global_grid_size=4, local_grid_size=2
+        global_crop_size=32,
+        local_crop_size=8,
+        n_local_views=6,
+        global_grid_size=4,
+        local_grid_size=2,
     )
     sample = Image.new("RGB", (100, 100))
     output = multi_view_transform(sample)
-    assert len(output) == 4
-    assert output[0].shape == (3, 32, 32)
-    assert output[1].shape == (3, 8, 8)
-    assert output[2].shape == (4, 4, 2)
-    assert output[3].shape == (2, 2, 2)
+    assert len(output) == 16  # (2 global crops * 2) + (6 local crops * 2)
+    global_views = output[:2]
+    local_views = output[2:8]
+    global_grids = output[8:10]
+    local_grids = output[10:]
+    assert all(view.shape == (3, 32, 32) for view in global_views)
+    assert all(view.shape == (3, 8, 8) for view in local_views)
+    assert all(grid.shape == (4, 4, 2) for grid in global_grids)
+    assert all(grid.shape == (2, 2, 2) for grid in local_grids)


### PR DESCRIPTION
## Changes

* Add support for multiple global and local views to `VICRegLLoss`
* Set default number of local views to 0 when using ResNet
* Generalize `VICRegLoss` to support multiple dimensions
* Update imagenette benchmark
* Cleanup

I thoroughly compared our loss implementation with the original loss. There is a slight difference in the nearest neighbor matching. The same neighbors are matched but the order in which they are returned is different. This results in small differences in the loss computation. Other than that the losses are equal. I trained the model once with our nearest neighbor implementation and once with the original one and there was no difference in performance.

Imagenette performance is a bit lower than before but it is very hard to say if this is expected or not. VICRegL should have similar performance as VICReg on 224px images but we train on 128px. Our old implementation was missing some terms in the loss and only compared one global with one local view. So the old results are also not really comparable.