### PR TITLE
Automate release using Github actions

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,9 +1,10 @@
 name: Build and release lightly
 
 on:
-  push:
-  release:
-    types: [created]
+  workflow_dispatch:
+# TODO(Philipp, 03/23): Enable me after proper testing.
+#  release:
+#    types: [created]
 
 jobs:
   build:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: refs/tags/`${ steps.get_release.outputs.name }`
+        ref: refs/tags/`${{ steps.get_release.outputs.name }}`
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -15,7 +15,8 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Checkout code
       uses: actions/checkout@v3
-      ref: ${ steps.get_release.outputs.tag_name }
+      with:
+        ref: ${ steps.get_release.outputs.tag_name }
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,23 +1,25 @@
 name: Build and release lightly
 
 on:
+  push:
   release:
-    types: [edited] # change me to created
+    types: [created]
 
 jobs:
   build:
     name: Build and release
     runs-on: ubuntu-latest
     steps:
-    - name: Get release
-      id: get_release
-      uses: bruceadams/get-release@v1.3.2
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+    - name: Get latest release
+      id: latest_release
+      uses: kaliber5/action-get-release@v1
+      with:
+        token: ${{ github.token }}
+        latest: true
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${ steps.get_release.outputs.tag_name }
+        ref: ${ steps.get_release.outputs.name }
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 # TODO(Philipp, 03/23): Enable me after proper testing.
 #  release:
-#    types: [created]
+#    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,7 +1,8 @@
+name: Build and release lightly
+
 on:
-  push: # TODO: Remove me
   release:
-    types: [created]
+    types: [edited] # change me to created
 
 jobs:
   build:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -52,4 +52,4 @@ jobs:
         SLACK_FOOTER: ""
         SLACK_MESSAGE: |
           Release status: {{steps.emoji_status.outputs.status}}
-          Url: https://pypi.org/project/lightly/${{steps.checkout_latest_release_tag.outputs.tag_name}}
+          https://pypi.org/project/lightly/${{steps.checkout_latest_release_tag.outputs.tag_name}}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${ steps.get_release.outputs.name }
+        ref: tags/${ steps.get_release.outputs.name }
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -12,14 +12,16 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        fetch-depth: 0
     - name: Checkout latest release tag
       run: |
         LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
         git checkout $LATEST_TAG
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
     - name: Build and release
       id: build_and_release
       run: git log -p -2

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -29,9 +29,9 @@ jobs:
       id: build_and_release
       run: |
         pip3 install wheel
-        make dist
         pip3 install twine
-        twine -h
+        make dist
+        twine upload -u ${{ secrets.PYPI_USER_NAME }} -p ${{ secrets.PYPI_PASSWORD }} dist/*
     - name: Convert success/failure strings to emojis
       id: emoji_status
       run: |

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -46,7 +46,7 @@ jobs:
       if: always()
       uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TEST_CHANNEL }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
         SLACK_ICON_EMOJI: ":python:"
         SLACK_USERNAME: Release of Lightly PIP Package ${{steps.checkout_latest_release_tag.outputs.tag_name}}
         SLACK_COLOR: ${{ steps.build_and_release.outcome }}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Build and release
       id: build_and_release
       run: |
+        pip3 install wheel
         make dist
         pip3 install twine
         twine -h

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -31,6 +31,16 @@ jobs:
         make dist
         pip3 install twine
         twine -h
+    - name: Convert success/failure strings to emojis
+      id: emoji-status
+      run: |
+        function set-emoji-output {
+          if [ "$2" == "success" ];
+          then echo "$1=:github-check-mark:" >> $GITHUB_OUTPUT;
+          else echo "$1=:github-changes-requested:" >> $GITHUB_OUTPUT;
+          fi
+        }
+        set-emoji-output status ${{ steps.build_and_release.outcome }}
     - name: Slack notification
       if: always()
       uses: rtCamp/action-slack-notify@v2
@@ -40,3 +50,5 @@ jobs:
         SLACK_USERNAME: Release of Lightly PIP Package ${{steps.checkout_latest_release_tag.outputs.tag_name}}
         SLACK_COLOR: ${{ steps.build_and_release.outcome }}
         SLACK_FOOTER: ""
+        SLACK_MESSAGE: |
+          Release status:  | URL: https://pypi.org/project/lightly/${{steps.checkout_latest_release_tag.outputs.tag_name}}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -1,0 +1,25 @@
+on:
+  push: # TODO: Remove me
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: Build and release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get release
+      id: get_release
+      uses: bruceadams/get-release@v1.3.2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+      ref: ${ steps.get_release.outputs.tag_name }
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Build and release
+      id: build_and_release
+      run: git log -p -2

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -10,20 +10,16 @@ jobs:
     name: Build and release
     runs-on: ubuntu-latest
     steps:
-    - name: Get latest release
-      id: latest_release
-      uses: kaliber5/action-get-release@v1
-      with:
-        token: ${{ github.token }}
-        latest: true
     - name: Checkout code
       uses: actions/checkout@v3
-      with:
-        ref: refs/tags/${{ steps.latest_release.outputs.name }}
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Checkout latest release tag
+      run: |
+        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+        git checkout $LATEST_TAG
     - name: Build and release
       id: build_and_release
       run: git log -p -2

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -51,5 +51,5 @@ jobs:
         SLACK_COLOR: ${{ steps.build_and_release.outcome }}
         SLACK_FOOTER: ""
         SLACK_MESSAGE: |
-          Release status: ${{steps.emoji_status.outputs.status}}
+          Release status: {{steps.emoji_status.outputs.status}}
           Url: https://pypi.org/project/lightly/${{steps.checkout_latest_release_tag.outputs.tag_name}}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -47,7 +47,7 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TEST_CHANNEL }}
-        SLACK_ICON_EMOJI: ":github:"
+        SLACK_ICON_EMOJI: ":python:"
         SLACK_USERNAME: Release of Lightly PIP Package ${{steps.checkout_latest_release_tag.outputs.tag_name}}
         SLACK_COLOR: ${{ steps.build_and_release.outcome }}
         SLACK_FOOTER: ""

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -32,7 +32,7 @@ jobs:
         pip3 install twine
         twine -h
     - name: Convert success/failure strings to emojis
-      id: emoji-status
+      id: emoji_status
       run: |
         function set-emoji-output {
           if [ "$2" == "success" ];
@@ -51,4 +51,5 @@ jobs:
         SLACK_COLOR: ${{ steps.build_and_release.outcome }}
         SLACK_FOOTER: ""
         SLACK_MESSAGE: |
-          Release status:  | URL: https://pypi.org/project/lightly/${{steps.checkout_latest_release_tag.outputs.tag_name}}
+          Release status: ${{steps.emoji_status.outputs.status}}
+          Url: https://pypi.org/project/lightly/${{steps.checkout_latest_release_tag.outputs.tag_name}}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -37,6 +37,6 @@ jobs:
       env:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TEST_CHANNEL }}
         SLACK_ICON_EMOJI: ":github:"
-        SLACK_USERNAME: Release of Lightly PIP Package ${{checkout_latest_release_tag.outputs.tag_name}}
+        SLACK_USERNAME: Release of Lightly PIP Package ${{steps.checkout_latest_release_tag.outputs.tag_name}}
         SLACK_COLOR: ${{ steps.build_and_release.outcome }}
         SLACK_FOOTER: ""

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -24,4 +24,7 @@ jobs:
         python-version: "3.10"
     - name: Build and release
       id: build_and_release
-      run: git log -2
+      run: |
+        make dist
+        pip3 install twine
+        twine -h

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -51,5 +51,5 @@ jobs:
         SLACK_COLOR: ${{ steps.build_and_release.outcome }}
         SLACK_FOOTER: ""
         SLACK_MESSAGE: |
-          Release status: {{steps.emoji_status.outputs.status}}
+          Release status: ${{steps.emoji_status.outputs.status}}
           https://pypi.org/project/lightly/${{steps.checkout_latest_release_tag.outputs.tag_name}}

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: tags/${ steps.get_release.outputs.name }
+        ref: tags/`${ steps.get_release.outputs.name }`
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: refs/tags/`${{ steps.get_release.outputs.name }}`
+        ref: refs/tags/${{ steps.latest_release.outputs.name }}
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -15,9 +15,11 @@ jobs:
       with:
         fetch-depth: 0
     - name: Checkout latest release tag
+      id: checkout_latest_release_tag
       run: |
         LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
         git checkout $LATEST_TAG
+        echo "tag_name=$LATEST_TAG" >> $GITHUB_OUTPUT;
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
@@ -29,3 +31,12 @@ jobs:
         make dist
         pip3 install twine
         twine -h
+    - name: Slack notification
+      if: always()
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_TEST_CHANNEL }}
+        SLACK_ICON_EMOJI: ":github:"
+        SLACK_USERNAME: Release of Lightly PIP Package ${{checkout_latest_release_tag.outputs.tag_name}}
+        SLACK_COLOR: ${{ steps.build_and_release.outcome }}
+        SLACK_FOOTER: ""

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -24,4 +24,4 @@ jobs:
         python-version: "3.10"
     - name: Build and release
       id: build_and_release
-      run: git log -p -2
+      run: git log -2

--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: tags/`${ steps.get_release.outputs.name }`
+        ref: refs/tags/`${ steps.get_release.outputs.name }`
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
### What has changed and why?

Add automated release workflow for the Lightly PIP package:
- On dispatch for now (change to release later)
- Check out latest tag
- Install `wheel` and `twine`
- Build distribution and upload to PyPI
- Send Slack message indicating success or failure

### How has this been tested?

Action runs through successfully using `twine -h` instead of `twine upload ...`:
- [Action](https://github.com/lightly-ai/lightly/actions/runs/4575518821/jobs/8078446374?pr=1126)
- [Slack message](https://lightly-ai.slack.com/archives/C03T7GLHG8P/p1680268950577909)