### PR TITLE
Shaun lig 3228 fix pip build and release action

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+        check-latest: true
     - name: Build and release
       id: build_and_release
       run: |

--- a/.github/workflows/test_release_pypi.yml
+++ b/.github/workflows/test_release_pypi.yml
@@ -1,0 +1,36 @@
+name: Build and release lightly
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - shaun-lig-3228-fix-pip-build-and-release-action
+# TODO(Philipp, 03/23): Enable me after proper testing.
+#  release:
+#    types: [published]
+
+jobs:
+  build:
+    name: Test build and release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Checkout latest release tag
+      id: checkout_latest_release_tag
+      run: |
+        LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+        git checkout $LATEST_TAG
+        echo "tag_name=$LATEST_TAG" >> $GITHUB_OUTPUT;
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+        check-latest: true
+    - name: Build and release
+      id: build_and_release
+      run: |
+        pip3 install wheel
+        pip3 install twine


### PR DESCRIPTION

See discussion in issue:
https://linear.app/lightly/issue/LIG-3228/fix-pip-build-and-release-action

Test workflow run:
https://github.com/lightly-ai/lightly/actions/runs/4925523237/jobs/8799856074