### PR TITLE
Enable installation of api dependencies via requirements.txt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,12 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
         key: cache_v2_${{ env.pythonLocation }}-${{ hashFiles('requirements/**') }}
     - name: Install Dependencies and lightly
       run: pip install -e '.[all]'
-    - name: Debug requrements
-      run: pip freeze
     - name: Run Pytest
       run: |
         export LIGHTLY_SERVER_LOCATION="localhost:-1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-    - uses: actions/cache@v2
-      with:
-        path: ${{ env.pythonLocation }}
-        key: cache_v2_${{ env.pythonLocation }}-${{ hashFiles('requirements/**') }}
+    # - uses: actions/cache@v2
+    #   with:
+    #     path: ${{ env.pythonLocation }}
+    #     key: cache_v2_${{ env.pythonLocation }}-${{ hashFiles('requirements/**') }}
     - name: Install Dependencies and lightly
       run: pip install -e '.[all]'
     - name: Run Pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,14 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
-    # - uses: actions/cache@v2
-    #   with:
-    #     path: ${{ env.pythonLocation }}
-    #     key: cache_v2_${{ env.pythonLocation }}-${{ hashFiles('requirements/**') }}
+    - uses: actions/cache@v3
+      with:
+        path: ${{ env.pythonLocation }}
+        key: cache_v2_${{ env.pythonLocation }}-${{ hashFiles('requirements/**') }}
     - name: Install Dependencies and lightly
       run: pip install -e '.[all]'
+    - name: Debug requrements
+      run: pip freeze
     - name: Run Pytest
       run: |
         export LIGHTLY_SERVER_LOCATION="localhost:-1"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,9 +9,5 @@ requests>=2.23.0
 # is resolved.
 setuptools>=21.0.0,<=65.5.1
 six>=1.10
-torchvision
 tqdm>=4.44
 urllib3>=1.15.1
-# Note: pytorch_lightning>=1.5 is required for CLI
-# https://github.com/lightly-ai/lightly/issues/912
-pytorch_lightning>=1.0.4

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,0 +1,4 @@
+torchvision
+# Note: pytorch_lightning>=1.5 is required for CLI
+# https://github.com/lightly-ai/lightly/issues/912
+pytorch_lightning>=1.0.4

--- a/requirements/torch.txt
+++ b/requirements/torch.txt
@@ -1,3 +1,4 @@
+torch<2
 torchvision
 # Note: pytorch_lightning>=1.5 is required for CLI
 # https://github.com/lightly-ai/lightly/issues/912

--- a/setup.py
+++ b/setup.py
@@ -65,14 +65,16 @@ if __name__ == "__main__":
     long_description = load_description()
 
     python_requires = ">=3.6"
-    install_requires = load_requirements()
+    base_requires = load_requirements(filename="base.txt")
+    torch_requires = load_requirements(filename="torch.txt")
     video_requires = load_requirements(filename="video.txt")
     dev_requires = load_requirements(filename="dev.txt")
-    all_requires = dev_requires + video_requires
+
+    install_requires = base_requires + torch_requires
     extras_require = {
         "video": video_requires,
         "dev": dev_requires,
-        "all": all_requires,
+        "all": dev_requires + video_requires,
     }
 
     packages = [


### PR DESCRIPTION
### What has changed

Move torch dependencies to torch.txt. Lightly installation does not change, The dependencies for the install are now loaded from `base.txt` and `torch.txt`.

This enables to install `base.txt` manually without installing bulky torch.