### PR TITLE
Remove default query_tag_name from ApiWorkflowClient.upload_scores

### DIFF
--- a/lightly/active_learning/agents/agent.py
+++ b/lightly/active_learning/agents/agent.py
@@ -63,14 +63,12 @@ class ActiveLearningAgent:
     def __init__(
         self,
         api_workflow_client: ApiWorkflowClient,
-        query_tag_name: str = "initial-tag",
+        query_tag_name: str,
         preselected_tag_name: str = None,
     ):
         raise_active_learning_deprecation_warning()
         self.api_workflow_client = api_workflow_client
 
-        # set the query_tag_id and preselected_tag_id
-        self._query_tag_id = None
         self._preselected_tag_id = None
 
         # build lookup table for tag_name to tag_id

--- a/lightly/api/api_workflow_selection.py
+++ b/lightly/api/api_workflow_selection.py
@@ -33,17 +33,7 @@ def _parse_active_learning_scores(scores: Union[np.ndarray, List]):
 
 
 class _SelectionMixin:
-    def upload_scores(self, al_scores: Dict[str, np.ndarray], query_tag_id: str = None):
-        tags = self.get_all_tags()
-
-        # upload the active learning scores to the api
-        # change @20210422: we store the active learning scores with the query
-        # tag. policy is that if there's no explicit query tag, the whole dataset
-        # will be the query tag (i.e. query_tag = initial-tag)
-        # set the query tag to the initial-tag if necessary
-        if query_tag_id is None:
-            query_tag = next(t for t in tags if t.name == "initial-tag")
-            query_tag_id = query_tag.id
+    def upload_scores(self, al_scores: Dict[str, np.ndarray], query_tag_id: str):
         # iterate over all available score types and upload them
         for score_type, score_values in al_scores.items():
             body = ActiveLearningScoreCreateRequest(

--- a/tests/UNMOCKED_end2end_tests/test_api.py
+++ b/tests/UNMOCKED_end2end_tests/test_api.py
@@ -191,7 +191,7 @@ def t_est_api_with_matrix(
     )
 
     for method in [SamplingMethod.CORAL, SamplingMethod.CORESET, SamplingMethod.RANDOM]:
-        for query_tag_name in ["initial-tag", "query_tag_name_xyz"]:
+        for query_tag_name in ["query_tag_name_xyz"]:
             for preselected_tag_name in [None, "preselected_tag_name_xyz"]:
                 print(
                     f"Starting AL run with method '{method}', query_tag '{query_tag_name}' "

--- a/tests/active_learning/test_active_learning_agent.py
+++ b/tests/active_learning/test_active_learning_agent.py
@@ -11,18 +11,25 @@ from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
 class TestActiveLearningAgent(MockedApiWorkflowSetup):
     def test_agent(self):
         self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        tags = self.api_workflow_client.get_all_tags()
+        assert tags[1].name != "initial-tag"
+        query_tag_name = tags[1].name
 
-        agent_0 = ActiveLearningAgent(self.api_workflow_client)
+        agent_0 = ActiveLearningAgent(
+            self.api_workflow_client, query_tag_name=query_tag_name
+        )
         agent_1 = ActiveLearningAgent(
             self.api_workflow_client, query_tag_name="query_tag_name_xyz"
         )
         agent_2 = ActiveLearningAgent(
             self.api_workflow_client,
-            query_tag_name="query_tag_name_xyz",
+            query_tag_name=query_tag_name,
             preselected_tag_name="preselected_tag_name_xyz",
         )
         agent_3 = ActiveLearningAgent(
-            self.api_workflow_client, preselected_tag_name="preselected_tag_name_xyz"
+            self.api_workflow_client,
+            query_tag_name=query_tag_name,
+            preselected_tag_name="preselected_tag_name_xyz",
         )
 
         for method in [
@@ -73,9 +80,14 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
 
     def test_agent_wrong_number_of_scores(self):
         self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        tags = self.api_workflow_client.get_all_tags()
+        assert tags[1].name != "initial-tag"
+        query_tag_name = tags[1].name
 
         agent = ActiveLearningAgent(
-            self.api_workflow_client, preselected_tag_name="preselected_tag_name_xyz"
+            self.api_workflow_client,
+            query_tag_name=query_tag_name,
+            preselected_tag_name="preselected_tag_name_xyz",
         )
         method = SamplingMethod.CORAL
         n_samples = len(agent.labeled_set) + 2
@@ -97,8 +109,14 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
         height = 32
         no_classes = 13
 
+        tags = self.api_workflow_client.get_all_tags()
+        assert tags[1].name != "initial-tag"
+        query_tag_name = tags[1].name
+
         agent = ActiveLearningAgent(
-            self.api_workflow_client, preselected_tag_name="preselected_tag_name_xyz"
+            self.api_workflow_client,
+            query_tag_name=query_tag_name,
+            preselected_tag_name="preselected_tag_name_xyz",
         )
         method = SamplingMethod.CORAL
         n_samples = len(agent.labeled_set) + 2
@@ -124,8 +142,14 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
 
     def test_agent_added_set_before_query(self):
         self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        tags = self.api_workflow_client.get_all_tags()
+        assert tags[1].name != "initial-tag"
+        query_tag_name = tags[1].name
+
         agent = ActiveLearningAgent(
-            self.api_workflow_client, preselected_tag_name="preselected_tag_name_xyz"
+            self.api_workflow_client,
+            query_tag_name=query_tag_name,
+            preselected_tag_name="preselected_tag_name_xyz",
         )
 
         agent.query_set
@@ -136,8 +160,13 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
 
     def test_agent_query_too_few(self):
         self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        tags = self.api_workflow_client.get_all_tags()
+        assert tags[1].name != "initial-tag"
+        query_tag_name = tags[1].name
+
         agent = ActiveLearningAgent(
             self.api_workflow_client,
+            query_tag_name=query_tag_name,
             preselected_tag_name="preselected_tag_name_xyz",
         )
 
@@ -148,8 +177,13 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
 
     def test_agent_only_upload_scores(self):
         self.api_workflow_client.embedding_id = "embedding_id_xyz"
+        tags = self.api_workflow_client.get_all_tags()
+        assert tags[1].name != "initial-tag"
+        query_tag_name = tags[1].name
+
         agent = ActiveLearningAgent(
             self.api_workflow_client,
+            query_tag_name=query_tag_name,
             preselected_tag_name="preselected_tag_name_xyz",
         )
 
@@ -163,8 +197,14 @@ class TestActiveLearningAgent(MockedApiWorkflowSetup):
         agent.upload_scores(al_scorer)
 
     def test_agent_without_embedding_id(self):
+        tags = self.api_workflow_client.get_all_tags()
+        assert tags[1].name != "initial-tag"
+        query_tag_name = tags[1].name
+
         agent = ActiveLearningAgent(
-            self.api_workflow_client, preselected_tag_name="preselected_tag_name_xyz"
+            self.api_workflow_client,
+            query_tag_name=query_tag_name,
+            preselected_tag_name="preselected_tag_name_xyz",
         )
         method = SamplingMethod.CORAL
         n_samples = len(agent.labeled_set) + 2


### PR DESCRIPTION
`query_tag_name` can no longer be `initial-tag`, which is rejected by the API server when one attempts to upload AL scores, so the default value becomes meaningless and unnecessary. This PR removes the default value and makes it a required parameter. ActiveLearningAgent is also updated because it uses `initial-tag` by default as well.