### PR TITLE
lig 3050 simclr benchmark improvements

### DIFF
--- a/benchmarks/imagenet/resnet50/knn_eval.py
+++ b/benchmarks/imagenet/resnet50/knn_eval.py
@@ -75,4 +75,4 @@ def knn_eval(
         val_dataloaders=val_dataloader,
     )
     for metric in ["val_top1", "val_top5"]:
-        print(f"{metric}: {metric_callback.val_metrics[metric]}")
+        print(f"knn {metric}: {max(metric_callback.val_metrics[metric])}")

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -38,13 +38,13 @@ class SimCLR(LightningModule):
         views, targets = batch[0], batch[1]
         features = self.forward(torch.cat(views, dim=0)).flatten(start_dim=1)
         z = self.projection_head(features)
-        z0, z1 = torch.chunk(z, 2, dim=0)
+        z0, z1 = z.chunk(len(views))
         loss = self.criterion(z0, z1)
         self.log(
             "train_loss", loss, prog_bar=True, sync_dist=True, batch_size=len(targets)
         )
 
-        features0 = torch.chunk(features, 2, dim=0)[0]
+        features0 = features.chunk(len(views))[0]
         cls_loss, cls_log = self.online_classifier.training_step(
             (features0, targets), batch_idx
         )

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -1,5 +1,6 @@
 from typing import List, Tuple
 
+import torch
 from pytorch_lightning import LightningModule
 from torch import Tensor
 from torch.nn import Identity
@@ -12,7 +13,6 @@ from lightly.transforms import SimCLRTransform
 from lightly.utils.benchmarking import OnlineLinearClassifier
 from lightly.utils.lars import LARS
 from lightly.utils.scheduler import CosineWarmupScheduler
-import torch
 
 
 class SimCLR(LightningModule):
@@ -44,8 +44,9 @@ class SimCLR(LightningModule):
             "train_loss", loss, prog_bar=True, sync_dist=True, batch_size=len(targets)
         )
 
+        features0 = torch.chunk(features, 0, dim=0)[0]
         cls_loss, cls_log = self.online_classifier.training_step(
-            (features, targets), batch_idx
+            (features0, targets), batch_idx
         )
         self.log_dict(cls_log, sync_dist=True, batch_size=len(targets))
         return loss + cls_loss

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -44,7 +44,7 @@ class SimCLR(LightningModule):
             "train_loss", loss, prog_bar=True, sync_dist=True, batch_size=len(targets)
         )
 
-        features0 = torch.chunk(features, 0, dim=0)[0]
+        features0 = torch.chunk(features, 2, dim=0)[0]
         cls_loss, cls_log = self.online_classifier.training_step(
             (features0, targets), batch_idx
         )

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -14,6 +14,7 @@ from lightly.transforms import SimCLRTransform
 from lightly.utils.benchmarking import OnlineLinearClassifier
 from lightly.utils.lars import LARS
 from lightly.utils.scheduler import CosineWarmupScheduler
+import torch
 
 
 class SimCLR(LightningModule):

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -14,7 +14,6 @@ from lightly.transforms import SimCLRTransform
 from lightly.utils.benchmarking import OnlineLinearClassifier
 from lightly.utils.lars import LARS
 from lightly.utils.scheduler import CosineWarmupScheduler
-import torch
 
 
 class SimCLR(LightningModule):

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -82,6 +82,9 @@ class SimCLR(LightningModule):
                     "weight_decay": 0.0,
                 },
             ],
+            # Use square root scaling for small batch sizes (<=2048) and few training
+            # epochs (<=200): lr=0.075 * sqrt(self.batch_size * self.trainer.world_size)
+            # See Table B.1. in the SimCLR paper https://arxiv.org/abs/2002.05709
             lr=0.3 * self.batch_size * self.trainer.world_size / 256,
             momentum=0.9,
             weight_decay=1e-6,

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -64,7 +64,7 @@ class SimCLR(LightningModule):
 
     def configure_optimizers(self):
         # Don't use weight decay for batch norm, bias parameters, and classification
-        # head.
+        # head to improve performance.
         params, params_no_weight_decay = get_weight_decay_parameters(
             [self.backbone, self.projection_head]
         )
@@ -87,6 +87,8 @@ class SimCLR(LightningModule):
             # See Table B.1. in the SimCLR paper https://arxiv.org/abs/2002.05709
             lr=0.3 * self.batch_size * self.trainer.world_size / 256,
             momentum=0.9,
+            # Note: Paper uses weight decay of 1e-6 but reference code 1e-4. See:
+            # https://github.com/google-research/simclr/blob/2fc637bdd6a723130db91b377ac15151e01e4fc2/README.md?plain=1#L103
             weight_decay=1e-6,
         )
         scheduler = {

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -83,6 +83,7 @@ class SimCLR(LightningModule):
                 },
             ],
             lr=0.3 * self.batch_size * self.trainer.world_size / 256,
+            momentum=0.9,
             weight_decay=1e-6,
         )
         scheduler = {

--- a/benchmarks/imagenet/resnet50/simclr.py
+++ b/benchmarks/imagenet/resnet50/simclr.py
@@ -82,8 +82,9 @@ class SimCLR(LightningModule):
                     "weight_decay": 0.0,
                 },
             ],
-            # Use square root scaling for small batch sizes (<=2048) and few training
-            # epochs (<=200): lr=0.075 * sqrt(self.batch_size * self.trainer.world_size)
+            # For better performance use square root scaling for small batch sizes (<=2048)
+            # and few training epochs (<=200):
+            #   lr=0.075 * sqrt(self.batch_size * self.trainer.world_size)
             # See Table B.1. in the SimCLR paper https://arxiv.org/abs/2002.05709
             lr=0.3 * self.batch_size * self.trainer.world_size / 256,
             momentum=0.9,


### PR DESCRIPTION
## Changes

* Encode all views at once. This is how it is implemented in the original paper. It should slightly improve training as the model  cannot use batch norm statistics to differentiate between embeddings from view 1 and 2. Not sure how much it improves though, didn't benchmark it.
* Use square root learning rate scaling. This is recommended by the paper for smaller batch sizes.
* Use 0.9 momentum. Forgot to add this previously. This is why the results are now much better.

## How was it tested?

Ran the benchmark again. We get now 63.2% linear eval top1 accuracy, compared to the paper which reports 62.8% for the same settings. Full results:
```
Imagenet
	max val_online_cls_top1: 	0.6309599876403809
	max val_online_cls_top5: 	0.8507199883460999
	knn val_top1: 			0.44929999113082886
	knn val_top5: 			0.7418799996376038
	max linear val_top1: 		0.6319800019264221
	max linear val_top5: 		0.8527600169181824

Imagenet100
	max val_online_cls_top1: 	0.6898000240325928
	max val_online_cls_top5: 	0.8980000019073486
	knn val_top1: 			0.5752000212669373
	knn val_top5: 			0.8485999703407288
	max linear val_top1: 		0.7233999967575073
	max linear val_top5: 		0.9165999889373779
	max finetune val_top1: 		0.7954000234603882
	max finetune val_top5: 		0.949400007724762

Imagenette
	max val_online_cls_top1: 	0.8166072368621826
	max val_online_cls_top5: 	0.9801324605941772
	knn val_top1: 			0.7763627171516418
	knn val_top5: 			0.9793683290481567
	max linear val_top1: 		0.8494651317596436
	max linear val_top5: 		0.9857361316680908
	max finetune val_top1: 		0.6314314603805542
	max finetune val_top5: 		0.943708598613739
```

Training was 100 epochs with batch size 256 (=2x128). This corresponds to the first entry in this table:
<img width="1003" alt="Screen Shot 2023-05-08 at 13 51 04" src="https://user-images.githubusercontent.com/43336610/236816670-3fe48588-6b2b-4bad-aeab-4082c96e06e7.png">


Will make a follow-up PR to add the results to readme/docs.