### PR TITLE
Guarin lig 3049 add metric callback tests

### DIFF
--- a/benchmarks/imagenet/resnet50/linear_eval.py
+++ b/benchmarks/imagenet/resnet50/linear_eval.py
@@ -93,4 +93,4 @@ def linear_eval(
         val_dataloaders=val_dataloader,
     )
     for metric in ["val_top1", "val_top5"]:
-        print(f"max linear {metric}: {max(metric_callback.get(metric))}")
+        print(f"max linear {metric}: {max(metric_callback.val_metrics[metric])}")

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -194,7 +194,7 @@ def pretrain(
         val_dataloaders=val_dataloader,
     )
     for metric in ["val_online_cls_top1", "val_online_cls_top5"]:
-        print(f"max {metric}: {max(metric_callback.get(metric))}")
+        print(f"max {metric}: {max(metric_callback.val_metrics[metric])}")
 
 
 if __name__ == "__main__":

--- a/lightly/utils/benchmarking/metric_callback.py
+++ b/lightly/utils/benchmarking/metric_callback.py
@@ -1,5 +1,4 @@
-from collections import defaultdict
-from typing import List
+from typing import Dict, List
 
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import Callback
@@ -9,6 +8,12 @@ from torch import Tensor
 class MetricCallback(Callback):
     """Callback that collects log metrics from the LightningModule and stores them after
     every epoch.
+
+    Attributes:
+        train_metrics:
+            Dictionary that stores the last logged metrics after every train epoch.
+        val_metrics:
+            Dictionary that stores the last logged metrics after every validation epoch.
 
     Example::
 
@@ -21,32 +26,40 @@ class MetricCallback(Callback):
         >>>         self.log("train_acc", acc)
         >>>         ...
         >>>
+        >>>     def validation_step(self, batch, batch_idx):
+        >>>         ...
+        >>>         self.log("val_acc", acc)
+        >>>         ...
+        >>>
         >>> metric_callback = MetricCallback()
         >>> trainer = Trainer(callbacks=[metric_callback], max_epochs=10)
         >>> trainer.fit(Model(), train_dataloder, val_dataloader)
         >>>
-        >>> max_train_acc = max(metric_callback.get("train_acc"))
+        >>> max_train_acc = max(metric_callback.train_metrics["train_acc"])
+        >>> max_val_acc = max(metric_callback.val_metrics["val_acc"])
     """
 
     def __init__(self):
         super().__init__()
-        self.metrics = defaultdict(list)
+        self.train_metrics: Dict[str, List[float]] = {}
+        self.val_metrics: Dict[str, List[float]] = {}
 
     def on_train_epoch_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
-        self._append_metrics(trainer=trainer)
+        if not trainer.sanity_checking:
+            self._append_metrics(metrics_dict=self.train_metrics, trainer=trainer)
 
     def on_validation_epoch_end(
         self, trainer: Trainer, pl_module: LightningModule
     ) -> None:
-        self._append_metrics(trainer=trainer)
+        if not trainer.sanity_checking:
+            self._append_metrics(metrics_dict=self.val_metrics, trainer=trainer)
 
-    def get(self, name: str) -> List[float]:
-        return [float(v) for v in self.metrics[name]]
-
-    def _append_metrics(self, trainer: Trainer) -> None:
+    def _append_metrics(
+        self, metrics_dict: Dict[str, List[float]], trainer: Trainer
+    ) -> None:
         for name, value in trainer.callback_metrics.items():
             # Only store scalar values.
             if isinstance(value, float) or (
                 isinstance(value, Tensor) and value.numel() == 1
             ):
-                self.metrics[name].append(value)
+                metrics_dict.setdefault(name, []).append(float(value))

--- a/tests/utils/benchmarking/test_metric_callback.py
+++ b/tests/utils/benchmarking/test_metric_callback.py
@@ -1,0 +1,39 @@
+from pytorch_lightning import LightningModule, Trainer
+from torch.utils.data import DataLoader
+from torchvision.datasets import FakeData
+from torchvision.transforms import ToTensor
+
+from lightly.utils.benchmarking import MetricCallback
+
+
+class TestMetricCallback:
+    def test(self) -> None:
+        callback = MetricCallback()
+        trainer = Trainer(accelerator="cpu", callbacks=[callback], max_epochs=3)
+        dataset = FakeData(
+            size=10, image_size=(3, 32, 32), num_classes=10, transform=ToTensor()
+        )
+        train_dataloader = DataLoader(dataset, batch_size=2)
+        val_dataloader = DataLoader(dataset, batch_size=2)
+        trainer.fit(
+            _DummyModule(),
+            train_dataloaders=train_dataloader,
+            val_dataloaders=val_dataloader,
+        )
+        assert callback.train_metrics["train_epoch"] == [0, 1, 2]
+        # test logs 2 * epoch in validation step
+        assert callback.val_metrics["val_epoch"] == [0, 2, 4]
+
+
+class _DummyModule(LightningModule):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def training_step(self, batch, batch_idx) -> None:
+        self.log("train_epoch", self.trainer.current_epoch)
+
+    def validation_step(self, batch, batch_idx) -> None:
+        self.log("val_epoch", self.trainer.current_epoch * 2)
+
+    def configure_optimizers(self) -> None:
+        return None

--- a/tests/utils/benchmarking/test_metric_callback.py
+++ b/tests/utils/benchmarking/test_metric_callback.py
@@ -1,3 +1,4 @@
+import torch
 from pytorch_lightning import LightningModule, Trainer
 from torch.utils.data import DataLoader
 from torchvision.datasets import FakeData
@@ -21,8 +22,10 @@ class TestMetricCallback:
             val_dataloaders=val_dataloader,
         )
         assert callback.train_metrics["train_epoch"] == [0, 1, 2]
+        assert callback.train_metrics["train_epoch_dict"] == [0, 1, 2]
         # test logs 2 * epoch in validation step
         assert callback.val_metrics["val_epoch"] == [0, 2, 4]
+        assert callback.val_metrics["val_epoch_dict"] == [0, 2, 4]
 
 
 class _DummyModule(LightningModule):
@@ -31,9 +34,11 @@ class _DummyModule(LightningModule):
 
     def training_step(self, batch, batch_idx) -> None:
         self.log("train_epoch", self.trainer.current_epoch)
+        self.log_dict({"train_epoch_dict": self.trainer.current_epoch})
 
     def validation_step(self, batch, batch_idx) -> None:
         self.log("val_epoch", self.trainer.current_epoch * 2)
+        self.log_dict({"val_epoch_dict": self.trainer.current_epoch * 2})
 
     def configure_optimizers(self) -> None:
         return None


### PR DESCRIPTION
## Changes

* Add `MetricCallback` tests
* Refactor `MetricCallback` to keep track of metrics after train and validation epochs separately.