### PR TITLE
lig-3208: Update ApiWorkflowClient for relevant filenames

### DIFF
--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -102,7 +102,7 @@ class _DatasourcesMixin:
         to: Optional[int] = None,
         relevant_filenames_file_name: Optional[str] = None,
         run_id: Optional[str] = None,
-        relevant_filenames_artefact_id: Optional[str] = None,
+        relevant_filenames_artifact_id: Optional[str] = None,
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
@@ -119,10 +119,10 @@ class _DatasourcesMixin:
                 The path to the relevant filenames text file in the cloud bucket.
                 The path is relative to the datasource root.
             run_id:
-                Run ID. Should be given along with `relevant_filenames_artefact_id` to
+                Run ID. Should be given along with `relevant_filenames_artifact_id` to
                 download relevant files only.
-            relevant_filenames_artefact_id:
-                ID of the relevant filename artefact. Should be given along with
+            relevant_filenames_artifact_id:
+                ID of the relevant filename artifact. Should be given along with
                 `run_id` to download relevant files only. Note that this is different
                 from `relevant_filenames_file_name`.
             use_redirected_read_url:
@@ -138,6 +138,17 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
+        if run_id and not relevant_filenames_artifact_id:
+            raise ValueError(
+                "'relevant_filenames_artifact_id' should not be `None` when 'run_id' "
+                "is specified."
+            )
+        if not run_id and relevant_filenames_artifact_id:
+            raise ValueError(
+                "'run_id' should not be `None` when 'relevant_filenames_artifact_id' "
+                "is specified."
+            )
+
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_from_datasource_by_dataset_id,
             from_=from_,
@@ -146,7 +157,7 @@ class _DatasourcesMixin:
             use_redirected_read_url=use_redirected_read_url,
             progress_bar=progress_bar,
             relevant_filenames_run_id=run_id,
-            relevant_filenames_artefact_id=relevant_filenames_artefact_id,
+            relevant_filenames_artifact_id=relevant_filenames_artifact_id,
         )
         return samples
 
@@ -157,7 +168,7 @@ class _DatasourcesMixin:
         to: Optional[int] = None,
         relevant_filenames_file_name: Optional[str] = None,
         run_id: Optional[str] = None,
-        relevant_filenames_artefact_id: Optional[str] = None,
+        relevant_filenames_artifact_id: Optional[str] = None,
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
@@ -176,10 +187,10 @@ class _DatasourcesMixin:
                 The path to the relevant filenames text file in the cloud bucket.
                 The path is relative to the datasource root.
             run_id:
-                Run ID. Should be given along with `relevant_filenames_artefact_id` to
+                Run ID. Should be given along with `relevant_filenames_artifact_id` to
                 download relevant files only.
-            relevant_filenames_artefact_id:
-                ID of the relevant filename artefact. Should be given along with
+            relevant_filenames_artifact_id:
+                ID of the relevant filename artifact. Should be given along with
                 `run_id` to download relevant files only. Note that this is different
                 from `relevant_filenames_file_name`.
             use_redirected_read_url:
@@ -195,6 +206,17 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
+        if run_id and not relevant_filenames_artifact_id:
+            raise ValueError(
+                "'relevant_filenames_artifact_id' should not be `None` when 'run_id' "
+                "is specified."
+            )
+        if not run_id and relevant_filenames_artifact_id:
+            raise ValueError(
+                "'run_id' should not be `None` when 'relevant_filenames_artifact_id' "
+                "is specified."
+            )
+
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id,
             from_=from_,
@@ -204,7 +226,7 @@ class _DatasourcesMixin:
             task_name=task_name,
             progress_bar=progress_bar,
             relevant_filenames_run_id=run_id,
-            relevant_filenames_artefact_id=relevant_filenames_artefact_id,
+            relevant_filenames_artifact_id=relevant_filenames_artifact_id,
         )
         return samples
 
@@ -213,7 +235,7 @@ class _DatasourcesMixin:
         from_: int = 0,
         to: Optional[int] = None,
         run_id: Optional[str] = None,
-        relevant_filenames_artefact_id: Optional[str] = None,
+        relevant_filenames_artifact_id: Optional[str] = None,
         relevant_filenames_file_name: Optional[str] = None,
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
@@ -231,10 +253,10 @@ class _DatasourcesMixin:
                 The path to the relevant filenames text file in the cloud bucket.
                 The path is relative to the datasource root.
             run_id:
-                Run ID. Should be given along with `relevant_filenames_artefact_id` to
+                Run ID. Should be given along with `relevant_filenames_artifact_id` to
                 download relevant files only.
-            relevant_filenames_artefact_id:
-                ID of the relevant filename artefact. Should be given along with
+            relevant_filenames_artifact_id:
+                ID of the relevant filename artifact. Should be given along with
                 `run_id` to download relevant files only. Note that this is different
                 from `relevant_filenames_file_name`.
             use_redirected_read_url:
@@ -250,6 +272,17 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
+        if run_id and not relevant_filenames_artifact_id:
+            raise ValueError(
+                "'relevant_filenames_artifact_id' should not be `None` when 'run_id' "
+                "is specified."
+            )
+        if not run_id and relevant_filenames_artifact_id:
+            raise ValueError(
+                "'run_id' should not be `None` when 'relevant_filenames_artifact_id' "
+                "is specified."
+            )
+
         samples = self._download_raw_files(
             self._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id,
             from_=from_,
@@ -258,7 +291,7 @@ class _DatasourcesMixin:
             use_redirected_read_url=use_redirected_read_url,
             progress_bar=progress_bar,
             relevant_filenames_run_id=run_id,
-            relevant_filenames_artefact_id=relevant_filenames_artefact_id,
+            relevant_filenames_artifact_id=relevant_filenames_artifact_id,
         )
         return samples
 

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -101,6 +101,8 @@ class _DatasourcesMixin:
         from_: int = 0,
         to: Optional[int] = None,
         relevant_filenames_file_name: Optional[str] = None,
+        run_id: Optional[str] = None,
+        relevant_filenames_artefact_id: Optional[str] = None,
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
@@ -116,6 +118,13 @@ class _DatasourcesMixin:
             relevant_filenames_file_name:
                 The path to the relevant filenames text file in the cloud bucket.
                 The path is relative to the datasource root.
+            run_id:
+                Run ID. Should be given along with `relevant_filenames_artefact_id` to
+                download relevant files only.
+            relevant_filenames_artefact_id:
+                ID of the relevant filename artefact. Should be given along with
+                `run_id` to download relevant files only. Note that this is different
+                from `relevant_filenames_file_name`.
             use_redirected_read_url:
                 By default this is set to false unless a S3DelegatedAccess is configured in which
                 case its always true and this param has no effect.
@@ -129,6 +138,13 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
+        relevant_filenames_kwargs = {}
+        if run_id and relevant_filenames_artefact_id:
+            relevant_filenames_kwargs["relevant_filenames_run_id"] = run_id
+            relevant_filenames_kwargs[
+                "relevant_filenames_artefact_id"
+            ] = relevant_filenames_artefact_id
+
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_from_datasource_by_dataset_id,
             from_=from_,
@@ -136,6 +152,7 @@ class _DatasourcesMixin:
             relevant_filenames_file_name=relevant_filenames_file_name,
             use_redirected_read_url=use_redirected_read_url,
             progress_bar=progress_bar,
+            **relevant_filenames_kwargs,
         )
         return samples
 
@@ -145,6 +162,8 @@ class _DatasourcesMixin:
         from_: int = 0,
         to: Optional[int] = None,
         relevant_filenames_file_name: Optional[str] = None,
+        run_id: Optional[str] = None,
+        relevant_filenames_artefact_id: Optional[str] = None,
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
@@ -162,6 +181,13 @@ class _DatasourcesMixin:
             relevant_filenames_file_name:
                 The path to the relevant filenames text file in the cloud bucket.
                 The path is relative to the datasource root.
+            run_id:
+                Run ID. Should be given along with `relevant_filenames_artefact_id` to
+                download relevant files only.
+            relevant_filenames_artefact_id:
+                ID of the relevant filename artefact. Should be given along with
+                `run_id` to download relevant files only. Note that this is different
+                from `relevant_filenames_file_name`.
             use_redirected_read_url:
                 By default this is set to false unless a S3DelegatedAccess is configured in which
                 case its always true and this param has no effect.
@@ -175,6 +201,13 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
+        relevant_filenames_kwargs = {}
+        if run_id and relevant_filenames_artefact_id:
+            relevant_filenames_kwargs["relevant_filenames_run_id"] = run_id
+            relevant_filenames_kwargs[
+                "relevant_filenames_artefact_id"
+            ] = relevant_filenames_artefact_id
+
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id,
             from_=from_,
@@ -183,6 +216,7 @@ class _DatasourcesMixin:
             use_redirected_read_url=use_redirected_read_url,
             task_name=task_name,
             progress_bar=progress_bar,
+            **relevant_filenames_kwargs,
         )
         return samples
 
@@ -190,6 +224,8 @@ class _DatasourcesMixin:
         self,
         from_: int = 0,
         to: Optional[int] = None,
+        run_id: Optional[str] = None,
+        relevant_filenames_artefact_id: Optional[str] = None,
         relevant_filenames_file_name: Optional[str] = None,
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
@@ -206,6 +242,13 @@ class _DatasourcesMixin:
             relevant_filenames_file_name:
                 The path to the relevant filenames text file in the cloud bucket.
                 The path is relative to the datasource root.
+            run_id:
+                Run ID. Should be given along with `relevant_filenames_artefact_id` to
+                download relevant files only.
+            relevant_filenames_artefact_id:
+                ID of the relevant filename artefact. Should be given along with
+                `run_id` to download relevant files only. Note that this is different
+                from `relevant_filenames_file_name`.
             use_redirected_read_url:
                 By default this is set to false unless a S3DelegatedAccess is configured in which
                 case its always true and this param has no effect.
@@ -219,6 +262,13 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
+        relevant_filenames_kwargs = {}
+        if run_id and relevant_filenames_artefact_id:
+            relevant_filenames_kwargs["relevant_filenames_run_id"] = run_id
+            relevant_filenames_kwargs[
+                "relevant_filenames_artefact_id"
+            ] = relevant_filenames_artefact_id
+
         samples = self._download_raw_files(
             self._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id,
             from_=from_,
@@ -226,6 +276,7 @@ class _DatasourcesMixin:
             relevant_filenames_file_name=relevant_filenames_file_name,
             use_redirected_read_url=use_redirected_read_url,
             progress_bar=progress_bar,
+            **relevant_filenames_kwargs,
         )
         return samples
 

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -138,13 +138,6 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
-        relevant_filenames_kwargs = {}
-        if run_id and relevant_filenames_artefact_id:
-            relevant_filenames_kwargs["relevant_filenames_run_id"] = run_id
-            relevant_filenames_kwargs[
-                "relevant_filenames_artefact_id"
-            ] = relevant_filenames_artefact_id
-
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_from_datasource_by_dataset_id,
             from_=from_,
@@ -152,7 +145,8 @@ class _DatasourcesMixin:
             relevant_filenames_file_name=relevant_filenames_file_name,
             use_redirected_read_url=use_redirected_read_url,
             progress_bar=progress_bar,
-            **relevant_filenames_kwargs,
+            relevant_filenames_run_id=run_id,
+            relevant_filenames_artefact_id=relevant_filenames_artefact_id,
         )
         return samples
 
@@ -201,13 +195,6 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
-        relevant_filenames_kwargs = {}
-        if run_id and relevant_filenames_artefact_id:
-            relevant_filenames_kwargs["relevant_filenames_run_id"] = run_id
-            relevant_filenames_kwargs[
-                "relevant_filenames_artefact_id"
-            ] = relevant_filenames_artefact_id
-
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id,
             from_=from_,
@@ -216,7 +203,8 @@ class _DatasourcesMixin:
             use_redirected_read_url=use_redirected_read_url,
             task_name=task_name,
             progress_bar=progress_bar,
-            **relevant_filenames_kwargs,
+            relevant_filenames_run_id=run_id,
+            relevant_filenames_artefact_id=relevant_filenames_artefact_id,
         )
         return samples
 
@@ -262,13 +250,6 @@ class _DatasourcesMixin:
            A list of (filename, url) tuples, where each tuple represents a sample
 
         """
-        relevant_filenames_kwargs = {}
-        if run_id and relevant_filenames_artefact_id:
-            relevant_filenames_kwargs["relevant_filenames_run_id"] = run_id
-            relevant_filenames_kwargs[
-                "relevant_filenames_artefact_id"
-            ] = relevant_filenames_artefact_id
-
         samples = self._download_raw_files(
             self._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id,
             from_=from_,
@@ -276,7 +257,8 @@ class _DatasourcesMixin:
             relevant_filenames_file_name=relevant_filenames_file_name,
             use_redirected_read_url=use_redirected_read_url,
             progress_bar=progress_bar,
-            **relevant_filenames_kwargs,
+            relevant_filenames_run_id=run_id,
+            relevant_filenames_artefact_id=relevant_filenames_artefact_id,
         )
         return samples
 

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -746,6 +746,7 @@ class MockedDatasourcesApi(DatasourcesApi):
         to: int = None,
         relevant_filenames_file_name: str = -1,
         use_redirected_read_url: bool = False,
+        **kwargs,
     ) -> DatasourceRawSamplesData:
         if relevant_filenames_file_name == -1:
             samples = self._samples[dataset_id]

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -108,10 +108,10 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
 
         # should raise ValueError when only run_id is given
         with pytest.raises(ValueError):
-            self.api_workflow_client.download_raw_samples(run_id="foo")
+            self.api_workflow_client.download_raw_predictions(run_id="foo")
         # should raise ValueError when only relevant_filenames_artifact_id is given
         with pytest.raises(ValueError):
-            self.api_workflow_client.download_raw_samples(
+            self.api_workflow_client.download_raw_predictions(
                 relevant_filenames_artifact_id="bar"
             )
 
@@ -132,10 +132,10 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
 
         # should raise ValueError when only run_id is given
         with pytest.raises(ValueError):
-            self.api_workflow_client.download_raw_samples(run_id="foo")
+            self.api_workflow_client.download_raw_metadata(run_id="foo")
         # should raise ValueError when only relevant_filenames_artifact_id is given
         with pytest.raises(ValueError):
-            self.api_workflow_client.download_raw_samples(
+            self.api_workflow_client.download_raw_metadata(
                 relevant_filenames_artifact_id="bar"
             )
 

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -76,13 +76,22 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             return_value=mock_response,
         ) as func:
             self.api_workflow_client.download_raw_samples(
-                run_id="foo", relevant_filenames_artefact_id="bar"
+                run_id="foo", relevant_filenames_artifact_id="bar"
             )
             kwargs = func.call_args[1]
             assert kwargs.get("relevant_filenames_run_id") == "foo"
-            assert kwargs.get("relevant_filenames_artefact_id") == "bar"
+            assert kwargs.get("relevant_filenames_artifact_id") == "bar"
 
-    def test_download_raw_samples_predictions_relevant_filenames_artefact_id(self):
+        # should raise ValueError when only run_id is given
+        with pytest.raises(ValueError):
+            self.api_workflow_client.download_raw_samples(run_id="foo")
+        # should raise ValueError when only relevant_filenames_artifact_id is given
+        with pytest.raises(ValueError):
+            self.api_workflow_client.download_raw_samples(
+                relevant_filenames_artifact_id="bar"
+            )
+
+    def test_download_raw_samples_predictions_relevant_filenames_artifact_id(self):
         mock_response = mock.MagicMock()
         mock_response.has_more = False
         with mock.patch(
@@ -91,13 +100,22 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             return_value=mock_response,
         ) as func:
             self.api_workflow_client.download_raw_predictions(
-                task_name="task", run_id="foo", relevant_filenames_artefact_id="bar"
+                task_name="task", run_id="foo", relevant_filenames_artifact_id="bar"
             )
             kwargs = func.call_args[1]
             assert kwargs.get("relevant_filenames_run_id") == "foo"
-            assert kwargs.get("relevant_filenames_artefact_id") == "bar"
+            assert kwargs.get("relevant_filenames_artifact_id") == "bar"
 
-    def test_download_raw_samples_metadata_relevant_filenames_artefact_id(self):
+        # should raise ValueError when only run_id is given
+        with pytest.raises(ValueError):
+            self.api_workflow_client.download_raw_samples(run_id="foo")
+        # should raise ValueError when only relevant_filenames_artifact_id is given
+        with pytest.raises(ValueError):
+            self.api_workflow_client.download_raw_samples(
+                relevant_filenames_artifact_id="bar"
+            )
+
+    def test_download_raw_samples_metadata_relevant_filenames_artifact_id(self):
         mock_response = mock.MagicMock()
         mock_response.has_more = False
         with mock.patch(
@@ -106,11 +124,20 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
             return_value=mock_response,
         ) as func:
             self.api_workflow_client.download_raw_metadata(
-                run_id="foo", relevant_filenames_artefact_id="bar"
+                run_id="foo", relevant_filenames_artifact_id="bar"
             )
             kwargs = func.call_args[1]
             assert kwargs.get("relevant_filenames_run_id") == "foo"
-            assert kwargs.get("relevant_filenames_artefact_id") == "bar"
+            assert kwargs.get("relevant_filenames_artifact_id") == "bar"
+
+        # should raise ValueError when only run_id is given
+        with pytest.raises(ValueError):
+            self.api_workflow_client.download_raw_samples(run_id="foo")
+        # should raise ValueError when only relevant_filenames_artifact_id is given
+        with pytest.raises(ValueError):
+            self.api_workflow_client.download_raw_samples(
+                relevant_filenames_artifact_id="bar"
+            )
 
     def test_download_raw_samples_or_metadata_relevant_filenames(self):
         self.api_workflow_client._datasources_api.reset()

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -67,6 +67,51 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
         assert len(samples) == len(new_samples)
         assert set(samples) == set(new_samples)
 
+    def test_download_raw_samples_relevant_filenames_artefact_id(self):
+        mock_response = mock.MagicMock()
+        mock_response.has_more = False
+        with mock.patch(
+            "tests.api_workflow.mocked_api_workflow_client.MockedDatasourcesApi"
+            ".get_list_of_raw_samples_from_datasource_by_dataset_id",
+            return_value=mock_response,
+        ) as func:
+            self.api_workflow_client.download_raw_samples(
+                run_id="foo", relevant_filenames_artefact_id="bar"
+            )
+            kwargs = func.call_args[1]
+            assert kwargs.get("relevant_filenames_run_id") == "foo"
+            assert kwargs.get("relevant_filenames_artefact_id") == "bar"
+
+    def test_download_raw_samples_predictions_relevant_filenames_artefact_id(self):
+        mock_response = mock.MagicMock()
+        mock_response.has_more = False
+        with mock.patch(
+            "tests.api_workflow.mocked_api_workflow_client.MockedDatasourcesApi"
+            ".get_list_of_raw_samples_predictions_from_datasource_by_dataset_id",
+            return_value=mock_response,
+        ) as func:
+            self.api_workflow_client.download_raw_predictions(
+                task_name="task", run_id="foo", relevant_filenames_artefact_id="bar"
+            )
+            kwargs = func.call_args[1]
+            assert kwargs.get("relevant_filenames_run_id") == "foo"
+            assert kwargs.get("relevant_filenames_artefact_id") == "bar"
+
+    def test_download_raw_samples_metadata_relevant_filenames_artefact_id(self):
+        mock_response = mock.MagicMock()
+        mock_response.has_more = False
+        with mock.patch(
+            "tests.api_workflow.mocked_api_workflow_client.MockedDatasourcesApi"
+            ".get_list_of_raw_samples_metadata_from_datasource_by_dataset_id",
+            return_value=mock_response,
+        ) as func:
+            self.api_workflow_client.download_raw_metadata(
+                run_id="foo", relevant_filenames_artefact_id="bar"
+            )
+            kwargs = func.call_args[1]
+            assert kwargs.get("relevant_filenames_run_id") == "foo"
+            assert kwargs.get("relevant_filenames_artefact_id") == "bar"
+
     def test_download_raw_samples_or_metadata_relevant_filenames(self):
         self.api_workflow_client._datasources_api.reset()
         for method in [

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -108,11 +108,13 @@ class TestApiWorkflowDatasources(MockedApiWorkflowSetup):
 
         # should raise ValueError when only run_id is given
         with pytest.raises(ValueError):
-            self.api_workflow_client.download_raw_predictions(run_id="foo")
+            self.api_workflow_client.download_raw_predictions(
+                task_name="foobar", run_id="foo"
+            )
         # should raise ValueError when only relevant_filenames_artifact_id is given
         with pytest.raises(ValueError):
             self.api_workflow_client.download_raw_predictions(
-                relevant_filenames_artifact_id="bar"
+                task_name="foobar", relevant_filenames_artifact_id="bar"
             )
 
     def test_download_raw_samples_metadata_relevant_filenames_artifact_id(self):


### PR DESCRIPTION
Updated ApiWorkflowClient for handling relevant filenames with relevant filenames artefact ID. Note that `relevant_filenames_artefact_id` and `run_id` must both be given at the same time. This is consistent with the logic on the API server side.

Also added some test cases to check this behaviour.