### PR TITLE
Add support for SimCLR v2

### DIFF
--- a/lightly/cli/_cli_simclr.py
+++ b/lightly/cli/_cli_simclr.py
@@ -21,7 +21,9 @@ class _SimCLR(nn.Module):
         super(_SimCLR, self).__init__()
 
         self.backbone = backbone
-        self.projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
+        self.projection_head = SimCLRProjectionHead(
+            num_ftrs, num_ftrs, out_dim, batch_norm=False
+        )
 
     def forward(self, x0: torch.Tensor, x1: torch.Tensor = None):
         """Embeds and projects the input images."""

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -230,17 +230,14 @@ class SimCLRProjectionHead(ProjectionHead):
                 nn.ReLU(),
             )
         )
-        if num_layers > 2:
-            layers.extend(
-                [
-                    (
-                        hidden_dim,
-                        hidden_dim,
-                        nn.BatchNorm1d(hidden_dim) if batch_norm else None,
-                        nn.ReLU(),
-                    )
-                ]
-                * (num_layers - 2)
+        for layers in range(2, num_layers):
+            layers.append(
+                (
+                    hidden_dim,
+                    hidden_dim,
+                    nn.BatchNorm1d(hidden_dim) if batch_norm else None,
+                    nn.ReLU(),
+                )
             )
         layers.append(
             (

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -219,7 +219,7 @@ class SimCLRProjectionHead(ProjectionHead):
             output_dim: Number of output dimensions.
             num_layers: Number of hidden layers.
         """
-        layers: list[tuple[int, int, Optional[nn.Module], Optional[nn.Module]]] = []
+        layers: List[Tuple[int, int, Optional[nn.Module], Optional[nn.Module]]] = []
         layers.append((input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()))
         if num_layers > 2:
             layers.extend(

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -219,14 +219,14 @@ class SimCLRProjectionHead(ProjectionHead):
             output_dim: Number of output dimensions.
             num_layers: Number of hidden layers.
         """
-        super().__init__(
-            [
-                (input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()),
-                (hidden_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU())
-                * (num_layers - 2),
-                (hidden_dim, output_dim, nn.BatchNorm1d(output_dim), None),
-            ]
-        )
+        layers = [(input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU())]
+        if num_layers > 2:
+            layers.extend(
+                [(hidden_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU())]
+                * (num_layers - 2)
+            )
+        layers.append((hidden_dim, output_dim, nn.BatchNorm1d(output_dim), None))
+        super().__init__(layers)
 
 
 class SimSiamProjectionHead(ProjectionHead):

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -230,7 +230,7 @@ class SimCLRProjectionHead(ProjectionHead):
                 nn.ReLU(),
             )
         )
-        for layers in range(2, num_layers):
+        for _ in range(2, num_layers):
             layers.append(
                 (
                     hidden_dim,

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -198,17 +198,33 @@ class SimCLRProjectionHead(ProjectionHead):
     "We use a MLP with one hidden layer to obtain zi = g(h) = W_2 * σ(W_1 * h)
     where σ is a ReLU non-linearity." [0]
 
-    [0] SimCLR, 2020, https://arxiv.org/abs/2002.05709
+    "We use a 3-layer MLP projection head on top of a ResNet encoder." [1]
 
+    [0] SimCLR, 2020, https://arxiv.org/abs/2002.05709
+    [1] SimCLR, 2020, https://arxiv.org/abs/2006.10029
     """
 
     def __init__(
-        self, input_dim: int = 2048, hidden_dim: int = 2048, output_dim: int = 128
+        self,
+        input_dim: int = 2048,
+        hidden_dim: int = 2048,
+        output_dim: int = 2048,
+        num_layers: int = 3,
     ):
-        super(SimCLRProjectionHead, self).__init__(
+        """Initialize a new SimCLRProjectionHead instance.
+
+        Args:
+            input_dim: Number of input dimensions.
+            hidden_dim: Number of hidden dimensions.
+            output_dim: Number of output dimensions.
+            num_layers: Number of hidden layers.
+        """
+        super().__init__(
             [
-                (input_dim, hidden_dim, None, nn.ReLU()),
-                (hidden_dim, output_dim, None, None),
+                (input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()),
+                (hidden_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU())
+                * (num_layers - 2),
+                (hidden_dim, output_dim, nn.BatchNorm1d(output_dim), None),
             ]
         )
 

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -219,7 +219,8 @@ class SimCLRProjectionHead(ProjectionHead):
             output_dim: Number of output dimensions.
             num_layers: Number of hidden layers.
         """
-        layers = [(input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU())]
+        layers: list[tuple[int, int, Optional[nn.Module], Optional[nn.Module]]] = []
+        layers.append((input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()))
         if num_layers > 2:
             layers.extend(
                 [(hidden_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU())]

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -200,8 +200,8 @@ class SimCLRProjectionHead(ProjectionHead):
 
     "We use a 3-layer MLP projection head on top of a ResNet encoder." [1]
 
-    [0] SimCLR, 2020, https://arxiv.org/abs/2002.05709
-    [1] SimCLR, 2020, https://arxiv.org/abs/2006.10029
+    [0] SimCLR v1, 2020, https://arxiv.org/abs/2002.05709
+    [1] SimCLR v2, 2020, https://arxiv.org/abs/2006.10029
     """
 
     def __init__(
@@ -209,7 +209,8 @@ class SimCLRProjectionHead(ProjectionHead):
         input_dim: int = 2048,
         hidden_dim: int = 2048,
         output_dim: int = 2048,
-        num_layers: int = 3,
+        num_layers: int = 2,
+        batch_norm: bool = True,
     ):
         """Initialize a new SimCLRProjectionHead instance.
 
@@ -217,16 +218,38 @@ class SimCLRProjectionHead(ProjectionHead):
             input_dim: Number of input dimensions.
             hidden_dim: Number of hidden dimensions.
             output_dim: Number of output dimensions.
-            num_layers: Number of hidden layers.
+            num_layers: Number of hidden layers (2 for v1, 3+ for v2).
+            batch_norm: Whether or not to use batch norms.
         """
         layers: List[Tuple[int, int, Optional[nn.Module], Optional[nn.Module]]] = []
-        layers.append((input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()))
+        layers.append(
+            (
+                input_dim,
+                hidden_dim,
+                nn.BatchNorm1d(hidden_dim) if batch_norm else None,
+                nn.ReLU(),
+            )
+        )
         if num_layers > 2:
             layers.extend(
-                [(hidden_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU())]
+                [
+                    (
+                        hidden_dim,
+                        hidden_dim,
+                        nn.BatchNorm1d(hidden_dim) if batch_norm else None,
+                        nn.ReLU(),
+                    )
+                ]
                 * (num_layers - 2)
             )
-        layers.append((hidden_dim, output_dim, nn.BatchNorm1d(output_dim), None))
+        layers.append(
+            (
+                hidden_dim,
+                output_dim,
+                nn.BatchNorm1d(output_dim) if batch_norm else None,
+                None,
+            )
+        )
         super().__init__(layers)
 
 

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -32,7 +32,9 @@ class SimCLR(nn.Module):
         super(SimCLR, self).__init__()
 
         self.backbone = backbone
-        self.projection_head = SimCLRProjectionHead(num_ftrs, num_ftrs, out_dim)
+        self.projection_head = SimCLRProjectionHead(
+            num_ftrs, num_ftrs, out_dim, batch_norm=False
+        )
 
         warnings.warn(
             Warning(

--- a/tests/models/test_ProjectionHeads.py
+++ b/tests/models/test_ProjectionHeads.py
@@ -221,3 +221,30 @@ class TestProjectionHeads(unittest.TestCase):
                                     self.assertFalse(are_same)
                                 else:
                                     self.assertTrue(are_same)
+
+    def test_simclr_project_head_multiple_layers(self, device: str = "cpu", seed=0):
+        for in_features, hidden_features, out_features in self.n_features:
+            for num_layers in range(2, 5):
+                for batch_norm in [True, False]:
+                    torch.manual_seed(seed)
+                    head = SimCLRProjectionHead(
+                        in_features,
+                        hidden_features,
+                        out_features,
+                        num_layers,
+                        batch_norm,
+                    )
+                    head = head.eval()
+                    head = head.to(device)
+                    for batch_size in [1, 2]:
+                        msg = (
+                            f"head: SimCLRProjectionHead"
+                            + f"d_in, d_h, d_out = "
+                            + f"{in_features}x{hidden_features}x{out_features}"
+                        )
+                        with self.subTest(msg=msg):
+                            x = torch.torch.rand((batch_size, in_features)).to(device)
+                            with torch.no_grad():
+                                y = head(x)
+                            self.assertEqual(y.shape[0], batch_size)
+                            self.assertEqual(y.shape[1], out_features)

--- a/tests/models/test_ProjectionHeads.py
+++ b/tests/models/test_ProjectionHeads.py
@@ -59,6 +59,10 @@ class TestProjectionHeads(unittest.TestCase):
                     head = head_cls(
                         in_features, hidden_features, bottleneck_features, out_features
                     )
+                elif head_cls == SimCLRProjectionHead:
+                    head = head_cls(
+                        in_features, hidden_features, out_features, batch_norm=False
+                    )
                 else:
                     head = head_cls(in_features, hidden_features, out_features)
                 head = head.eval()


### PR DESCRIPTION
SimCLR v2 adds a deeper projection head (they experiment with 2–4 layers). By default, the input_dim, hidden_dim, and output_dim all match the number of outputs from the ResNet. All layers use a BatchNorm. 

See https://github.com/google-research/simclr/blob/master/model_util.py#L141 for the reference implementation.