### PR TITLE
lig-3138: Refine get_compute_worker_run_info

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -31,8 +31,6 @@ from lightly.openapi_generated.swagger_client import (
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
 
-STATE_SCHEDULED_ID_NOT_FOUND = "CANCELED_OR_NOT_EXISTING"
-
 
 class InvalidConfigurationError(RuntimeError):
     pass

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -2,7 +2,6 @@ import copy
 import dataclasses
 import difflib
 import time
-from enum import Enum
 from functools import partial
 from typing import Any, Callable, Dict, Iterator, List, Optional, Type, TypeVar, Union
 
@@ -15,7 +14,6 @@ from lightly.openapi_generated.swagger_client import (
     DockerRunScheduledCreateRequest,
     DockerRunScheduledData,
     DockerRunScheduledPriority,
-    DockerRunScheduledState,
     DockerRunState,
     DockerWorkerConfigV3,
     DockerWorkerConfigV3CreateRequest,

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -20,6 +20,7 @@ from lightly.openapi_generated.swagger_client import (
     DockerWorkerConfigV3CreateRequest,
     DockerWorkerConfigV3Docker,
     DockerWorkerConfigV3Lightly,
+    DockerWorkerRegistryEntryData,
     DockerWorkerType,
     SelectionConfig,
     SelectionConfigEntry,
@@ -109,6 +110,13 @@ class _ComputeWorkerMixin:
         """Returns the ids of all registered compute workers."""
         entries = self._compute_worker_api.get_docker_worker_registry_entries()
         return [entry.id for entry in entries]
+
+    def get_compute_workers(self) -> List[DockerWorkerRegistryEntryData]:
+        """Returns the ids of all registered compute workers."""
+        entries: list[
+            DockerWorkerRegistryEntryData
+        ] = self._compute_worker_api.get_docker_worker_registry_entries()
+        return entries
 
     def delete_compute_worker(self, worker_id: str):
         """Removes a compute worker.

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -29,6 +29,7 @@ from lightly.openapi_generated.swagger_client import (
     DockerWorkerConfigV3DockerCorruptnessCheck,
     DockerWorkerConfigV3Lightly,
     DockerWorkerConfigV3LightlyLoader,
+    DockerWorkerState,
     DockerWorkerType,
     SelectionConfig,
     SelectionConfigEntry,
@@ -150,6 +151,13 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
     def test_get_compute_worker_ids(self):
         ids = self.api_workflow_client.get_compute_worker_ids()
         assert all(isinstance(id_, str) for id_ in ids)
+
+    def test_get_compute_workers(self):
+        workers = self.api_workflow_client.get_compute_workers()
+        assert len(workers) == 1
+        assert workers[0].name == "worker-name-1"
+        assert workers[0].state == DockerWorkerState.OFFLINE
+        assert workers[0].labels == ["label-1"]
 
     def test_get_compute_worker_runs(self):
         runs = self.api_workflow_client.get_compute_worker_runs()


### PR DESCRIPTION
* Created class `ComputeWorkerRunState` from a union of states in different classes
* Added validation for `ComputeWorkerRunState`
* Changed state naming: `OPEN` to `PENDING` and `CANCELED_OR_NOT_EXISTING` to `NOT_FOUND`. Note: no backward compatibility.