### PR TITLE
Document exceptions and error codes

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -231,8 +231,8 @@ class _ComputeWorkerMixin:
                 If the API call returns a status code other than 200.
                     400: Missing or invalid parameters
                     402: Insufficient plan
-                    403: Invalid token
-                    404: Dataset not found
+                    403: Not authorized for this resource or invalid token
+                    404: Resource (dataset or config) not found
                     422: Missing or invalid file in datasource
             InvalidConfigError:
                 If one of the configurations is invalid.

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -226,6 +226,17 @@ class _ComputeWorkerMixin:
         Returns:
             The id of the scheduled run.
 
+        Raises:
+            ApiException:
+                If the API call returns a status code other than 200.
+                    400: Missing or invalid parameters
+                    402: Insufficient plan
+                    403: Invalid token
+                    404: Dataset not found
+                    422: Missing or invalid file in datasource
+            InvalidConfigError:
+                If one of the configurations is invalid.
+
         """
         if runs_on is None:
             runs_on = []


### PR DESCRIPTION
 # Document exceptions and error codes

Closes LIG-3160.
* Add the possible exceptions and error codes to `schedule_compute_worker_run`.