### PR TITLE
remove raise_active_learning_deprecation_warning() in init

### DIFF
--- a/lightly/active_learning/__init__.py
+++ b/lightly/active_learning/__init__.py
@@ -9,6 +9,3 @@ def raise_active_learning_deprecation_warning():
         DeprecationWarning,
         stacklevel=2,
     )
-
-
-raise_active_learning_deprecation_warning()


### PR DESCRIPTION
- Remove in `active_learning.__init__`
- keep in all `active_learning` classes

solves  #1152 