### PR TITLE
add datasourceUrl to export endpoint

### DIFF
--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -250,7 +250,7 @@ class _ExportDatasetMixin:
             [
                 {
                     "fileName": "sample1.jpg",
-                    "readURL": "s3://my_datasource/sample1.jpg?read_url_key=EAIFUIENDLFN",
+                    "readUrl": "s3://my_datasource/sample1.jpg?read_url_key=EAIFUIENDLFN",
                     "datasourceUrl": "s3://my_datasource/sample1.jpg",
                 },
                 {

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -308,7 +308,7 @@ class _ExportDatasetMixin:
                 Name of the tag which should exported.
 
         Returns:
-            A list of dictionaries with the keys "filename", "readURL" and "datasourceURL".
+            A list of dictionaries with the keys "filename", "readUrl" and "datasourceUrl".
 
         Examples:
             >>> # write json file which can be used to access the actual file contents.

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -238,7 +238,7 @@ class _ExportDatasetMixin:
         self,
         tag_id: str,
     ) -> List[Dict[str, str]]:
-        """Export the samples filenames to map with their readURL and datasource URL.
+        """Export filenames, read URLs, and datasource URLs from the given tag.
 
         Args:
             tag_id:

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -255,7 +255,7 @@ class _ExportDatasetMixin:
                 },
                 {
                     "fileName": "sample2.jpg",
-                    "readURL": "s3://my_datasource/sample2.jpg?read_url_key=JSBFIEUHVSJ",
+                    "readUrl": "s3://my_datasource/sample2.jpg?read_url_key=JSBFIEUHVSJ",
                     "datasourceUrl": "s3://my_datasource/sample2.jpg",
                 },
             ]

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -245,7 +245,7 @@ class _ExportDatasetMixin:
                 Id of the tag which should exported.
 
         Returns:
-            A list of dictionaries with the keys "filename", "readURL" and "datasourceURL".
+            A list of dictionaries with the keys "filename", "readUrl" and "datasourceUrl".
             An example:
             [
                 {

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -290,9 +290,11 @@ class _ExportDatasetMixin:
             {
                 "fileName": filename,
                 "readUrl": read_url,
-                "datasourceUrl": datasource_url
+                "datasourceUrl": datasource_url,
             }
-            for filename, read_url, datasource_url in zip(filenames, read_urls, datasource_urls)
+            for filename, read_url, datasource_url in zip(
+                filenames, read_urls, datasource_urls
+            )
         ]
 
     def export_filenames_and_read_urls_by_tag_name(

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -301,7 +301,7 @@ class _ExportDatasetMixin:
         self,
         tag_name: str,
     ) -> List[Dict[str, str]]:
-        """Export the samples filenames to map with their readURL and datasource URL.
+        """Export filenames, read URLs, and datasource URLs from the given tag name.
 
         Args:
             tag_name:

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -237,19 +237,30 @@ class _ExportDatasetMixin:
     def export_filenames_and_read_urls_by_tag_id(
         self,
         tag_id: str,
-    ) -> List[Dict]:
-        """Export the samples filenames to map with their readURL.
+    ) -> List[Dict[str, str]]:
+        """Export the samples filenames to map with their readURL and datasource URL.
 
         Args:
             tag_id:
                 Id of the tag which should exported.
 
         Returns:
-            A list of mappings of the samples filenames and readURLs within a certain tag.
+            A list of dictionaries with the keys "filename", "readURL" and "datasourceURL".
+            An example:
+            [
+                {
+                    "fileName": "sample1.jpg",
+                    "readURL": "s3://my_datasource/sample1.jpg?read_url_key=EAIFUIENDLFN",
+                    "datasourceUrl": "s3://my_datasource/sample1.jpg",
+                },
+                {
+                    "fileName": "sample2.jpg",
+                    "readURL": "s3://my_datasource/sample2.jpg?read_url_key=JSBFIEUHVSJ",
+                    "datasourceUrl": "s3://my_datasource/sample2.jpg",
+                },
+            ]
 
         """
-        # TODO (Philipp, 10.01.2023): Switch to the exportTagToBasicFilenamesAndReadUrls
-        # when the read-urls are fixed.
         filenames_string = retry(
             self._tags_api.export_tag_to_basic_filenames,
             dataset_id=self.dataset_id,
@@ -262,32 +273,40 @@ class _ExportDatasetMixin:
             tag_id=tag_id,
             file_name_format=FileNameFormat.REDIRECTED_READ_URL,
         )
+        datasource_urls_string = retry(
+            self._tags_api.export_tag_to_basic_filenames,
+            dataset_id=self.dataset_id,
+            tag_id=tag_id,
+            file_name_format=FileNameFormat.DATASOURCE_FULL,
+        )
         # The endpoint exportTagToBasicFilenames returns a plain string so we
         # have to split it by newlines in order to get the individual entries.
+        # The order of the fileNames and readUrls and datasourceUrls is guaranteed to be the same
+        # by the API so we can simply zip them.
         filenames = filenames_string.split("\n")
         read_urls = read_urls_string.split("\n")
-        # The order of the fileNames and readUrls is guaranteed to be the same
-        # by the API so we can simply zip them.
+        datasource_urls = datasource_urls_string.split("\n")
         return [
             {
                 "fileName": filename,
                 "readUrl": read_url,
+                "datasourceUrl": datasource_url
             }
-            for filename, read_url in zip(filenames, read_urls)
+            for filename, read_url, datasource_url in zip(filenames, read_urls, datasource_urls)
         ]
 
     def export_filenames_and_read_urls_by_tag_name(
         self,
         tag_name: str,
-    ) -> List[Dict]:
-        """Export the samples filenames to map with their readURL.
+    ) -> List[Dict[str, str]]:
+        """Export the samples filenames to map with their readURL and datasource URL.
 
         Args:
             tag_name:
                 Name of the tag which should exported.
 
         Returns:
-            A list of mappings of the samples filenames and readURLs within a certain tag.
+            A list of dictionaries with the keys "filename", "readURL" and "datasourceURL".
 
         Examples:
             >>> # write json file which can be used to access the actual file contents.
@@ -295,7 +314,7 @@ class _ExportDatasetMixin:
             >>>     'initial-tag'
             >>> )
             >>>
-            >>> with open('my-readURL-mappings.json', 'w') as f:
+            >>> with open('my-samples.json', 'w') as f:
             >>>     json.dump(mappings, f)
 
         """

--- a/tests/api_workflow/test_api_workflow_export.py
+++ b/tests/api_workflow/test_api_workflow_export.py
@@ -1,5 +1,7 @@
-from lightly.api import api_workflow_download_dataset
-from lightly.openapi_generated.swagger_client import DatasetEmbeddingData
+from unittest.mock import MagicMock
+
+from lightly.api import api_workflow_download_dataset, ApiWorkflowClient
+from lightly.openapi_generated.swagger_client import DatasetEmbeddingData, FileNameFormat, TagsApi
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 
@@ -62,18 +64,34 @@ class TestApiWorkflowExport(MockedApiWorkflowSetup):
         self.assertTrue(all(isinstance(task, dict) for task in tasks))
 
     def test_export_tag_to_basic_filenames_and_read_urls(self):
-        filenames_and_read_urls = (
-            self.api_workflow_client.export_filenames_and_read_urls_by_tag_name(
-                "initial-tag"
-            )
-        )
-        self.assertIsNotNone(filenames_and_read_urls)
-        self.assertTrue(
-            all(
-                isinstance(filenames_and_read_url, dict)
-                for filenames_and_read_url in filenames_and_read_urls
-            )
-        )
+
+        def mocked_export_tag_to_basic_filenames(dataset_id: str, tag_id: str, file_name_format: str):
+            return {
+                FileNameFormat.NAME: "\n".join(["sample1.jpg", "sample2.jpg"]),
+                FileNameFormat.REDIRECTED_READ_URL: "\n".join(["READ_URL_1", "READ_URL_2"]),
+                FileNameFormat.DATASOURCE_FULL: "\n".join(["s3://my_datasource/sample1.jpg", "s3://my_datasource/sample2.jpg"]),
+            }[file_name_format]
+
+        mocked_client = MagicMock(spec=ApiWorkflowClient)
+        mocked_client.dataset_id = "some_dataset_id"
+        mocked_client._tags_api = MagicMock(spec_set=TagsApi)
+        mocked_client._tags_api.export_tag_to_basic_filenames.side_effect = mocked_export_tag_to_basic_filenames
+
+        data = ApiWorkflowClient.export_filenames_and_read_urls_by_tag_id(self=mocked_client, tag_id="tag_id")
+
+        assert data == [
+                {
+                    "fileName": "sample1.jpg",
+                    "readUrl": "READ_URL_1",
+                    "datasourceUrl": "s3://my_datasource/sample1.jpg",
+                },
+                {
+                    "fileName": "sample2.jpg",
+                    "readUrl": "READ_URL_2",
+                    "datasourceUrl": "s3://my_datasource/sample2.jpg",
+                },
+            ]
+
 
     def test_export_filenames_by_tag_name(self):
         filenames = self.api_workflow_client.export_filenames_by_tag_name("initial-tag")

--- a/tests/api_workflow/test_api_workflow_export.py
+++ b/tests/api_workflow/test_api_workflow_export.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from lightly.api import api_workflow_download_dataset, ApiWorkflowClient
+from lightly.api import ApiWorkflowClient, api_workflow_download_dataset
 from lightly.openapi_generated.swagger_client import (
     DatasetEmbeddingData,
     FileNameFormat,

--- a/tests/api_workflow/test_api_workflow_export.py
+++ b/tests/api_workflow/test_api_workflow_export.py
@@ -1,7 +1,11 @@
 from unittest.mock import MagicMock
 
 from lightly.api import api_workflow_download_dataset, ApiWorkflowClient
-from lightly.openapi_generated.swagger_client import DatasetEmbeddingData, FileNameFormat, TagsApi
+from lightly.openapi_generated.swagger_client import (
+    DatasetEmbeddingData,
+    FileNameFormat,
+    TagsApi,
+)
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 
@@ -64,34 +68,42 @@ class TestApiWorkflowExport(MockedApiWorkflowSetup):
         self.assertTrue(all(isinstance(task, dict) for task in tasks))
 
     def test_export_tag_to_basic_filenames_and_read_urls(self):
-
-        def mocked_export_tag_to_basic_filenames(dataset_id: str, tag_id: str, file_name_format: str):
+        def mocked_export_tag_to_basic_filenames(
+            dataset_id: str, tag_id: str, file_name_format: str
+        ):
             return {
                 FileNameFormat.NAME: "\n".join(["sample1.jpg", "sample2.jpg"]),
-                FileNameFormat.REDIRECTED_READ_URL: "\n".join(["READ_URL_1", "READ_URL_2"]),
-                FileNameFormat.DATASOURCE_FULL: "\n".join(["s3://my_datasource/sample1.jpg", "s3://my_datasource/sample2.jpg"]),
+                FileNameFormat.REDIRECTED_READ_URL: "\n".join(
+                    ["READ_URL_1", "READ_URL_2"]
+                ),
+                FileNameFormat.DATASOURCE_FULL: "\n".join(
+                    ["s3://my_datasource/sample1.jpg", "s3://my_datasource/sample2.jpg"]
+                ),
             }[file_name_format]
 
         mocked_client = MagicMock(spec=ApiWorkflowClient)
         mocked_client.dataset_id = "some_dataset_id"
         mocked_client._tags_api = MagicMock(spec_set=TagsApi)
-        mocked_client._tags_api.export_tag_to_basic_filenames.side_effect = mocked_export_tag_to_basic_filenames
+        mocked_client._tags_api.export_tag_to_basic_filenames.side_effect = (
+            mocked_export_tag_to_basic_filenames
+        )
 
-        data = ApiWorkflowClient.export_filenames_and_read_urls_by_tag_id(self=mocked_client, tag_id="tag_id")
+        data = ApiWorkflowClient.export_filenames_and_read_urls_by_tag_id(
+            self=mocked_client, tag_id="tag_id"
+        )
 
         assert data == [
-                {
-                    "fileName": "sample1.jpg",
-                    "readUrl": "READ_URL_1",
-                    "datasourceUrl": "s3://my_datasource/sample1.jpg",
-                },
-                {
-                    "fileName": "sample2.jpg",
-                    "readUrl": "READ_URL_2",
-                    "datasourceUrl": "s3://my_datasource/sample2.jpg",
-                },
-            ]
-
+            {
+                "fileName": "sample1.jpg",
+                "readUrl": "READ_URL_1",
+                "datasourceUrl": "s3://my_datasource/sample1.jpg",
+            },
+            {
+                "fileName": "sample2.jpg",
+                "readUrl": "READ_URL_2",
+                "datasourceUrl": "s3://my_datasource/sample2.jpg",
+            },
+        ]
 
     def test_export_filenames_by_tag_name(self):
         filenames = self.api_workflow_client.export_filenames_by_tag_name("initial-tag")


### PR DESCRIPTION
## Description

The `ApiWorkflowClient.export_filenames_and_read_urls_by_tag_id` now also includes the datasource URL.

Other possible implementation options I tried but decided against:
1. As separate functions for the one with read_urls and datasource_urls -> lots of duplicate code.
2. By allowing to set the `FileNameFormat` -> makes it more complicated.

Why is the name of the method the same?
I know that it does not fit perfectly, but changing it would be breaking. Thus I would leave it as it is.