### PR TITLE
Guarin lig 3096 update main concepts docs

### DIFF
--- a/docs/source/getting_started/main_concepts.rst
+++ b/docs/source/getting_started/main_concepts.rst
@@ -1,12 +1,12 @@
 .. _lightly-main-concepts:
 
-Main concepts
+Main Concepts
 =============
 
-Self-supervised Learning
+Self-Supervised Learning
 ------------------------
 
-The figure below shows an overview of the different concepts used by the ligthly PIP package
+The figure below shows an overview of the different concepts used by the Lightly package
 and a schema of how they interact. The expressions in **bold** are explained further
 below.
 
@@ -14,64 +14,89 @@ below.
     :align: center
     :alt: Lightly Overview
 
-    Overview of the different concepts used by the lightly PIP package and
-    how they interact.
+    Overview of the different concepts used by the Lightly package and how they interact.
 
 * **Dataset**
-   In lightly, datasets are accessed through :py:class:`lightly.data.dataset.LightlyDataset`.
-   You can create a `LightlyDataset` from a folder of images, videos, or simply from
-   a torchvision dataset. You can learn more about this here: 
-   
-   * :ref:`input-structure-label`
-   
-* **Collate Function**
-   The collate function is the place where lightly applies augmentations which are crucial
-   for self-supervised learning. You can use our pre-defined augmentations or write your own
-   ones. For more information, check out :ref:`lightly-advanced` and :py:class:`lightly.data.collate.BaseCollateFunction`.
-   You can add your own augmentations very easily as we show in this tutorial:
+   In Lightly, datasets are accessed through :py:class:`~lightly.data.dataset.LightlyDataset`.
+   You can create a :py:class:`~lightly.data.dataset.LightlyDataset` from a folder of
+   images, videos, or simply from a `torchvision dataset <https://pytorch.org/vision/stable/datasets.html>`_.
+   You can learn more about this in our tutorial: 
 
-   * :ref:`lightly-custom-augmentation-5`
+   * :ref:`input-structure-label`
+
+* **Transform**
+   In self-supervised learning, the input images are often randomly transformed into
+   *views* of the orignal images. The views and their underlying transforms are
+   important as they define the properties of the model and the image embeddings.
+   You can either use our pre-defined :py:mod:`~lightly.transforms` or write your own.
+   For more information, check out the following pages:
+
+   * :ref:`lightly-advanced`
+   * :ref:`lightly-custom-augmentation-5`.
+
+* **Collate Function**
+   The collate function aggregates the views of multiple images into a single batch.
+   Lightly provides a default :py:class:`~lightly.data.multi_view_collate.MultiViewCollate`
+   function that can be used with any transform.
 
 * **Dataloader**
-   For the dataloader you can simply use the PyTorch dataloader. Be sure to pass it a `LightlyDataset` though!
+   For the dataloader you can simply use a `PyTorch dataloader <https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader>`_.
+   Be sure to pass it a :py:class:`~lightly.data.dataset.LightlyDataset` though!
+
 * **Backbone Neural Network**
    One of the cool things about self-supervised learning is that you can pre-train
    your neural networks without the need for annotated data. You can plugin whatever
-   backbone you want! If you don't know where to start, our tutorials show how you
-   can get a backbone neural network from a :py:class:`lightly.models.resnet.ResNet`.
+   backbone you want! If you don't know where to start, have a look at our :ref:`simclr`
+   example on how to use a `ResNet <https://pytorch.org/vision/main/models/resnet.html>`_ 
+   backbone or :ref:`msn` for a `Vision Transformer <https://pytorch.org/vision/main/models/vision_transformer.html>`_
+   backbone.
+
+* **Heads**
+   The heads are the last layers of the neural network and added on top of the backbone.
+   They project the outputs of the backbone, commonly called *embeddings*,
+   *representations*, or *features*, into a new space in which the loss is calculated.
+   This has been found to be hugely beneficial instead of directly calculating the loss
+   on the embeddings. Lightly provides common :py:mod:`~lightly.models.modules.heads`
+   that can be added to any backbone.
+
 * **Model**
    The model combines your backbone neural network with one or multiple heads and, if
    required, a momentum encoder to provide an easy-to-use interface to the most
-   popular self-supervised learning frameworks. Learn more in our tutorials:
+   popular self-supervised learning models. Our :ref:`models <models>` page contains
+   a large number of example implementations. You can also head over to one of our
+   tutorials if you want to learn more about models and how to use them:
 
    * :ref:`sphx_glr_tutorials_package_tutorial_moco_memory_bank.py`
    * :ref:`sphx_glr_tutorials_package_tutorial_simclr_clothing.py`
    * :ref:`sphx_glr_tutorials_package_tutorial_simsiam_esa.py`
 
 * **Loss**
-   The loss function plays a crucial role in self-supervised learning. Currently,
-   lightly supports contrastive and similarity based loss functions.
+   The loss function plays a crucial role in self-supervised learning. Lightly provides
+   common loss functions in the :py:mod:`~lightly.loss` module.
+
 * **Optimizer**
-   With lightly, you can use any PyTorch optimizer to train your model.
+   With Lightly, you can use any `PyTorch optimizer <https://pytorch.org/docs/stable/optim.html>`_
+   to train your model.
+
 * **Training**
-   The model can either be trained using a plain PyTorch training loop or
-   with a dedicated framework such as PyTorch Lightning. Lightly lets you
-   choose what is best for you. Check out our `tutorials section <https://docs.lightly.ai/tutorials/package.html>`_ 
-   for examples.
+   The model can either be trained using a plain `PyTorch training loop <https://pytorch.org/tutorials/beginner/introyt/trainingyt.html>`_
+   or with a dedicated framework such as `PyTorch Lightning <https://www.pytorchlightning.ai/index.html>`_.
+   Lightly lets you choose what is best for you. Check out our :ref:`models <models>` and
+   `tutorials <https://docs.lightly.ai/self-supervised-learning/tutorials/package.html>`_
+   sections on how to train models with PyTorch or PyTorch Lightning.
+
 * **Image Embeddings**
    During the training process, the model learns to create compact embeddings from images.
-   The embeddings, also often called representations, can then be used for tasks such as
-   identifying similar images or creating a diverse subset from your data:
+   The embeddings, also often called representations or features, can then be used for
+   tasks such as identifying similar images or creating a diverse subset from your data:
 
    * :ref:`lightly-tutorial-sunflowers`
-   * :ref:`lightly-simsiam-tutorial-4`  
+   * :ref:`lightly-simsiam-tutorial-4`
 
-* **Pre-trained Backbone**
-   The backbone can be reused after self-supervised training. We can transfer it
-   to any other task that requires a similar network architecture, including 
-   image classification, object detection and segmentation tasks. You can learn more in
+* **Pre-Trained Backbone**
+   The backbone can be reused after self-supervised training. It can be transferred to
+   any other task that requires a similar network architecture, including
+   image classification, object detection, and segmentation tasks. You can learn more in
    our object detection tutorial:
 
    * :ref:`lightly-detectron-tutorial-6`
-
-

--- a/docs/source/lightly.api.rst
+++ b/docs/source/lightly.api.rst
@@ -3,7 +3,6 @@ lightly.api
 
 .. automodule:: lightly.api
 
-.api_workflow_client
 .. automodule:: lightly.api.api_workflow_client
    :members:
    :inherited-members:

--- a/docs/source/lightly.api.rst
+++ b/docs/source/lightly.api.rst
@@ -7,14 +7,8 @@ lightly.api
    :members:
    :inherited-members:
 
-.. automodule:: lightly.api.api_workflow_datasets
+.. autoclass:: lightly.api.api_workflow_compute_worker.ComputeWorkerRunInfo
    :members:
 
-.. automodule:: lightly.api.api_workflow_download_dataset
-   :members:
-
-.. automodule:: lightly.api.api_workflow_selection
-   :members:
-
-.. automodule:: lightly.api.api_workflow_compute_worker
+.. autoclass:: lightly.api.api_workflow_compute_worker.InvalidConfigurationError
    :members:

--- a/docs/source/lightly.api.rst
+++ b/docs/source/lightly.api.rst
@@ -4,7 +4,6 @@ lightly.api
 .. automodule:: lightly.api
 
 .api_workflow_client
----------------------
 .. automodule:: lightly.api.api_workflow_client
    :members:
    :inherited-members:

--- a/docs/source/lightly.data.rst
+++ b/docs/source/lightly.data.rst
@@ -3,11 +3,6 @@ lightly.data
 
 .. automodule:: lightly.data
 
-.collate
----------------
-.. automodule:: lightly.data.collate
-   :members:
-
 .dataset
 ---------------
 .. automodule:: lightly.data.dataset
@@ -18,3 +13,8 @@ lightly.data
 .. autoclass:: lightly.data.multi_view_collate.MultiViewCollate
    :members:
    :special-members: __call__
+
+.collate:
+---------
+.. automodule:: lightly.data.collate
+   :members:

--- a/docs/source/lightly.data.rst
+++ b/docs/source/lightly.data.rst
@@ -15,5 +15,6 @@ lightly.data
 
 .multi_view_collate
 -------------------
-.. automodule:: lightly.data.multi_view_collate
+.. autoclass:: lightly.data.multi_view_collate.MultiViewCollate
    :members:
+   :special-members: __call__

--- a/docs/source/lightly.data.rst
+++ b/docs/source/lightly.data.rst
@@ -12,3 +12,8 @@ lightly.data
 ---------------
 .. automodule:: lightly.data.dataset
    :members:
+
+.multi_view_collate
+-------------------
+.. automodule:: lightly.data.multi_view_collate
+   :members:

--- a/docs/source/lightly.loss.rst
+++ b/docs/source/lightly.loss.rst
@@ -1,85 +1,57 @@
+.. _lightly-loss:
+
 lightly.loss
-===================
+============
 
 .. automodule:: lightly.loss
 
-.barlow_twins_loss
-------------------
 .. autoclass:: lightly.loss.barlow_twins_loss.BarlowTwinsLoss
    :members:
 
-.dcl_loss
-------------------
 .. autoclass:: lightly.loss.dcl_loss.DCLLoss
    :members:
 
 .. autoclass:: lightly.loss.dcl_loss.DCLWLoss
    :members:
 
-.dino_loss
-----------
 .. autoclass:: lightly.loss.dino_loss.DINOLoss
    :members:
 
-.hypersphere_loss
------------------
 .. autoclass:: lightly.loss.hypersphere_loss.HypersphereLoss
    :members:
 
-.memory_bank
--------------
 .. autoclass:: lightly.loss.memory_bank.MemoryBankModule
    :members:
 
-.msn_loss
----------
 .. autoclass:: lightly.loss.msn_loss.MSNLoss
    :members:
 
-.negative_cosine_similarity
----------------------------
 .. autoclass:: lightly.loss.negative_cosine_similarity.NegativeCosineSimilarity
    :members:
 
-.ntx_ent_loss
----------------
 .. autoclass:: lightly.loss.ntx_ent_loss.NTXentLoss
    :members:
 
-.regularizer.co2
------------------
-.. autoclass:: lightly.loss.regularizer.co2.CO2Regularizer
-   :members:
-
-.pmsn_loss
----------
 .. autoclass:: lightly.loss.pmsn_loss.PMSNLoss
    :members:
 
 .. autoclass:: lightly.loss.pmsn_loss.PMSNCustomLoss
    :members:
 
-.sym_neg_cos_sim_loss
-----------------------
-.. autoclass:: lightly.loss.sym_neg_cos_sim_loss.SymNegCosineSimilarityLoss
+.. autoclass:: lightly.loss.regularizer.co2.CO2Regularizer
    :members:
 
-.swav_loss
-----------
 .. autoclass:: lightly.loss.swav_loss.SwaVLoss
    :members:
 
-.tico_loss
-----------
+.. autoclass:: lightly.loss.sym_neg_cos_sim_loss.SymNegCosineSimilarityLoss
+   :members:
+
 .. autoclass:: lightly.loss.tico_loss.TiCoLoss
    :members:
 
-.vicreg_loss
--------------
 .. autoclass:: lightly.loss.vicreg_loss.VICRegLoss
    :members:
 
-.vicregl_loss
---------------
 .. autoclass:: lightly.loss.vicregl_loss.VICRegLLoss
    :members:

--- a/docs/source/lightly.models.rst
+++ b/docs/source/lightly.models.rst
@@ -24,4 +24,3 @@ lightly.models
 --------
 .. automodule:: lightly.models.modules.heads
    :members:
-

--- a/docs/source/lightly.transforms.rst
+++ b/docs/source/lightly.transforms.rst
@@ -3,17 +3,65 @@ lightly.transforms
 
 .. automodule:: lightly.transforms
 
-.gaussian_blur
----------------
+.. automodule:: lightly.transforms.dino_transform
+   :members:
+
+.. automodule:: lightly.transforms.fast_siam_transform
+   :members:
+
 .. automodule:: lightly.transforms.gaussian_blur
    :members:
 
-.rotation
----------------
+.. automodule:: lightly.transforms.image_grid_transform
+   :members:
+
+.. automodule:: lightly.transforms.jigsaw
+   :members:
+
+.. automodule:: lightly.transforms.mae_transform
+   :members:
+
+.. automodule:: lightly.transforms.moco_transform
+   :members:
+
+.. automodule:: lightly.transforms.msn_transform
+   :members:
+
+.. automodule:: lightly.transforms.multi_crop_transform
+   :members:
+
+.. automodule:: lightly.transforms.multi_view_transform
+   :members:
+
+.. automodule:: lightly.transforms.pirl_transform
+   :members:
+
+.. automodule:: lightly.transforms.random_crop_and_flip_with_grid
+   :members:
+
 .. automodule:: lightly.transforms.rotation
    :members:
 
-.solarize
----------------
+.. automodule:: lightly.transforms.simclr_transform
+   :members:
+
+.. automodule:: lightly.transforms.simsiam_transform
+   :members:
+
+.. automodule:: lightly.transforms.smog_transform
+   :members:
+
 .. automodule:: lightly.transforms.solarize
+   :members:
+
+.. automodule:: lightly.transforms.swav_transform
+   :members:
+
+.. automodule:: lightly.transforms.utils
+   :members:
+
+.. automodule:: lightly.transforms.vicreg_transform
+   :members:
+
+.. automodule:: lightly.transforms.vicregl_transform
    :members:

--- a/docs/source/lightly.transforms.rst
+++ b/docs/source/lightly.transforms.rst
@@ -5,63 +5,84 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.dino_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.fast_siam_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.gaussian_blur
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.image_grid_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.jigsaw
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.mae_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.moco_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.msn_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.multi_crop_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.multi_view_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.pirl_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.random_crop_and_flip_with_grid
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.rotation
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.simclr_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.simsiam_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.smog_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.solarize
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.swav_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.utils
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.vicreg_transform
    :members:
+   :special-members: __call__
 
 .. automodule:: lightly.transforms.vicregl_transform
    :members:
+   :special-members: __call__

--- a/lightly/api/__init__.py
+++ b/lightly/api/__init__.py
@@ -1,4 +1,4 @@
-""" The lightly.api module provides access to the Lightly web-app. """
+""" The lightly.api module provides access to the Lightly API."""
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -1,5 +1,3 @@
-""" Lightly Dataset """
-
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 

--- a/lightly/data/multi_view_collate.py
+++ b/lightly/data/multi_view_collate.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import List, Tuple
 from warnings import warn
 
 import torch
@@ -6,36 +6,52 @@ from torch import Tensor
 
 
 class MultiViewCollate:
+    """Collate function that combines views from multiple images into a batch.
+
+    Example:
+        >>> transform = SimCLRTransform()
+        >>> dataset = LightlyDataset(input_dir, transform=transform)
+        >>> dataloader = DataLoader(dataset, batch_size=4, collate_fn=MultiViewCollate())
+        >>> for views, targets, filenames in dataloader:
+        >>>     view0, view1 = views # each view is a tensor of shape (batch_size, channels, height, weidth)
+        >>>
+    """
+
     def __call__(
         self, batch: List[Tuple[List[Tensor], int, str]]
     ) -> Tuple[List[Tensor], Tensor, List[str]]:
-        """Turns a batch of tuples into single tuple.
+        """Turns a batch of (views, label, filename) tuples into single
+        (views, labels, filenames) tuple.
 
         Args:
             batch:
-                The input batch. It is a list of (views, label, filename) tuples for each file in the dataset.
-                In particular, views is the output of the augmentation, so it is a list of tensors with n views.
-                For example:
+                The input batch as a list of (views, label, filename) tuples, one for
+                each image in the batch. In particular, views is a list of N view
+                tensors. Every view tensor is a transformed version of the original
+                image. Label and filename are the class label and filename of the
+                corresponding image. For example:
+
                 [
-                    ([image_0_view_0, image_0_view_1, ...], label_0, filename_0),
-                    ([image_1_view_0, image_1_view_1, ...], label_1, filename_1),
+                    ([img_0_view_0, ..., img_0_view_N], label_0, filename_0),   # image 0
+                    ([img_1_view_0, ..., img_1_view_N], label_1, filename_1),   # image 1
                     ...
+                    ([img_B_view_0, ..., img_B_view_N], label_B, filename_B]),  # image B
                 ]
 
         Returns:
-            A (views, labels, filenames) tuple. Views is a list of tensors with each tensor containing one
-            view for every image in the batch. For example:
+            A (views, labels, filenames) tuple. Views is a list of tensors with each
+            tensor containing one view for every image in the batch. For example:
+
             (
                 [
-                    Tensor([image_0_view_0, image_1_view_0, ...]),    # view 0
-                    Tensor([image_0_view_1, image_1_view_1, ...]),    # view 1
+                    Tensor([img_0_view_0, ..., img_B_view_0]),    # view 0
+                    Tensor([img_0_view_1, ..., img_B_view_1]),    # view 1
                     ...
+                    Tensor([img_0_view_N, ..., img_B_view_N]),    # view N
                 ],
-                [label_0, label_1, ...],
-                [filename_0, filename_1, ...]
+                [label_0, ..., label_B],
+                [filename_0, ..., filename_B],
             )
-
-
         """
         if len(batch) == 0:
             warn("MultiViewCollate received empty batch.")

--- a/lightly/data/multi_view_collate.py
+++ b/lightly/data/multi_view_collate.py
@@ -29,29 +29,31 @@ class MultiViewCollate:
                 each image in the batch. In particular, views is a list of N view
                 tensors. Every view tensor is a transformed version of the original
                 image. Label and filename are the class label and filename of the
-                corresponding image. For example:
+                corresponding image.
 
-                [
-                    ([img_0_view_0, ..., img_0_view_N], label_0, filename_0),   # image 0
-                    ([img_1_view_0, ..., img_1_view_N], label_1, filename_1),   # image 1
-                    ...
-                    ([img_B_view_0, ..., img_B_view_N], label_B, filename_B]),  # image B
-                ]
+                Example:
+                    >>> batch = [
+                    >>>     ([img_0_view_0, ..., img_0_view_N], label_0, filename_0),   # image 0
+                    >>>     ([img_1_view_0, ..., img_1_view_N], label_1, filename_1),   # image 1
+                    >>>     ...
+                    >>>     ([img_B_view_0, ..., img_B_view_N], label_B, filename_B]),  # image B
+                    >>> ]
 
         Returns:
             A (views, labels, filenames) tuple. Views is a list of tensors with each
-            tensor containing one view for every image in the batch. For example:
+            tensor containing one view for every image in the batch.
 
-            (
-                [
-                    Tensor([img_0_view_0, ..., img_B_view_0]),    # view 0
-                    Tensor([img_0_view_1, ..., img_B_view_1]),    # view 1
-                    ...
-                    Tensor([img_0_view_N, ..., img_B_view_N]),    # view N
-                ],
-                [label_0, ..., label_B],
-                [filename_0, ..., filename_B],
-            )
+            Example:
+                >>> output = (
+                >>>     [
+                >>>         Tensor([img_0_view_0, ..., img_B_view_0]),    # view 0
+                >>>         Tensor([img_0_view_1, ..., img_B_view_1]),    # view 1
+                >>>         ...
+                >>>         Tensor([img_0_view_N, ..., img_B_view_N]),    # view N
+                >>>     ],
+                >>>     [label_0, ..., label_B],
+                >>>     [filename_0, ..., filename_B],
+                >>> )
         """
         if len(batch) == 0:
             warn("MultiViewCollate received empty batch.")

--- a/lightly/transforms/__init__.py
+++ b/lightly/transforms/__init__.py
@@ -1,8 +1,8 @@
-"""The lightly.transforms package provides additional augmentations.
+"""The lightly.transforms package transforms for various self-supervised learning
+methods.
 
-    Contains implementations of Gaussian blur and random rotations which are
-    not part of torchvisions transforms.
-
+It also contains some additional transforms that are not part of torchvisions
+transforms.
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.

--- a/lightly/transforms/gaussian_blur.py
+++ b/lightly/transforms/gaussian_blur.py
@@ -1,5 +1,3 @@
-""" Gaussian Blur """
-
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -1,5 +1,3 @@
-""" Jigsaw Crop """
-
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 

--- a/lightly/transforms/moco_transform.py
+++ b/lightly/transforms/moco_transform.py
@@ -93,4 +93,55 @@ class MoCoV1Transform(SimCLRTransform):
         )
 
 
-MoCoV2Transform = SimCLRTransform  # MoCo v2 uses the same transform as SimCLR
+class MoCoV2Transform(SimCLRTransform):
+    """Implements the transformations for MoCo v2 [0].
+
+    Identical to SimCLRTransform.
+
+    - [0]: MoCo v2, 2020, https://arxiv.org/abs/2003.04297
+
+    Attributes:
+        input_size:
+            Size of the input image in pixels.
+        cj_prob:
+            Probability that color jitter is applied.
+        cj_strength:
+            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
+            `cj_hue` are multiplied by this value. For datasets with small images,
+            such as CIFAR, it is recommended to set `cj_strenght` to 0.5.
+        cj_bright:
+            How much to jitter brightness.
+        cj_contrast:
+            How much to jitter constrast.
+        cj_sat:
+            How much to jitter saturation.
+        cj_hue:
+            How much to jitter hue.
+        min_scale:
+            Minimum size of the randomized crop relative to the input_size.
+        random_gray_scale:
+            Probability of conversion to grayscale.
+        gaussian_blur:
+            Probability of Gaussian blur.
+        kernel_size:
+            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
+            Used to calculate sigma of gaussian blur with kernel_size * input_size.
+        sigmas:
+            Tuple of min and max value from which the std of the gaussian kernel is sampled.
+            Is ignored if `kernel_size` is set.
+        vf_prob:
+            Probability that vertical flip is applied.
+        hf_prob:
+            Probability that horizontal flip is applied.
+        rr_prob:
+            Probability that random rotation is applied.
+        rr_degrees:
+            Range of degrees to select from for random rotation. If rr_degrees is None,
+            images are rotated by 90 degrees. If rr_degrees is a (min, max) tuple,
+            images are rotated by a random angle in [min, max]. If rr_degrees is a
+            single number, images are rotated by a random angle in
+            [-rr_degrees, +rr_degrees]. All rotations are counter-clockwise.
+        normalize:
+            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
+
+    """

--- a/lightly/transforms/rotation.py
+++ b/lightly/transforms/rotation.py
@@ -1,5 +1,3 @@
-""" Random Rotation """
-
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -13,6 +13,8 @@ from lightly.transforms.utils import IMAGENET_NORMALIZE
 class SimCLRTransform(MultiViewTransform):
     """Implements the transformations for SimCLR [0, 1].
 
+    Note that SimCLR v1 and v2 use the same data augmentations.
+
     - [0]: SimCLR v1, 2020, https://arxiv.org/abs/2002.05709
     - [1]: SimCLR v2, 2020, https://arxiv.org/abs/2006.10029
 

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -11,7 +11,10 @@ from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
 class SimCLRTransform(MultiViewTransform):
-    """Implements the transformations for SimCLR.
+    """Implements the transformations for SimCLR [0, 1].
+
+    - [0]: SimCLR v1, 2020, https://arxiv.org/abs/2002.05709
+    - [1]: SimCLR v2, 2020, https://arxiv.org/abs/2006.10029
 
     Attributes:
         input_size:

--- a/lightly/transforms/solarize.py
+++ b/lightly/transforms/solarize.py
@@ -1,5 +1,3 @@
-""" Solarization """
-
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 


### PR DESCRIPTION
## Changes

* Update main concepts docs page. It now also includes transforms, heads, and the new `MultiViewCollate` function
* Add missing autogenerated docs
* Remove additional titles from autogenerated docs
* Make MoCoV2 transform a sublcass of SimCLR transform instead of an alias. This allows us to add it to the docs.
* Add docstring for `MultiViewCollate`

The main part of this PR is updating the main concepts page. The other parts are just cleanup.

[Main Concepts — lightly 1.4.5 documentation.pdf](https://github.com/lightly-ai/lightly/files/11464365/Main.Concepts.lightly.1.4.5.documentation.pdf)
[lightly.data — lightly 1.4.5 documentation.pdf](https://github.com/lightly-ai/lightly/files/11464367/lightly.data.lightly.1.4.5.documentation.pdf)
[lightly.loss — lightly 1.4.5 documentation.pdf](https://github.com/lightly-ai/lightly/files/11464368/lightly.loss.lightly.1.4.5.documentation.pdf)
[lightly.transforms — lightly 1.4.5 documentation.pdf](https://github.com/lightly-ai/lightly/files/11464370/lightly.transforms.lightly.1.4.5.documentation.pdf)
