### PR TITLE
lig-2904: Remove hydra from lightly config

### DIFF
--- a/lightly/cli/config/get_config.py
+++ b/lightly/cli/config/get_config.py
@@ -6,7 +6,7 @@ from omegaconf import DictConfig, OmegaConf
 def get_lightly_config() -> DictConfig:
     config_path = Path(__file__).with_name("config.yaml")
     conf = OmegaConf.load(config_path)
-    # FIXME: remove this when hydra is completely dropped
+    # TODO(Huan, 05.04.2023): remove this when hydra is completely dropped
     if conf.get("hydra"):
         # This config entry is only for hydra; not referenced in any logic
         del conf["hydra"]

--- a/lightly/cli/config/get_config.py
+++ b/lightly/cli/config/get_config.py
@@ -6,4 +6,8 @@ from omegaconf import DictConfig, OmegaConf
 def get_lightly_config() -> DictConfig:
     config_path = Path(__file__).with_name("config.yaml")
     conf = OmegaConf.load(config_path)
+    # FIXME: remove this when hydra is completely dropped
+    if conf.get("hydra"):
+        # This config entry is only for hydra; not referenced in any logic
+        del conf["hydra"]
     return conf


### PR DESCRIPTION
The `hydra` section in `config.yaml` is only for hydra and not used in any logic. Removing this redundant bit from the actual lightly config read from the config file.