### PR TITLE
Add links to other lightly pages

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,16 @@ datasets. It is built on top of PyTorch and therefore fully compatible with
 other frameworks such as Fast.ai.
 
 
+Lightly
+-------
+
+- `Homepage <https://www.lightly.ai>`_
+- `Web-App <https://app.lightly.ai>`_
+- `Documentation <https://docs.lightly.ai/self-supervised-learning/>`_
+- `Lightly Solution Documentation (Lightly Worker & API) <https://docs.lightly.ai/>`_
+- `Github <https://github.com/lightly-ai/lightly>`_
+- `Discord <https://discord.gg/xvNJW94>`_ (We have weekly paper sessions!)
+
 .. toctree::
    :maxdepth: 1
    :caption: Getting Started


### PR DESCRIPTION
## Changes

* Add links from docs to other lightly pages

[Documentation — lightly 1.4.4 documentation.pdf](https://github.com/lightly-ai/lightly/files/11380954/Documentation.lightly.1.4.4.documentation.pdf)
