### PR TITLE
Add support for MoCo v3

### DIFF
--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -43,9 +43,7 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
         super(MoCo, self).__init__()
 
         self.backbone = backbone
-        self.projection_head = MoCoProjectionHead(
-            num_ftrs, num_ftrs, out_dim, batch_norm=False
-        )
+        self.projection_head = MoCoProjectionHead(num_ftrs, num_ftrs, out_dim)
         self.momentum_features = None
         self.momentum_projection_head = None
 

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -43,7 +43,9 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
         super(MoCo, self).__init__()
 
         self.backbone = backbone
-        self.projection_head = MoCoProjectionHead(num_ftrs, num_ftrs, out_dim, batch_norm=False)
+        self.projection_head = MoCoProjectionHead(
+            num_ftrs, num_ftrs, out_dim, batch_norm=False
+        )
         self.momentum_features = None
         self.momentum_projection_head = None
 

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -43,7 +43,7 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
         super(MoCo, self).__init__()
 
         self.backbone = backbone
-        self.projection_head = MoCoProjectionHead(num_ftrs, num_ftrs, out_dim)
+        self.projection_head = MoCoProjectionHead(num_ftrs, num_ftrs, out_dim, batch_norm=False)
         self.momentum_features = None
         self.momentum_projection_head = None
 

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -142,10 +142,10 @@ class MoCoProjectionHead(ProjectionHead):
     def __init__(
         self,
         input_dim: int = 2048,
-        hidden_dim: int = 4096,
-        output_dim: int = 256,
+        hidden_dim: int = 2048,
+        output_dim: int = 128,
         num_layers: int = 2,
-        batch_norm: bool = True,
+        batch_norm: bool = False,
     ):
         """Initialize a new MoCoProjectionHead instance.
 

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -128,7 +128,7 @@ class MoCoProjectionHead(ProjectionHead):
     """Projection head used for MoCo.
 
     "(...) we replace the fc head in MoCo with a 2-layer MLP head (hidden layer
-    2048-d, with ReLU)" [0]
+    2048-d, with ReLU)" [1]
 
     "The projection head is a 3-layer MLP. The prediction head is a 2-layer MLP. The
     hidden layers of both MLPs are 4096-d and are with ReLU; the output layers of both
@@ -151,11 +151,11 @@ class MoCoProjectionHead(ProjectionHead):
 
         Args:
             input_dim: Number of input dimensions.
-            hidden_dim: Number of hidden dimensions (2048 for v1 and v2, 4096 for v3).
-            output_dim: Number of output dimensions (128 for v1 and v2, 256 for v3).
-            num_layers: Number of hidden layers (2 for v1 and v2, 3 for v3).
+            hidden_dim: Number of hidden dimensions (2048 for v2, 4096 for v3).
+            output_dim: Number of output dimensions (128 for v2, 256 for v3).
+            num_layers: Number of hidden layers (2 for v2, 3 for v3).
             batch_norm: Whether or not to use batch norms.
-                (False for v1 and v2, True for v3)
+                (False for v2, True for v3)
         """
         layers: List[Tuple[int, int, Optional[nn.Module], Optional[nn.Module]]] = []
         layers.append(

--- a/tests/models/test_ProjectionHeads.py
+++ b/tests/models/test_ProjectionHeads.py
@@ -59,7 +59,7 @@ class TestProjectionHeads(unittest.TestCase):
                     head = head_cls(
                         in_features, hidden_features, bottleneck_features, out_features
                     )
-                elif head_cls in [MoCoProjectionHead, SimCLRProjectionHead]:
+                elif head_cls == SimCLRProjectionHead:
                     head = head_cls(
                         in_features, hidden_features, out_features, batch_norm=False
                     )


### PR DESCRIPTION
Exact same design as #1150. Should we just subclass one in the other?

I'll let you decide whether you want to default to v1/2 or v3 hyperparams.

Reference implementations:

* v1 and v2: https://github.com/facebookresearch/moco/blob/main/moco/builder.py#L34
* v3: https://github.com/facebookresearch/moco-v3/blob/main/moco/builder.py#L36