### PR TITLE
lig-3137: Add get_compute_workers to API client

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -20,6 +20,7 @@ from lightly.openapi_generated.swagger_client import (
     DockerWorkerConfigV3CreateRequest,
     DockerWorkerConfigV3Docker,
     DockerWorkerConfigV3Lightly,
+    DockerWorkerRegistryEntryData,
     DockerWorkerType,
     SelectionConfig,
     SelectionConfigEntry,
@@ -109,6 +110,13 @@ class _ComputeWorkerMixin:
         """Returns the ids of all registered compute workers."""
         entries = self._compute_worker_api.get_docker_worker_registry_entries()
         return [entry.id for entry in entries]
+
+    def get_compute_workers(self) -> List[DockerWorkerRegistryEntryData]:
+        """Returns the ids of all registered compute workers."""
+        entries: list[
+            DockerWorkerRegistryEntryData
+        ] = self._compute_worker_api.get_docker_worker_registry_entries()
+        return entries
 
     def delete_compute_worker(self, worker_id: str):
         """Removes a compute worker.

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -29,6 +29,7 @@ from lightly.openapi_generated.swagger_client import (
     DockerWorkerConfigV3DockerCorruptnessCheck,
     DockerWorkerConfigV3Lightly,
     DockerWorkerConfigV3LightlyLoader,
+    DockerWorkerState,
     DockerWorkerType,
     SelectionConfig,
     SelectionConfigEntry,
@@ -150,6 +151,13 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
     def test_get_compute_worker_ids(self):
         ids = self.api_workflow_client.get_compute_worker_ids()
         assert all(isinstance(id_, str) for id_ in ids)
+
+    def test_get_compute_workers(self):
+        workers = self.api_workflow_client.get_compute_workers()
+        assert len(workers) == 1
+        assert workers[0].name == "worker-name-1"
+        assert workers[0].state == DockerWorkerState.OFFLINE
+        assert workers[0].labels == ["label-1"]
 
     def test_get_compute_worker_runs(self):
         runs = self.api_workflow_client.get_compute_worker_runs()


### PR DESCRIPTION
`get_compute_workers` returns information of a list of workers.