### PR TITLE
lig-3121: Update API client docstring - part 2

### DIFF
--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -33,7 +33,7 @@ class _DatasourcesMixin:
         from_: int = 0,
         to: Optional[int] = None,
         relevant_filenames_file_name: Optional[str] = None,
-        use_redirected_read_url: Optional[bool] = False,
+        use_redirected_read_url: bool = False,
         progress_bar: Optional[tqdm.tqdm] = None,
         **kwargs,
     ) -> List[Tuple[str, str]]:
@@ -104,29 +104,33 @@ class _DatasourcesMixin:
         use_redirected_read_url: Optional[bool] = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
-        """Downloads all filenames and read urls from the datasource between `from_` and `to`.
+        """Downloads filenames and read urls from the datasource.
 
-        Samples which have timestamp == `from_` or timestamp == `to` will also be included.
+        Only samples with timestamp between `from_` (inclusive) and `to` (inclusive)
+        will be downloaded.
 
         Args:
             from_:
-                Unix timestamp from which on samples are downloaded.
+                Unix timestamp from which on samples are downloaded. Default to the
+                very beginning (timestamp 0).
             to:
-                Unix timestamp up to and including which samples are downloaded.
+                Unix timestamp up to and including which samples are downloaded. If
+                not given, the current timestamp is used. Optional.
             relevant_filenames_file_name:
-                The path to the relevant filenames text file in the cloud bucket.
-                The path is relative to the datasource root.
+                Path to the relevant filenames text file in the cloud bucket.
+                The path is relative to the datasource root. Optional.
             use_redirected_read_url:
-                By default this is set to false unless a S3DelegatedAccess is configured in which
-                case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
-                returned URLs allow for unlimited access to the file
+                Flag for redirected read urls. When this flag is true,
+                RedirectedReadUrls are returned instead of ReadUrls, meaning that the
+                returned URLs have unlimited access to the file.
+                Default to False. When S3DelegatedAccess is configured, this flag has
+                no effect because RedirectedReadUrls are always returned.
             progress_bar:
                 Tqdm progress bar to show how many samples have already been
                 retrieved.
 
         Returns:
-           A list of (filename, url) tuples, where each tuple represents a sample
+            A list of (filename, url) tuples where each tuple represents a sample.
 
         """
         samples = self._download_raw_files(
@@ -147,41 +151,45 @@ class _DatasourcesMixin:
         relevant_filenames_file_name: Optional[str] = None,
         run_id: Optional[str] = None,
         relevant_filenames_artifact_id: Optional[str] = None,
-        use_redirected_read_url: Optional[bool] = False,
+        use_redirected_read_url: bool = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
-        """Downloads all prediction filenames and read urls from the datasource between `from_` and `to`.
+        """Downloads prediction filenames and read urls from the datasource.
 
-        Samples which have timestamp == `from_` or timestamp == `to` will also be included.
+        Only samples with timestamp between `from_` (inclusive) and `to` (inclusive)
+        will be downloaded.
 
         Args:
             task_name:
                 Name of the prediction task.
             from_:
-                Unix timestamp from which on samples are downloaded.
+                Unix timestamp from which on samples are downloaded. Default to the
+                very beginning (timestamp 0).
             to:
-                Unix timestamp up to and including which samples are downloaded.
+                Unix timestamp up to and including which samples are downloaded. If
+                not given, the current timestamp is used. Optional.
             relevant_filenames_file_name:
-                The path to the relevant filenames text file in the cloud bucket.
-                The path is relative to the datasource root.
+                Path to the relevant filenames text file in the cloud bucket.
+                The path is relative to the datasource root. Optional.
             run_id:
-                Run ID. Should be given along with `relevant_filenames_artifact_id` to
-                download relevant files only.
+                Run ID. Optional. Should be given along with
+                `relevant_filenames_artifact_id` to download relevant files only.
             relevant_filenames_artifact_id:
-                ID of the relevant filename artifact. Should be given along with
-                `run_id` to download relevant files only. Note that this is different
-                from `relevant_filenames_file_name`.
+                ID of the relevant filename artifact. Optional. Should be given along
+                with `run_id` to download relevant files only. Note that this is
+                different from `relevant_filenames_file_name`.
             use_redirected_read_url:
-                By default this is set to false unless a S3DelegatedAccess is configured in which
-                case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
-                returned URLs allow for unlimited access to the file
+                Flag for redirected read urls. When this flag is true,
+                RedirectedReadUrls are returned instead of ReadUrls, meaning that the
+                returned URLs have unlimited access to the file.
+                Default to False. When S3DelegatedAccess is configured, this flag has
+                no effect because RedirectedReadUrls are always returned.
             progress_bar:
                 Tqdm progress bar to show how many prediction files have already been
                 retrieved.
 
         Returns:
-           A list of (filename, url) tuples, where each tuple represents a sample
+            A list of (filename, url) tuples where each tuple represents a sample.
 
         """
         if run_id is not None and relevant_filenames_artifact_id is None:
@@ -220,39 +228,45 @@ class _DatasourcesMixin:
         run_id: Optional[str] = None,
         relevant_filenames_artifact_id: Optional[str] = None,
         relevant_filenames_file_name: Optional[str] = None,
-        use_redirected_read_url: Optional[bool] = False,
+        use_redirected_read_url: bool = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
-        """Downloads all metadata filenames and read urls from the datasource between `from_` and `to`.
+        """Downloads all metadata filenames and read urls from the datasource.
 
-        Samples which have timestamp == `from_` or timestamp == `to` will also be included.
+          between `from_` and `to`.
+
+        Only samples with timestamp between `from_` (inclusive) and `to` (inclusive)
+        will be downloaded.
 
         Args:
             from_:
-                Unix timestamp from which on samples are downloaded.
+                Unix timestamp from which on samples are downloaded. Default to the
+                very beginning (timestamp 0).
             to:
-                Unix timestamp up to and including which samples are downloaded.
+                Unix timestamp up to and including which samples are downloaded. If
+                not given, the current timestamp is used. Optional.
             relevant_filenames_file_name:
-                The path to the relevant filenames text file in the cloud bucket.
-                The path is relative to the datasource root.
+                Path to the relevant filenames text file in the cloud bucket.
+                The path is relative to the datasource root. Optional.
             run_id:
-                Run ID. Should be given along with `relevant_filenames_artifact_id` to
-                download relevant files only.
+                Run ID. Optional. Should be given along with
+                `relevant_filenames_artifact_id` to download relevant files only.
             relevant_filenames_artifact_id:
-                ID of the relevant filename artifact. Should be given along with
-                `run_id` to download relevant files only. Note that this is different
-                from `relevant_filenames_file_name`.
+                ID of the relevant filename artifact. Optional. Should be given along
+                with `run_id` to download relevant files only. Note that this is
+                different from `relevant_filenames_file_name`.
             use_redirected_read_url:
-                By default this is set to false unless a S3DelegatedAccess is configured in which
-                case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
-                returned URLs allow for unlimited access to the file
+                Flag for redirected read urls. When this flag is true,
+                RedirectedReadUrls are returned instead of ReadUrls, meaning that the
+                returned URLs have unlimited access to the file.
+                Default to False. When S3DelegatedAccess is configured, this flag has
+                no effect because RedirectedReadUrls are always returned.
             progress_bar:
                 Tqdm progress bar to show how many metadata files have already been
                 retrieved.
 
         Returns:
-           A list of (filename, url) tuples, where each tuple represents a sample
+            A list of (filename, url) tuples where each tuple represents a sample.
 
         """
         if run_id is not None and relevant_filenames_artifact_id is None:
@@ -285,23 +299,24 @@ class _DatasourcesMixin:
 
     def download_new_raw_samples(
         self,
-        use_redirected_read_url: Optional[bool] = False,
+        use_redirected_read_url: bool = False,
     ) -> List[Tuple[str, str]]:
         """Downloads filenames and read urls of unprocessed samples from the datasource.
 
         All samples after the timestamp of `ApiWorkflowClient.get_processed_until_timestamp()` are
-        fetched. After downloading the samples the timestamp is updated to the current time.
+        fetched. After downloading the samples, the timestamp is updated to the current time.
         This function can be repeatedly called to retrieve new samples from the datasource.
 
         Args:
             use_redirected_read_url:
-                By default this is set to false unless a S3DelegatedAccess is configured in which
-                case its always true and this param has no effect.
-                When true this will return RedirectedReadUrls instead of ReadUrls meaning that
-                returned URLs allow for unlimited access to the file
+                Flag for redirected read urls. When this flag is true,
+                RedirectedReadUrls are returned instead of ReadUrls, meaning that the
+                returned URLs have unlimited access to the file.
+                Default to False. When S3DelegatedAccess is configured, this flag has
+                no effect because RedirectedReadUrls are always returned.
 
         Returns:
-            A list of (filename, url) tuples, where each tuple represents a sample
+            A list of (filename, url) tuples where each tuple represents a sample.
 
         """
         from_ = self.get_processed_until_timestamp()
@@ -326,7 +341,7 @@ class _DatasourcesMixin:
         """Returns the timestamp until which samples have been processed.
 
         Returns:
-            Unix timestamp of last processed sample
+            Unix timestamp of last processed sample.
         """
         response: DatasourceProcessedUntilTimestampResponse = self._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id(
             dataset_id=self.dataset_id
@@ -339,7 +354,7 @@ class _DatasourcesMixin:
 
         Args:
             timestamp:
-                Unix timestamp of last processed sample
+                Unix timestamp of last processed sample.
         """
         body = DatasourceProcessedUntilTimestampRequest(
             processed_until_timestamp=timestamp
@@ -349,7 +364,7 @@ class _DatasourcesMixin:
         )
 
     def get_datasource(self) -> DatasourceConfig:
-        """Calls the api to return the datasource of the current dataset.
+        """Returns the datasource of the current dataset.
 
         Returns:
             Datasource data of the datasource of the current dataset.
@@ -642,8 +657,8 @@ class _DatasourcesMixin:
             filename:
                 Filename for which to get the read-url.
 
-        Returns the read-url. If the file does not exist, a read-url is returned
-        anyways.
+        Returns:
+            A read-url to the file.
 
         """
         return self._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id(
@@ -661,8 +676,8 @@ class _DatasourcesMixin:
             filename:
                 Filename for which to get the read-url.
 
-        Returns the read-url. If the file does not exist, a read-url is returned
-        anyways.
+        Returns:
+            A read-url to the file.
 
         """
         return self._datasources_api.get_metadata_file_read_url_from_datasource_by_dataset_id(
@@ -680,8 +695,8 @@ class _DatasourcesMixin:
             filename:
                 Filename for which to get the read-url.
 
-        Returns the read-url. If the file does not exist, a read-url is returned
-        anyways.
+        Returns:
+            A read-url to the file.
 
         """
         return self._datasources_api.get_custom_embedding_file_read_url_from_datasource_by_dataset_id(
@@ -692,12 +707,12 @@ class _DatasourcesMixin:
     def list_datasource_permissions(
         self,
     ) -> Dict[str, Union[bool, Optional[DatasourceConfigVerifyDataErrors]]]:
-        """List granted access permissions for the datasource set up with a dataset.
+        """Lists granted access permissions for the datasource set up with a dataset.
 
         Returns a string dictionary, with each permission mapped to a boolean value,
-        see the example below. Additionally, there is the ``errors`` key. If there
-        are permission errors it maps to a dictionary from permission name to the
-        error message, otherwise the value is ``None``.
+        see the example below. Additionally, there is the ``errors`` key. Permission
+        errors are stored in a dictionary where permission names are keys and error
+        messages are values. If there is no error, the value is ``None``.
 
         >>> from lightly.api import ApiWorkflowClient
         >>> client = ApiWorkflowClient(

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -47,7 +47,7 @@ class _DownloadDatasetMixin:
         tag_name: str = "initial-tag",
         max_workers: int = 8,
         verbose: bool = True,
-    ):
+    ) -> None:
         """Downloads images from the web-app and stores them in output_dir.
 
         Args:
@@ -144,13 +144,23 @@ class _DownloadDatasetMixin:
             warnings.warn(msg)
 
     def get_all_embedding_data(self) -> List[DatasetEmbeddingData]:
-        """Returns embedding data of all embeddings for this dataset."""
+        """Fetches embedding data of all embeddings for this dataset.
+
+        Returns:
+            A list of embedding data.
+        """
         return self._embeddings_api.get_embeddings_by_dataset_id(
             dataset_id=self.dataset_id
         )
 
     def get_embedding_data_by_name(self, name: str) -> DatasetEmbeddingData:
-        """Returns embedding data with the given name for this dataset.
+        """Fetches embedding data with the given name for this dataset.
+
+        Args:
+            name: Embedding name.
+
+        Returns:
+            Embedding data.
 
         Raises:
             ValueError:
@@ -170,8 +180,11 @@ class _DownloadDatasetMixin:
         embedding_id: str,
         output_path: str,
     ) -> None:
-        """Downloads embeddings with the given embedding id from the dataset and saves
-        them to the output path.
+        """Downloads embeddings with the given embedding id from the dataset.
+
+        Args:
+            embedding_id: ID of the embedding data to be downloaded.
+            output_path: Where the downloaded embedding data should be stored.
         """
         read_url = self._embeddings_api.get_embeddings_csv_read_url_by_id(
             dataset_id=self.dataset_id, embedding_id=embedding_id
@@ -179,8 +192,10 @@ class _DownloadDatasetMixin:
         download.download_and_write_file(url=read_url, output_path=output_path)
 
     def download_embeddings_csv(self, output_path: str) -> None:
-        """Downloads the latest embeddings from the dataset and saves them to the output
-        path.
+        """Downloads the latest embeddings from the dataset.
+
+        Args:
+            output_path: Where the downloaded embedding data should be stored.
 
         Raises:
             RuntimeError:

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -24,7 +24,7 @@ class _ExportDatasetMixin:
         self,
         tag_id: str,
     ) -> List[Dict]:
-        """Exports samples in a format compatible with Label Studio.
+        """Fetches samples in a format compatible with Label Studio.
 
         The format is documented here:
         https://labelstud.io/guide/tasks.html#Basic-Label-Studio-JSON-format
@@ -49,7 +49,7 @@ class _ExportDatasetMixin:
         self,
         tag_name: str,
     ) -> List[Dict]:
-        """Exports samples in a format compatible with Label Studio.
+        """Fetches samples in a format compatible with Label Studio.
 
         The format is documented here:
         https://labelstud.io/guide/tasks.html#Basic-Label-Studio-JSON-format
@@ -78,13 +78,13 @@ class _ExportDatasetMixin:
         self,
         tag_id: str,
     ) -> List[Dict]:
-        """Exports samples in a format compatible with Labelbox v3.
+        """Fetches samples in a format compatible with Labelbox v3.
 
         The format is documented here: https://docs.labelbox.com/docs/images-json
 
         Args:
             tag_id:
-                Id of the tag which should exported.
+                ID of the tag which should exported.
 
         Returns:
             A list of dictionaries in a format compatible with Labelbox v3.
@@ -109,7 +109,7 @@ class _ExportDatasetMixin:
         self,
         tag_name: str,
     ) -> List[Dict]:
-        """Exports samples in a format compatible with Labelbox v3.
+        """Fetches samples in a format compatible with Labelbox v3.
 
         The format is documented here: https://docs.labelbox.com/docs/images-json
 
@@ -144,13 +144,13 @@ class _ExportDatasetMixin:
         self,
         tag_id: str,
     ) -> List[Dict]:
-        """Exports samples in a format compatible with Labelbox v4.
+        """Fetches samples in a format compatible with Labelbox v4.
 
         The format is documented here: https://docs.labelbox.com/docs/images-json
 
         Args:
             tag_id:
-                Id of the tag which should exported.
+                ID of the tag which should exported.
         Returns:
             A list of dictionaries in a format compatible with Labelbox v4.
         """
@@ -166,7 +166,7 @@ class _ExportDatasetMixin:
         self,
         tag_name: str,
     ) -> List[Dict]:
-        """Exports samples in a format compatible with Labelbox.
+        """Fetches samples in a format compatible with Labelbox.
 
         The format is documented here: https://docs.labelbox.com/docs/images-json
 
@@ -191,14 +191,14 @@ class _ExportDatasetMixin:
         self,
         tag_id: str,
     ) -> str:
-        """Exports a list of the samples filenames within a certain tag.
+        """Fetches samples filenames within a certain tag by tag ID.
 
         Args:
             tag_id:
-                Id of the tag which should exported.
+                ID of the tag which should exported.
 
         Returns:
-            A list of the samples filenames within a certain tag.
+            A list of filenames of samples within a certain tag.
 
         """
         filenames = retry(
@@ -212,14 +212,14 @@ class _ExportDatasetMixin:
         self,
         tag_name: str,
     ) -> str:
-        """Exports a list of the samples filenames within a certain tag.
+        """Fetches samples filenames within a certain tag by tag name.
 
         Args:
             tag_name:
                 Name of the tag which should exported.
 
         Returns:
-            A list of the samples filenames within a certain tag.
+            A list of filenames of samples within a certain tag.
 
         Examples:
             >>> # write json file which can be imported in Label Studio
@@ -238,11 +238,11 @@ class _ExportDatasetMixin:
         self,
         tag_id: str,
     ) -> List[Dict[str, str]]:
-        """Export filenames, read URLs, and datasource URLs from the given tag.
+        """Fetches filenames, read URLs, and datasource URLs from the given tag.
 
         Args:
             tag_id:
-                Id of the tag which should exported.
+                ID of the tag which should exported.
 
         Returns:
             A list of dictionaries with the keys "filename", "readUrl" and "datasourceUrl".
@@ -301,14 +301,14 @@ class _ExportDatasetMixin:
         self,
         tag_name: str,
     ) -> List[Dict[str, str]]:
-        """Export filenames, read URLs, and datasource URLs from the given tag name.
+        """Fetches filenames, read URLs, and datasource URLs from the given tag name.
 
         Args:
             tag_name:
                 Name of the tag which should exported.
 
         Returns:
-            A list of dictionaries with the keys "filename", "readUrl" and "datasourceUrl".
+            A list of dictionaries with keys "filename", "readUrl" and "datasourceUrl".
 
         Examples:
             >>> # write json file which can be used to access the actual file contents.

--- a/lightly/api/api_workflow_predictions.py
+++ b/lightly/api/api_workflow_predictions.py
@@ -13,14 +13,14 @@ class _PredictionsMixin:
         schema: PredictionTaskSchema,
         prediction_version_id: int = -1,
     ) -> None:
-        """Creates or updates the prediction task schema
+        """Creates or updates the prediction task schema.
 
         Args:
             schema:
                 The prediction task schema.
             prediction_version_id:
-                A numerical id (e.g timestamp) to distinguish different predictions of different model versions.
-                Use the same id if you don't require versioning or if you wish to overwrite the previous schema.
+                A numerical ID (e.g., timestamp) to distinguish different predictions of different model versions.
+                Use the same ID if you don't require versioning or if you wish to overwrite the previous schema.
 
         Example:
           >>> import time
@@ -62,7 +62,7 @@ class _PredictionsMixin:
         progress_bar: Optional[tqdm.tqdm] = None,
         max_workers: int = 8,
     ) -> None:
-        """Creates or updates the predictions for specific samples
+        """Creates or updates the predictions for specific samples.
 
         Args:
             sample_id_to_prediction_singletons
@@ -70,9 +70,9 @@ class _PredictionsMixin:
                 The singletons can be from different tasks and different types.
 
             prediction_version_id:
-                 A numerical id (e.g timestamp) to distinguish different predictions of different model versions.
-                 Use the same id if you don't require versioning or if you wish to overwrite the previous schema.
-                 This id must match the id of a prediction task schema.
+                A numerical ID (e.g timestamp) to distinguish different predictions of different model versions.
+                Use the same id if you don't require versioning or if you wish to overwrite the previous schema.
+                This ID must match the ID of a prediction task schema.
 
             progress_bar:
                 Tqdm progress bar to show how many prediction files have already been uploaded.
@@ -137,17 +137,19 @@ class _PredictionsMixin:
         prediction_singletons: Sequence[PredictionSingletonRepr],
         prediction_version_id: int = -1,
     ) -> None:
-        """Creates or updates the predictions for one specific sample
+        """Creates or updates predictions for one specific sample.
 
         Args:
             sample_id
-                The id of the sample
+                The ID of the sample.
 
             prediction_version_id:
-                And id to distinguish different predictions for the same sample.
+                A numerical ID (e.g timestamp) to distinguish different predictions of different model versions.
+                Use the same id if you don't require versioning or if you wish to overwrite the previous schema.
+                This ID must match the ID of a prediction task schema.
 
             prediction_singletons:
-                The predictions to upload for that sample
+                Predictions to be uploaded for the designated sample.
         """
         prediction_singletons_for_sending = [
             singleton.to_dict() for singleton in prediction_singletons


### PR DESCRIPTION
Updates docstrings for methods of the API client. This PR covers
* api_workflow_datasources.py
* api_workflow_download_dataset.py
* api_workflow_export.py
* api_workflow_predictions.py