### PR TITLE
lig-3370: Add examples for API workflow client - part 1

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -99,6 +99,11 @@ class _ComputeWorkerMixin:
         Returns:
             ID of the registered Lightly Worker.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> worker_id = client.register_compute_worker(name="my-worker", labels=["worker-label"])
+            >>> worker_id
+            '64709eac61e9ce68180a6529'
         """
         if labels is None:
             labels = []
@@ -116,6 +121,12 @@ class _ComputeWorkerMixin:
 
         Returns:
             A list of worker IDs.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> worker_ids = client.get_compute_worker_ids()
+            >>> worker_ids
+            ['64709eac61e9ce68180a6529', '64709f8f61e9ce68180a652a']
         """
         entries = self._compute_worker_api.get_docker_worker_registry_entries()
         return [entry.id for entry in entries]
@@ -125,6 +136,17 @@ class _ComputeWorkerMixin:
 
         Returns:
             A list of Lightly Worker details.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> workers = client.get_compute_workers()
+            >>> workers
+            [{'created_at': 1685102336056,
+                'docker_version': '2.6.0',
+                'id': '64709eac61e9ce68180a6529',
+                'labels': [],
+                ...
+            }]
         """
         entries: list[
             DockerWorkerRegistryEntryData
@@ -138,6 +160,14 @@ class _ComputeWorkerMixin:
             worker_id:
                 ID of the worker to be removed.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> worker_ids = client.get_compute_worker_ids()
+            >>> worker_ids
+            ['64709eac61e9ce68180a6529']
+            >>> client.delete_compute_worker(worker_id="64709eac61e9ce68180a6529")
+            >>> client.get_compute_worker_ids()
+            []
         """
         self._compute_worker_api.delete_docker_worker_registry_entry_by_id(worker_id)
 
@@ -163,6 +193,20 @@ class _ComputeWorkerMixin:
         Returns:
             The ID of the created config.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> selection_config = {
+            ...     "n_samples": 3,
+            ...     "strategies": [
+            ...         {
+            ...             "input": {"type": "RANDOM", "random_seed": 42},
+            ...             "strategy": {"type": "WEIGHTS"},
+            ...         }
+            ...     ],
+            ... }
+            >>> config_id = client.create_compute_worker_config(
+            ...     selection_config=selection_config,
+            ... )
         """
         if isinstance(selection_config, dict):
             selection = selection_config_from_dict(cfg=selection_config)
@@ -242,6 +286,13 @@ class _ComputeWorkerMixin:
             InvalidConfigError:
                 If one of the configurations is invalid.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> selection_config = {...}
+            >>> worker_labels = ["worker-label"]
+            >>> run_id = client.schedule_compute_worker_run(
+            ...     selection_config=selection_config, runs_on=worker_labels
+            ... )
         """
         if runs_on is None:
             runs_on = []
@@ -276,6 +327,16 @@ class _ComputeWorkerMixin:
         Returns:
             Runs sorted by creation time from the oldest to the latest.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.get_compute_worker_runs()
+            [{'artifacts': [...],
+             'config_id': '6470a16461e9ce68180a6530',
+             'created_at': 1679479418110,
+             'dataset_id': '6470a36361e9ce68180a6531',
+             'docker_version': '2.6.0',
+             ...
+             }]
         """
         if dataset_id is not None:
             runs: List[DockerRunData] = utils.paginate_endpoint(
@@ -301,6 +362,17 @@ class _ComputeWorkerMixin:
         Raises:
             ApiException:
                 If no run with the given ID exists.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.get_compute_worker_run(run_id="6470a20461e9ce68180a6530")
+            {'artifacts': [...],
+             'config_id': '6470a16461e9ce68180a6530',
+             'created_at': 1679479418110,
+             'dataset_id': '6470a36361e9ce68180a6531',
+             'docker_version': '2.6.0',
+             ...
+             }
         """
         return self._compute_worker_api.get_docker_run_by_id(run_id=run_id)
 
@@ -320,6 +392,17 @@ class _ComputeWorkerMixin:
             ApiException:
                 If no run with the given scheduled run ID exists or if the scheduled
                 run is not yet picked up by a worker.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.get_compute_worker_run_from_scheduled_run(scheduled_run_id="646f338a8a5613b57d8b73a1")
+            {'artifacts': [...],
+             'config_id': '6470a16461e9ce68180a6530',
+             'created_at': 1679479418110,
+             'dataset_id': '6470a36361e9ce68180a6531',
+             'docker_version': '2.6.0',
+             ...
+            }
         """
         return self._compute_worker_api.get_docker_run_by_scheduled_id(
             scheduled_id=scheduled_run_id
@@ -340,6 +423,19 @@ class _ComputeWorkerMixin:
 
         Returns:
             A list of scheduled Lightly Worker runs.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.get_scheduled_compute_worker_runs(state="OPEN")
+            [{'config_id': '646f34608a5613b57d8b73cc',
+             'created_at': 1685009508254,
+             'dataset_id': '6470a36361e9ce68180a6531',
+             'id': '646f338a8a5613b57d8b73a1',
+             'last_modified_at': 1685009542667,
+             'owner': '643d050b8bcb91967ded65df',
+             'priority': 'MID',
+             'runs_on': ['worker-label'],
+             'state': 'OPEN'}]
         """
         if state is not None:
             return self._compute_worker_api.get_docker_runs_scheduled_by_dataset_id(

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -30,6 +30,13 @@ class _DatasetsMixin:
 
         Returns:
             True if the dataset exists and False otherwise.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> dataset_id = client.dataset_id
+            >>> client.dataset_exists(dataset_id=dataset_id)
+            True
         """
         try:
             self.get_dataset_by_id(dataset_id)
@@ -54,6 +61,12 @@ class _DatasetsMixin:
 
         Returns:
             A boolean value indicating whether any dataset with the given name exists.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.dataset_name_exists(dataset_name="your-dataset-name")
+            True
         """
         return bool(self.get_datasets_by_name(dataset_name=dataset_name, shared=shared))
 
@@ -65,6 +78,19 @@ class _DatasetsMixin:
 
         Returns:
             The dataset with the given dataset id.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> dataset_id = client.dataset_id
+            >>> client.get_dataset_by_id(dataset_id=dataset_id)
+            {'created_at': 1685009504596,
+             'datasource_processed_until_timestamp': 1685009513,
+             'datasources': ['646f346004d77b4e1424e67e', '646f346004d77b4e1424e695'],
+             'id': '646f34608a5613b57d8b73c9',
+             'img_type': 'full',
+             'type': 'Images',
+             ...}
         """
         dataset: DatasetData = self._datasets_api.get_dataset_by_id(dataset_id)
         return dataset
@@ -90,6 +116,22 @@ class _DatasetsMixin:
         Returns:
             A list of datasets that match the name. If no datasets with the name exist,
             an empty list is returned.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.get_datasets_by_name(dataset_name="your-dataset-name")
+            [{'created_at': 1685009504596,
+             'datasource_processed_until_timestamp': 1685009513,
+             'datasources': ['646f346004d77b4e1424e67e', '646f346004d77b4e1424e695'],
+             'id': '646f34608a5613b57d8b73c9',
+             'img_type': 'full',
+             'type': 'Images',
+             ...}]
+            >>>
+            >>> # Non-existent dataset
+            >>> client.get_datasets_by_name(dataset_name="random-name")
+            []
         """
         datasets = []
         if not shared or shared is None:
@@ -122,6 +164,18 @@ class _DatasetsMixin:
 
         Returns:
             A list of datasets owned by the current user.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.get_datasets()
+            [{'created_at': 1685009504596,
+             'datasource_processed_until_timestamp': 1685009513,
+             'datasources': ['646f346004d77b4e1424e67e', '646f346004d77b4e1424e695'],
+             'id': '646f34608a5613b57d8b73c9',
+             'img_type': 'full',
+             'type': 'Images',
+             ...}]
         """
         datasets = []
         if not shared or shared is None:
@@ -172,6 +226,10 @@ class _DatasetsMixin:
             ValueError:
                 If no dataset with the given name exists.
 
+        Examples:
+            >>> # A new session. Dataset "old-dataset" was created before.
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.set_dataset_id_by_name("old-dataset")
         """
         datasets = self.get_datasets_by_name(dataset_name=dataset_name, shared=shared)
         if not datasets:
@@ -282,6 +340,24 @@ class _DatasetsMixin:
                 The type of the dataset. We recommend to use the API provided
                 constants `DatasetType.IMAGES` and `DatasetType.VIDEOS`.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>>
+            >>> # Create a dataset with a brand new name.
+            >>> client.create_new_dataset_with_unique_name("new-dataset")
+            >>> client.get_dataset_by_id(client.dataset_id)
+            {'id': '6470abef4f0eb7e635c30954',
+             'name': 'new-dataset',
+             ...}
+            >>>
+            >>> # Create another dataset with the same name. This time, the
+            >>> # new dataset should have a suffix `_1`.
+            >>> client.create_new_dataset_with_unique_name("new-dataset")
+            >>> client.get_dataset_by_id(client.dataset_id)
+            {'id': '6470ac194f0eb7e635c30990',
+             'name': 'new-dataset_1',
+             ...}
+
         """
         if not self.dataset_name_exists(dataset_name=dataset_basename):
             self._create_dataset_without_check_existing(
@@ -312,6 +388,17 @@ class _DatasetsMixin:
             dataset_id:
                 The ID of the dataset to be deleted.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> dataset_id = client.dataset_id
+            >>> client.dataset_exists(dataset_id=dataset_id)
+            True
+            >>>
+            >>> # Delete the dataset
+            >>> client.delete_dataset_by_id(dataset_id=dataset_id)
+            >>> client.dataset_exists(dataset_id=dataset_id)
+            False
         """
         self._datasets_api.delete_dataset_by_id(dataset_id=dataset_id)
         del self._dataset_id

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -288,6 +288,8 @@ class _DatasourcesMixin:
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
             >>> client.download_raw_metadata()
+            [('.lightly/metadata/object-detection/image-1.json', 'https://......'),
+             ('.lightly/metadata/object-detection/image-2.json', 'https://......')]
         """
         if run_id is not None and relevant_filenames_artifact_id is None:
             raise ValueError(

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -132,6 +132,13 @@ class _DatasourcesMixin:
         Returns:
             A list of (filename, url) tuples where each tuple represents a sample.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>>
+            >>> # Already created some Lightly Worker runs with this dataset
+            >>> client.set_dataset_id_by_name("my-dataset")
+            >>> client.download_raw_samples()
+            [('image-1.png', 'https://......'), ('image-2.png', 'https://......')]
         """
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_from_datasource_by_dataset_id,
@@ -191,6 +198,15 @@ class _DatasourcesMixin:
         Returns:
             A list of (filename, url) tuples where each tuple represents a sample.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>>
+            >>> # Already created some Lightly Worker runs with this dataset
+            >>> task_name = "object-detection"
+            >>> client.set_dataset_id_by_name("my-dataset")
+            >>> client.download_raw_predictions(task_name=task_name)
+            [('.lightly/predictions/object-detection/image-1.json', 'https://......'),
+             ('.lightly/predictions/object-detection/image-2.json', 'https://......')]
         """
         if run_id is not None and relevant_filenames_artifact_id is None:
             raise ValueError(
@@ -266,6 +282,12 @@ class _DatasourcesMixin:
         Returns:
             A list of (filename, url) tuples where each tuple represents a sample.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>>
+            >>> # Already created some Lightly Worker runs with this dataset
+            >>> client.set_dataset_id_by_name("my-dataset")
+            >>> client.download_raw_metadata()
         """
         if run_id is not None and relevant_filenames_artifact_id is None:
             raise ValueError(
@@ -316,6 +338,13 @@ class _DatasourcesMixin:
         Returns:
             A list of (filename, url) tuples where each tuple represents a sample.
 
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>>
+            >>> # Already created some Lightly Worker runs with this dataset
+            >>> client.set_dataset_id_by_name("my-dataset")
+            >>> client.download_new_raw_samples()
+            [('image-3.png', 'https://......'), ('image-4.png', 'https://......')]
         """
         from_ = self.get_processed_until_timestamp()
 
@@ -340,6 +369,14 @@ class _DatasourcesMixin:
 
         Returns:
             Unix timestamp of last processed sample.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>>
+            >>> # Already created some Lightly Worker runs with this dataset
+            >>> client.set_dataset_id_by_name("my-dataset")
+            >>> client.get_processed_until_timestamp()
+            1684750513
         """
         response: DatasourceProcessedUntilTimestampResponse = self._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id(
             dataset_id=self.dataset_id
@@ -353,6 +390,20 @@ class _DatasourcesMixin:
         Args:
             timestamp:
                 Unix timestamp of last processed sample.
+
+        Examples:
+            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
+            >>>
+            >>> # Already created some Lightly Worker runs with this dataset.
+            >>> # All samples are processed at this moment.
+            >>> client.set_dataset_id_by_name("my-dataset")
+            >>> client.download_new_raw_samples()
+            []
+            >>>
+            >>> # Set timestamp to an earlier moment to reprocess samples
+            >>> client.update_processed_until_timestamp(1684749813)
+            >>> client.download_new_raw_samples()
+            [('image-3.png', 'https://......'), ('image-4.png', 'https://......')]
         """
         body = DatasourceProcessedUntilTimestampRequest(
             processed_until_timestamp=timestamp
@@ -656,7 +707,8 @@ class _DatasourcesMixin:
                 Filename for which to get the read-url.
 
         Returns:
-            A read-url to the file.
+            A read-url to the file. Note that a URL will be returned even if the file does not
+            exist.
 
         """
         return self._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id(


### PR DESCRIPTION
Added some examples to demonstrate how methods can be called. Note that some trivial methods like `set_s3_delegated_access_config` are ignored. This PR covers
* api_workflow_compute_worker.py
* api_workflow_datasets.py
* api_workflow_datasources.py