### PR TITLE
Revert "Bump version to 1.4.6"

### DIFF
--- a/lightly/__init__.py
+++ b/lightly/__init__.py
@@ -75,7 +75,7 @@ The framework is structured into the following modules:
 # All Rights Reserved
 
 __name__ = "lightly"
-__version__ = "1.4.6"
+__version__ = "1.4.5"
 
 import os
 


### PR DESCRIPTION
Reverts lightly-ai/lightly#1237

Reason: The changes from latest release are just in the docs. It does not make sense to release a new package version.