### PR TITLE
Make type hints public

### DIFF
--- a/lightly/py.typed
+++ b/lightly/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [metadata]
 # This includes the license file(s) in the wheel.
 license_files = LICENSE.txt
+
+[options.package_data]
+lightly = py.typed


### PR DESCRIPTION
This will allow downstream libraries to use lightly's type hints with mypy.

See [PEP 561](https://peps.python.org/pep-0561/)