### PR TITLE
Fix dataset exists

### DIFF
--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -27,8 +27,10 @@ class _DatasetsMixin:
         try:
             self.get_dataset_by_id(dataset_id)
             return True
-        except ApiException:
-            return False
+        except ApiException as exception:
+            if exception.status == 404:  # Not Found
+                return False
+            raise exception
 
     def dataset_name_exists(
         self, dataset_name: str, shared: Optional[bool] = False

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -158,8 +158,8 @@ from lightly.openapi_generated.swagger_client.rest import ApiException
 
 
 def _check_dataset_id(dataset_id: str):
-    assert isinstance(dataset_id, str)
-    assert len(dataset_id) > 0
+    if not isinstance(dataset_id, str) or len(dataset_id) == 0:
+        raise ApiException(status=400, reason="Invalid dataset id.")
 
 
 N_FILES_ON_SERVER = 100
@@ -657,7 +657,7 @@ class MockedDatasetsApi(DatasetsApi):
             None,
         )
         if dataset is None:
-            raise ApiException()
+            raise ApiException(status=404, reason="Not found")
         return dataset
 
     def register_dataset_upload_by_id(self, body, dataset_id):

--- a/tests/api_workflow/test_api_workflow_datasets.py
+++ b/tests/api_workflow/test_api_workflow_datasets.py
@@ -7,6 +7,7 @@ from lightly.openapi_generated.swagger_client import (
     DatasetsApi,
     DatasetType,
 )
+from lightly.openapi_generated.swagger_client.rest import ApiException
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 
 
@@ -28,6 +29,16 @@ class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
         assert not self.api_workflow_client.dataset_name_exists(
             dataset_name="not_existing_dataset"
         )
+
+    def test_dataset_exists(self):
+        assert self.api_workflow_client.dataset_exists(dataset_id="dataset_1_id")
+        assert not self.api_workflow_client.dataset_exists(
+            dataset_id="non_existing_dataset_id"
+        )
+
+    def test_dataset_exists__raises_error(self):
+        with self.assertRaises(ApiException):
+            self.api_workflow_client.dataset_exists(dataset_id=None)
 
     def test_dataset_name_exists__own_existing(self):
         assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_1")

--- a/tests/api_workflow/test_api_workflow_datasets.py
+++ b/tests/api_workflow/test_api_workflow_datasets.py
@@ -37,8 +37,9 @@ class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
         )
 
     def test_dataset_exists__raises_error(self):
-        with self.assertRaises(ApiException):
+        with self.assertRaises(ApiException) as e:
             self.api_workflow_client.dataset_exists(dataset_id=None)
+            assert e.status != 404
 
     def test_dataset_name_exists__own_existing(self):
         assert self.api_workflow_client.dataset_name_exists(dataset_name="dataset_1")


### PR DESCRIPTION
# Fix dataset exists

* Make `dataset_exist` raise if the api exception is not `404` (not found).
* Add unit tests.

Note: `dataset_exist` works with `dataset_id` not with `dataset_name`. For the latter use `dataset_name_exists`.