### PR TITLE
Fix NTXentLoss for distributed training without gather_distributed

### DIFF
--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -161,7 +161,8 @@ class NTXentLoss(MemoryBankModule):
 
             # create labels
             labels = torch.arange(batch_size, device=device, dtype=torch.long)
-            labels = labels + dist.rank() * batch_size
+            if self.gather_distributed:
+                labels = labels + dist.rank() * batch_size
             labels = labels.repeat(2)
 
         loss = self.cross_entropy(logits, labels)


### PR DESCRIPTION
## Changes

* Only adapt labels if `gather_distributed` is true

Before this change the labels were wrongly calculated if `gather_distributed` was `False` during distributed training. In that case we would increase the labels by `rank * batch_size` which is incorrect as the logits are only calculated from the current rank ([here](https://github.com/lightly-ai/lightly/blob/03f534b39c1ff5343eeb6c1b9643ab60248d5f9b/lightly/loss/ntx_ent_loss.py#L133-L137)) and labels don't need to be adapted.

Closes  #1176
