### PR TITLE
Add SwaV ImageNet benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,10 @@ tuned for maximum accuracy. For detailed results and more info about the benchma
 
 ### Imagenet
 
-| Model       | Backbone | Batch Size | Epochs | Linear Top1 | Linear Top1 Online | KNN Top1 | Tensorboard | Checkpoint |
-|-------------|----------|------------|--------|-------------|--------------------|----------|-------------|------------|
-| SimCLR      | Res50    |        256 |    100 |        63.2 |               63.1 |     44.9 |      [link](https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |
-| SwAV        | Res50    |        256 |    100 |        67.2 |               62.1 |     49.5 |      [link](https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt)
+| Model       | Backbone | Batch Size | Epochs | Linear Top1 | Finetune Top1 | KNN Top1 | Tensorboard | Checkpoint |
+|-------------|----------|------------|--------|-------------|---------------|----------|-------------|------------|
+| SimCLR      | Res50    |        256 |    100 |        63.2 |           N/A |     44.9 |      [link](https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |
+| SwAV        | Res50    |        256 |    100 |        67.2 |          75.4 |     49.5 |      [link](https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt)
 
 
 ### ImageNette

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ tuned for maximum accuracy. For detailed results and more info about the benchma
 | Model       | Backbone | Batch Size | Epochs | Linear Top1 | Linear Top1 Online | KNN Top1 | Tensorboard | Checkpoint |
 |-------------|----------|------------|--------|-------------|--------------------|----------|-------------|------------|
 | SimCLR      | Res50    |        256 |    100 |        63.2 |               63.1 |     44.9 |      [link](https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |
+| SwAV        | Res50    |        256 |    100 |        67.2 |               62.1 |     49.5 |      [link](https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg) |       [link](TODO)
 
 
 ### ImageNette

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ tuned for maximum accuracy. For detailed results and more info about the benchma
 | Model       | Backbone | Batch Size | Epochs | Linear Top1 | Linear Top1 Online | KNN Top1 | Tensorboard | Checkpoint |
 |-------------|----------|------------|--------|-------------|--------------------|----------|-------------|------------|
 | SimCLR      | Res50    |        256 |    100 |        63.2 |               63.1 |     44.9 |      [link](https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |
-| SwAV        | Res50    |        256 |    100 |        67.2 |               62.1 |     49.5 |      [link](https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg) |       [link](TODO)
+| SwAV        | Res50    |        256 |    100 |        67.2 |               62.1 |     49.5 |      [link](https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt)
 
 
 ### ImageNette

--- a/benchmarks/imagenet/resnet50/README.md
+++ b/benchmarks/imagenet/resnet50/README.md
@@ -43,7 +43,7 @@ Or with SLURM, create the following script (`run_imagenet.sh`):
 
 eval "$(conda shell.bash hook)"
 
-conda lightly-env
+conda activate lightly-env
 srun python main.py --epochs 100 --train-dir /datasets/imagenet/train --val-dir /datasets/imagenet/val --num-workers 12 --devices 2 --batch-size 128
 conda deactivate
 ```

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -7,6 +7,7 @@ import finetune_eval
 import knn_eval
 import linear_eval
 import simclr
+import swav
 import torch
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks import DeviceStatsMonitor, LearningRateMonitor
@@ -38,6 +39,7 @@ parser.add_argument("--skip-finetune-eval", action="store_true")
 
 METHODS = {
     "simclr": {"model": simclr.SimCLR, "transform": simclr.transform},
+    "swav": {"model": swav.SwAV, "transform": swav.transform},
 }
 
 

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -185,7 +185,6 @@ def pretrain(
     )
 
     # Train model.
-    accelerator = "cpu" # TODO: Remove me
     metric_callback = MetricCallback()
     trainer = Trainer(
         max_epochs=epochs,

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -185,6 +185,7 @@ def pretrain(
     )
 
     # Train model.
+    accelerator = "cpu" # TODO: Remove me
     metric_callback = MetricCallback()
     trainer = Trainer(
         max_epochs=epochs,
@@ -197,6 +198,7 @@ def pretrain(
         ],
         logger=TensorBoardLogger(save_dir=str(log_dir), name="pretrain"),
         precision=precision,
+        strategy="ddp_find_unused_parameters_true",
         sync_batchnorm=True,
     )
 

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -1,0 +1,204 @@
+import math
+from typing import List, Tuple
+
+import torch
+from torch.nn import functional as F
+from torch.nn import ModuleList
+from pytorch_lightning import LightningModule
+from torch import Tensor
+from torch.nn import Identity
+from torchvision.models import resnet50
+from lightly.loss.memory_bank import MemoryBankModule
+
+from lightly.loss.swav_loss import SwaVLoss
+from lightly.models.modules import SwaVProjectionHead, SwaVPrototypes
+from lightly.models.utils import get_weight_decay_parameters
+from lightly.transforms import SwaVTransform
+from lightly.utils.benchmarking import OnlineLinearClassifier
+from lightly.utils.lars import LARS
+from lightly.utils.scheduler import CosineWarmupScheduler
+
+
+CROP_COUNTS: Tuple[int, int] = (2, 6)
+
+
+class SwAV(LightningModule):
+    def __init__(self, batch_size: int, num_classes: int) -> None:
+        super().__init__()
+        self.save_hyperparameters()
+        self.batch_size = batch_size
+
+        resnet = resnet50()
+        resnet.fc = Identity()  # Ignore classification head
+        self.backbone = resnet
+        self.projection_head = SwaVProjectionHead()
+        self.prototypes = SwaVPrototypes(n_steps_frozen_prototypes=1)  # TODO
+        self.criterion = SwaVLoss(sinkhorn_gather_distributed=True)
+        self.online_classifier = OnlineLinearClassifier(num_classes=num_classes)
+
+        if self.batch_size <= 256:
+            self.start_queue_at_epoch = 15
+            self.queues = ModuleList(
+                [
+                    MemoryBankModule(size=15 * self.batch_size)
+                    for _ in range(CROP_COUNTS[0])
+                ]
+            )
+        else:
+            self.start_queue_at_epoch = None
+            self.queues = None
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.backbone(x)
+
+    def training_step(
+        self, batch: Tuple[List[Tensor], Tensor, List[str]], batch_idx: int
+    ) -> Tensor:
+        # Normalize the prototypes so they are on the unit sphere.
+        self.prototypes.normalize()
+
+        # The multi-crop dataloader returns a list of image crops where the
+        # first few items are high resolution crops and the rest are low
+        # resolution crops.
+        multi_crops, targets, _ = batch
+        multi_crop_features = [
+            self.forward(crops).flatten(start_dim=1) for crops in multi_crops
+        ]
+
+        def _project(x: Tensor) -> Tensor:
+            x = self.projection_head(x)
+            return F.normalize(x, dim=1, p=2)
+
+        multi_crop_projections = [
+            _project(features) for features in multi_crop_features
+        ]
+        multi_crop_logits = [
+            self.prototypes(projections, step=self.global_step)
+            for projections in multi_crop_projections
+        ]
+
+        # TODO: Make nice and add explanation
+        queue_crop_logits = None
+        if self.queues is not None:
+            queue_crop_projections = _get_queue_projections(
+                high_resolution_projections=multi_crop_projections[: CROP_COUNTS[0]],
+                queues=self.queues,
+                return_projections=self.start_queue_at_epoch > 0
+                and self.current_epoch < self.start_queue_at_epoch,
+            )
+            if queue_crop_projections is not None:
+                with torch.no_grad():
+                    queue_crop_logits = [
+                        self.prototypes(projections, step=self.global_step)
+                        for projections in queue_crop_projections
+                    ]
+
+        # Split the list of crop logits into high and low resolution.
+        high_resolution_logits = multi_crop_logits[: CROP_COUNTS[0]]
+        low_resolution_logits = multi_crop_logits[CROP_COUNTS[0] :]
+
+        # Calculate the SwAV loss.
+        loss = self.criterion(
+            high_resolution_outputs=high_resolution_logits,
+            low_resolution_outputs=low_resolution_logits,
+            queue_outputs=queue_crop_logits,
+        )
+        self.log(
+            "train_loss", loss, prog_bar=True, sync_dist=True, batch_size=len(targets)
+        )
+
+        # Calculate the classification loss.
+        features = torch.cat(multi_crop_features[: CROP_COUNTS[0]])
+        cls_loss, cls_log = self.online_classifier.training_step(
+            (features.detach(), targets.repeat(CROP_COUNTS[0])), batch_idx
+        )
+        self.log_dict(cls_log, sync_dist=True, batch_size=len(targets))
+        return loss + cls_loss
+
+    def validation_step(
+        self, batch: Tuple[Tensor, Tensor, List[str]], batch_idx: int
+    ) -> Tensor:
+        images, targets = batch[0], batch[1]
+        features = self.forward(images).flatten(start_dim=1)
+        cls_loss, cls_log = self.online_classifier.validation_step(
+            (features.detach(), targets), batch_idx
+        )
+        self.log_dict(cls_log, prog_bar=True, sync_dist=True, batch_size=len(targets))
+        return cls_loss
+
+    def configure_optimizers(self):
+        # Don't use weight decay for batch norm, bias parameters, and classification
+        # head to improve performance.
+        params, params_no_weight_decay = get_weight_decay_parameters(
+            [self.backbone, self.projection_head, self.prototypes]
+        )
+        # After warmup, we use the cosine learning rate decay [40 , 44] witha final value of 0.0048
+        optimizer = LARS(
+            [
+                {"name": "swav", "params": params},
+                {
+                    "name": "swav_no_weight_decay",
+                    "params": params_no_weight_decay,
+                    "weight_decay": 0.0,
+                },
+                {
+                    "name": "online_classifier",
+                    "params": self.online_classifier.parameters(),
+                    "weight_decay": 0.0,
+                },
+            ],
+            # Smaller learning rate for smaller batches: lr=0.6 for batch_size=256
+            # scaled by linearly by batch size to lr=4.8 for batch_size=2048.
+            # See Appendix A.1. and A.6. in SwAV paper https://arxiv.org/pdf/2006.09882.pdf
+            lr=0.6 * (self.batch_size * self.trainer.world_size) / 256,
+            momentum=0.9,
+            weight_decay=1e-6,
+        )
+        scheduler = {
+            "scheduler": CosineWarmupScheduler(
+                optimizer=optimizer,
+                warmup_epochs=(
+                    self.trainer.estimated_stepping_batches
+                    / self.trainer.max_epochs
+                    * 10
+                ),
+                max_epochs=self.trainer.estimated_stepping_batches,
+                end_value=0.0006 * (self.batch_size * self.trainer.world_size) / 256,
+            ),
+            "interval": "step",
+        }
+        return [optimizer], [scheduler]
+
+
+transform = SwaVTransform(crop_counts=CROP_COUNTS)
+
+
+@torch.no_grad()
+def _get_queue_projections(
+    high_resolution_projections: List[Tensor],
+    queues: ModuleList[MemoryBankModule],
+    return_projections: bool,
+):
+    """TODO"""
+
+    if len(high_resolution_projections) != len(queues):
+        raise ValueError(
+            f"The number of queues ({len(queues)}) should be equal to the number of high "
+            f"resolution inputs ({len(high_resolution_projections)})."
+        )
+
+    # Get the queue features
+    queue_features = []
+    for i in range(len(queues)):
+        _, features = queues[i](high_resolution_projections[i], update=True)
+        # Queue features are in (num_ftrs X queue_length) shape, while the high res
+        # features are in (batch_size X num_ftrs). Swap the axes for interoperability.
+        features = torch.permute(features, (1, 0))
+        queue_features.append(features)
+
+    # If loss calculation with queue prototypes starts at a later epoch,
+    # just queue the features and return None instead of queue prototypes.
+    if not return_projections:
+        return None
+
+    return queue_features

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -108,9 +108,8 @@ class SwAV(LightningModule):
         )
 
         # Calculate the classification loss.
-        features = torch.cat(multi_crop_features[: CROP_COUNTS[0]])
         cls_loss, cls_log = self.online_classifier.training_step(
-            (features.detach(), targets.repeat(CROP_COUNTS[0])), batch_idx
+            (multi_crop_features[0].detach(), targets), batch_idx
         )
         self.log_dict(cls_log, sync_dist=True, batch_size=len(targets))
         return loss + cls_loss

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -30,11 +30,7 @@ class SwAV(LightningModule):
         resnet.fc = Identity()  # Ignore classification head
         self.backbone = resnet
         self.projection_head = SwaVProjectionHead()
-        self.prototypes = SwaVPrototypes(
-            n_steps_frozen_prototypes=(
-                2  # TODO: self.trainer.estimated_stepping_batches / self.trainer.max_epochs
-            )
-        )
+        self.prototypes = SwaVPrototypes()
         self.criterion = SwaVLoss(sinkhorn_gather_distributed=True)
         self.online_classifier = OnlineLinearClassifier(num_classes=num_classes)
 
@@ -166,6 +162,10 @@ class SwAV(LightningModule):
             ),
             "interval": "step",
         }
+        # Set the number of steps to freeze the prototypes for.
+        self.prototypes.n_steps_frozen_prototypes = (
+            self.trainer.estimated_stepping_batches / self.trainer.max_epochs
+        )
         return [optimizer], [scheduler]
 
 

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -32,7 +32,7 @@ class SwAV(LightningModule):
         self.projection_head = SwaVProjectionHead()
         self.prototypes = SwaVPrototypes(
             n_steps_frozen_prototypes=(
-                2# TODO: self.trainer.estimated_stepping_batches / self.trainer.max_epochs
+                2  # TODO: self.trainer.estimated_stepping_batches / self.trainer.max_epochs
             )
         )
         self.criterion = SwaVLoss(sinkhorn_gather_distributed=True)

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -86,7 +86,7 @@ class SwAV(LightningModule):
                 high_resolution_projections=multi_crop_projections[: CROP_COUNTS[0]],
                 queues=self.queues,
             )
-            if self.current_epoch < self.start_queue_at_epoch:
+            if self.current_epoch >= self.start_queue_at_epoch:
                 with torch.no_grad():
                     queue_crop_logits = [
                         self.prototypes(projections, step=self.global_step)

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -59,10 +59,10 @@ class SwAV(LightningModule):
         # Normalize the prototypes so they are on the unit sphere.
         self.prototypes.normalize()
 
-        # The multi-crop dataloader returns a list of image crops where the
+        # The dataloader returns a list of image crops where the
         # first few items are high resolution crops and the rest are low
         # resolution crops.
-        multi_crops, targets, _ = batch
+        multi_crops, targets = batch[0], batch[1]
 
         # Forward pass through backbone and projection head.
         multi_crop_features = [

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -32,7 +32,7 @@ class SwAV(LightningModule):
         self.projection_head = SwaVProjectionHead()
         self.prototypes = SwaVPrototypes(
             n_steps_frozen_prototypes=(
-                self.trainer.estimated_stepping_batches / self.trainer.max_epochs
+                2# TODO: self.trainer.estimated_stepping_batches / self.trainer.max_epochs
             )
         )
         self.criterion = SwaVLoss(sinkhorn_gather_distributed=True)
@@ -176,7 +176,7 @@ transform = SwaVTransform(crop_counts=CROP_COUNTS)
 @torch.no_grad()
 def _enqueue_and_get_queue_projections(
     high_resolution_projections: List[Tensor],
-    queues: ModuleList[MemoryBankModule],
+    queues: ModuleList,
 ):
     """Adds the high resolution projections to the queues and returns the queues."""
 

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -25,7 +25,7 @@ the code at `benchmarks/imagenet/resnet50 <https://github.com/lightly-ai/lightly
   :widths: 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20
 
   "SimCLR", "Res50", "256", "100", "63.2", "85.3", "63.1", "85.2", "44.9", "74.2", "`link <https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-
+  "SwAV", "Res50", "256", "100", "67.2", "88.1", "62.1", "85.4", "49.5", "78.6", "`link <https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg>`_", "`link <TODO>`_"
 
 
 ImageNette

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -21,11 +21,11 @@ takes about two days on two GeForce RTX 4090 GPUs. You can reproduce the results
 the code at `benchmarks/imagenet/resnet50 <https://github.com/lightly-ai/lightly/tree/master/benchmarks/imagenet/resnet50>`_.
 
 .. csv-table:: Imagenet benchmark results.
-  :header: "Model", "Backbone", "Batch Size", "Epochs", "Linear Top1", "Linear Top5", "Linear Top1 Online", "Linear Top5 Online", "KNN Top1", "KNN Top5", "Tensorboard", "Checkpoint"
+  :header: "Model", "Backbone", "Batch Size", "Epochs", "Linear Top1", "Linear Top5", "Finetune Top1", "Finetune Top5", "KNN Top1", "KNN Top5", "Tensorboard", "Checkpoint"
   :widths: 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20
 
-  "SimCLR", "Res50", "256", "100", "63.2", "85.3", "63.1", "85.2", "44.9", "74.2", "`link <https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "SwAV", "Res50", "256", "100", "67.2", "88.1", "62.1", "85.4", "49.5", "78.6", "`link <https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "SimCLR", "Res50", "256", "100", "63.2", "85.3", "N/A", "N/A", "44.9", "74.2", "`link <https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "SwAV", "Res50", "256", "100", "67.2", "88.1", "75.4", "92.7", "49.5", "78.6", "`link <https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
 
 
 ImageNette

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -25,7 +25,7 @@ the code at `benchmarks/imagenet/resnet50 <https://github.com/lightly-ai/lightly
   :widths: 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20
 
   "SimCLR", "Res50", "256", "100", "63.2", "85.3", "63.1", "85.2", "44.9", "74.2", "`link <https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "SwAV", "Res50", "256", "100", "67.2", "88.1", "62.1", "85.4", "49.5", "78.6", "`link <https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg>`_", "`link <TODO>`_"
+  "SwAV", "Res50", "256", "100", "67.2", "88.1", "62.1", "85.4", "49.5", "78.6", "`link <https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
 
 
 ImageNette

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":
         "lightly.models.modules",
         "lightly.transforms",
         "lightly.utils",
+        "lightly.utils.benchmarking",
         "lightly.utils.cropping",
         "lightly.active_learning",
         "lightly.active_learning.agents",


### PR DESCRIPTION
# Add SwaV ImageNet benchmark

Closes https://github.com/lightly-ai/lightly/issues/1230. 
* Add Code for SwAV ImageNet benchmark.
* Update tables with results.
* Fix imports by adding `lightly.utils.benchmarking` to `setup.py`.
* Fix instructions to run benchmarks.

## Results
Tensorboard link: https://tensorboard.dev/experiment/Ipx4Oxl5Qkqm5Sl5kWyKKg/#scalars
```
Imagenet:
    knn val_top1: 0.49526000022888184
    knn val_top5: 0.7857199907302856
    max linear val_top1: 0.671999990940094
    max linear val_top5: 0.8811799883842468
    max finetune val_top1: 0.7540599703788757
    max finetune val_top5: 0.9268800020217896
```
Training was 100 epochs with batch size 256 (=2x128) to match the experiment settings of the SimCLR benchmarks. Unfortunately, the SwAV paper only has numbers for 200 epochs with batch size 256:
![image](https://github.com/lightly-ai/lightly/assets/65946090/970e3f18-8803-416b-8d76-d2fe316c87c3)
