### PR TITLE
Replace multiviewcollate with default collate

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ import torchvision
 from lightly import loss
 from lightly import transforms
 from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models.modules import heads
 
 
@@ -155,8 +154,6 @@ model = SimCLR(backbone)
 # Prepare transform that creates multiple random views for every image.
 transform = transforms.SimCLRTransform(input_size=32, cj_prob=0.5)
 
-# Combine views from multiple images into a batch.
-collate_fn = MultiViewCollate()
 
 # Create a dataset from your image folder.
 dataset = data.LightlyDataset(input_dir="./my/cute/cats/dataset/", transform=transform)
@@ -166,7 +163,6 @@ dataloader = torch.utils.data.DataLoader(
     dataset,  # Pass the dataset to the dataloader.
     batch_size=128,  # A large batch size helps with the learning.
     shuffle=True,  # Shuffling is important!
-    collate_fn=collate_fn,
 )
 
 # Lightly exposes building blocks such as loss functions.

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -16,7 +16,6 @@ from torch.utils.data import DataLoader
 from torchvision import transforms as T
 
 from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 from lightly.utils.benchmarking import MetricCallback
 
@@ -165,7 +164,6 @@ def pretrain(
         batch_size=batch_size_per_device,
         shuffle=True,
         num_workers=num_workers,
-        collate_fn=MultiViewCollate(),
         drop_last=True,
     )
 

--- a/docs/source/getting_started/advanced.rst
+++ b/docs/source/getting_started/advanced.rst
@@ -121,7 +121,7 @@ There are three ways how you can customize augmentations in Lightly:
     from lightly.transforms.multi_view_transform import MultiViewTransform
 
     # Create a global view transform that crops 224x224 patches from the input image.
-    global_view = T.Collate([
+    global_view = T.Compose([
         T.RandomResizedCrop(size=224, scale=(0.08, 1.0)),
         T.RandomHorizontalFlip(p=0.5),
         T.RandomGrayscale(p=0.5),
@@ -129,7 +129,7 @@ There are three ways how you can customize augmentations in Lightly:
     ])
 
     # Create a local view transform that crops a random portion of the input image and resizes it to a 96x96 patch.
-    local_view = T.Collate([
+    local_view = T.Compose([
         T.RandomResizedCrop(size=96, scale=(0.05, 0.4)),
         T.RandomHorizontalFlip(p=0.5),
         T.RandomGrayscale(p=0.5),

--- a/docs/source/getting_started/benchmarks/cifar10_benchmark.py
+++ b/docs/source/getting_started/benchmarks/cifar10_benchmark.py
@@ -71,7 +71,6 @@ import torchvision
 from pytorch_lightning.loggers import TensorBoardLogger
 
 from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import (
     BarlowTwinsLoss,
     DCLLoss,
@@ -161,9 +160,6 @@ else:
 #  L truck/
 path_to_train = "/datasets/cifar10/train/"
 path_to_test = "/datasets/cifar10/test/"
-
-# Collate function init
-collate_fn = MultiViewCollate()
 
 # Use SimCLR augmentations
 simclr_transform = SimCLRTransform(
@@ -260,7 +256,6 @@ def get_data_loaders(batch_size: int, dataset_train_ssl):
         dataset_train_ssl,
         batch_size=batch_size,
         shuffle=True,
-        collate_fn=collate_fn,
         drop_last=True,
         num_workers=num_workers,
     )

--- a/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
@@ -40,7 +40,6 @@ from pytorch_lightning.loggers import TensorBoardLogger
 from torch.optim.lr_scheduler import LambdaLR
 
 from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import (
     BarlowTwinsLoss,
     DINOLoss,
@@ -108,9 +107,6 @@ else:
 
 path_to_train = "/datasets/imagenet100/train/"
 path_to_test = "/datasets/imagenet100/val/"
-
-# Collate function init
-collate_fn = MultiViewCollate()
 
 # Use SimCLR augmentations
 simclr_transform = SimCLRTransform(input_size=input_size)
@@ -183,7 +179,6 @@ def get_data_loaders(batch_size: int, dataset_train_ssl):
         dataset_train_ssl,
         batch_size=batch_size,
         shuffle=True,
-        collate_fn=collate_fn,
         drop_last=True,
         num_workers=num_workers,
     )

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -72,7 +72,6 @@ from pl_bolts.optimizers.lars import LARS
 from pytorch_lightning.loggers import TensorBoardLogger
 
 from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import (
     BarlowTwinsLoss,
     DCLLoss,
@@ -154,9 +153,6 @@ else:
 
 path_to_train = "/datasets/imagenette2-160/train/"
 path_to_test = "/datasets/imagenette2-160/val/"
-
-# Collate function init
-collate_fn = MultiViewCollate()
 
 # Use SimCLR augmentations
 simclr_transform = SimCLRTransform(
@@ -283,7 +279,6 @@ def get_data_loaders(batch_size: int, dataset_train_ssl):
         dataset_train_ssl,
         batch_size=batch_size,
         shuffle=True,
-        collate_fn=collate_fn,
         drop_last=True,
         num_workers=num_workers,
     )

--- a/docs/source/getting_started/main_concepts.rst
+++ b/docs/source/getting_started/main_concepts.rst
@@ -34,11 +34,6 @@ below.
    * :ref:`lightly-advanced`
    * :ref:`lightly-custom-augmentation-5`.
 
-* **Collate Function**
-   The collate function aggregates the views of multiple images into a single batch.
-   Lightly provides a default :py:class:`~lightly.data.multi_view_collate.MultiViewCollate`
-   function that can be used with any transform.
-
 * **Dataloader**
    For the dataloader you can simply use a `PyTorch dataloader <https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader>`_.
    Be sure to pass it a :py:class:`~lightly.data.dataset.LightlyDataset` though!

--- a/docs/source/getting_started/main_concepts.rst
+++ b/docs/source/getting_started/main_concepts.rst
@@ -34,6 +34,11 @@ below.
    * :ref:`lightly-advanced`
    * :ref:`lightly-custom-augmentation-5`.
 
+* **Collate Function**
+   The collate function aggregates the views of multiple images into a single batch.
+   You can use the default collate function. Lightly also provides a  
+   :py:class:`~lightly.data.multi_view_collate.MultiViewCollate`
+
 * **Dataloader**
    For the dataloader you can simply use a `PyTorch dataloader <https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader>`_.
    Be sure to pass it a :py:class:`~lightly.data.dataset.LightlyDataset` though!

--- a/examples/pytorch/barlowtwins.py
+++ b/examples/pytorch/barlowtwins.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import BarlowTwinsLoss
 from lightly.models.modules import BarlowTwinsProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
@@ -32,18 +30,16 @@ model = BarlowTwins(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/barlowtwins.py
+++ b/examples/pytorch/barlowtwins.py
@@ -51,7 +51,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch/byol.py
+++ b/examples/pytorch/byol.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import BYOLPredictionHead, BYOLProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -51,18 +49,16 @@ model = BYOL(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/byol.py
+++ b/examples/pytorch/byol.py
@@ -73,7 +73,7 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         update_momentum(model.backbone, model.backbone_momentum, m=momentum_val)
         update_momentum(
             model.projection_head, model.projection_head_momentum, m=momentum_val

--- a/examples/pytorch/dcl.py
+++ b/examples/pytorch/dcl.py
@@ -54,7 +54,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch/dcl.py
+++ b/examples/pytorch/dcl.py
@@ -6,9 +6,7 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
-from lightly.loss import DCLLoss, DCLWLoss
+from lightly.loss import DCLLoss
 from lightly.models.modules import SimCLRProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
 
@@ -32,18 +30,16 @@ model = DCL(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/dino.py
+++ b/examples/pytorch/dino.py
@@ -53,7 +53,10 @@ model.to(device)
 
 transform = DINOTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -81,7 +84,7 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for views, _, _ in dataloader:
+    for views, _ in dataloader:
         update_momentum(model.student_backbone, model.teacher_backbone, m=momentum_val)
         update_momentum(model.student_head, model.teacher_head, m=momentum_val)
         views = [view.to(device) for view in views]

--- a/examples/pytorch/dino.py
+++ b/examples/pytorch/dino.py
@@ -52,7 +52,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = DINOTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/dino.py
+++ b/examples/pytorch/dino.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import DINOLoss
 from lightly.models.modules import DINOProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -53,21 +51,16 @@ model = DINO(backbone, input_dim)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = DINOTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/fastsiam.py
+++ b/examples/pytorch/fastsiam.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
 from lightly.transforms import FastSiamTransform
@@ -35,18 +33,16 @@ model = FastSiam(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = FastSiamTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/fastsiam.py
+++ b/examples/pytorch/fastsiam.py
@@ -54,7 +54,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for views, _, _ in dataloader:
+    for views, _ in dataloader:
         features = [model(view.to(device)) for view in views]
         zs = torch.stack([z for z, _ in features])
         ps = torch.stack([p for _, p in features])

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -78,7 +78,10 @@ model.to(device)
 
 transform = MAETransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -97,7 +100,7 @@ optimizer = torch.optim.AdamW(model.parameters(), lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for images, _, _ in dataloader:
+    for images, _ in dataloader:
         images = images[0].to(device)  # images is a list containing only one view
         predictions, targets = model(images)
         loss = criterion(predictions, targets)

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -85,7 +85,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=256,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models import utils
 from lightly.models.modules import masked_autoencoder
 from lightly.transforms.mae_transform import MAETransform
@@ -78,21 +76,16 @@ model = MAE(vit)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = MAETransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=256,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -77,7 +77,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MAETransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/moco.py
+++ b/examples/pytorch/moco.py
@@ -71,7 +71,7 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for (x_query, x_key), _, _ in dataloader:
+    for (x_query, x_key), _ in dataloader:
         update_momentum(model.backbone, model.backbone_momentum, m=momentum_val)
         update_momentum(
             model.projection_head, model.projection_head_momentum, m=momentum_val

--- a/examples/pytorch/moco.py
+++ b/examples/pytorch/moco.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import MoCoProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -48,18 +46,17 @@ model = MoCo(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
-transform = MoCoV2Transform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
-# or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
+transform = MoCoV2Transform(input_size=32)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/msn.py
+++ b/examples/pytorch/msn.py
@@ -65,7 +65,10 @@ model.to(device)
 
 transform = MSNTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -90,7 +93,7 @@ optimizer = torch.optim.AdamW(params, lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for views, _, _ in dataloader:
+    for views, _ in dataloader:
         utils.update_momentum(model.anchor_backbone, model.backbone, 0.996)
         utils.update_momentum(
             model.anchor_projection_head, model.projection_head, 0.996

--- a/examples/pytorch/msn.py
+++ b/examples/pytorch/msn.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import MSNLoss
 from lightly.models import utils
 from lightly.models.modules.heads import MSNProjectionHead
@@ -65,21 +63,16 @@ model = MSN(vit)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = MSNTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/msn.py
+++ b/examples/pytorch/msn.py
@@ -64,7 +64,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MSNTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/nnclr.py
+++ b/examples/pytorch/nnclr.py
@@ -62,7 +62,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0, p0 = model(x0)

--- a/examples/pytorch/nnclr.py
+++ b/examples/pytorch/nnclr.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import (
     NNCLRPredictionHead,
@@ -43,18 +41,16 @@ model.to(device)
 memory_bank = NNMemoryBankModule(size=4096)
 memory_bank.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/pmsn.py
+++ b/examples/pytorch/pmsn.py
@@ -65,7 +65,10 @@ model.to(device)
 
 transform = MSNTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -90,7 +93,7 @@ optimizer = torch.optim.AdamW(params, lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for views, _, _ in dataloader:
+    for views, _ in dataloader:
         utils.update_momentum(model.anchor_backbone, model.backbone, 0.996)
         utils.update_momentum(
             model.anchor_projection_head, model.projection_head, 0.996

--- a/examples/pytorch/pmsn.py
+++ b/examples/pytorch/pmsn.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import PMSNLoss
 from lightly.models import utils
 from lightly.models.modules.heads import MSNProjectionHead
@@ -65,21 +63,16 @@ model = PMSN(vit)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = MSNTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/pmsn.py
+++ b/examples/pytorch/pmsn.py
@@ -64,7 +64,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MSNTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/simclr.py
+++ b/examples/pytorch/simclr.py
@@ -51,7 +51,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch/simclr.py
+++ b/examples/pytorch/simclr.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset, SimCLRCollateFunction
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import SimCLRProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
@@ -32,18 +30,16 @@ model = SimCLR(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32, gaussian_blur=0.0)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/simmim.py
+++ b/examples/pytorch/simmim.py
@@ -71,7 +71,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=8,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/simmim.py
+++ b/examples/pytorch/simmim.py
@@ -63,7 +63,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MAETransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/simmim.py
+++ b/examples/pytorch/simmim.py
@@ -64,7 +64,10 @@ model.to(device)
 
 transform = MAETransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -84,7 +87,7 @@ optimizer = torch.optim.AdamW(model.parameters(), lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for images, _, _ in dataloader:
+    for images, _ in dataloader:
         images = images[0].to(device)  # images is a list containing only one view
         predictions, targets = model(images)
 

--- a/examples/pytorch/simmim.py
+++ b/examples/pytorch/simmim.py
@@ -2,8 +2,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models import utils
 from lightly.models.modules import masked_autoencoder
 from lightly.transforms.mae_transform import MAETransform  # Same transform as MAE
@@ -64,21 +62,16 @@ model = SimMIM(vit)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=False, target_transform=lambda t: 0
-)
 transform = MAETransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=8,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/simsiam.py
+++ b/examples/pytorch/simsiam.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
 from lightly.transforms import SimSiamTransform
@@ -35,18 +33,16 @@ model = SimSiam(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimSiamTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/simsiam.py
+++ b/examples/pytorch/simsiam.py
@@ -54,7 +54,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0, p0 = model(x0)

--- a/examples/pytorch/smog.py
+++ b/examples/pytorch/smog.py
@@ -9,8 +9,6 @@ import torchvision
 from sklearn.cluster import KMeans
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss.memory_bank import MemoryBankModule
 from lightly.models import utils
 from lightly.models.modules.heads import (
@@ -87,7 +85,6 @@ memory_bank = MemoryBankModule(size=memory_bank_size)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SMoGTransform(
     crop_sizes=(32, 32),
     crop_counts=(1, 1),
@@ -95,19 +92,15 @@ transform = SMoGTransform(
     crop_min_scales=(0.2, 0.2),
     crop_max_scales=(1.0, 1.0),
 )
-dataset = LightlyDataset.from_torch_dataset(
-    cifar10,
-    transform=transform,
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
 )
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/smog.py
+++ b/examples/pytorch/smog.py
@@ -117,7 +117,7 @@ print("Starting Training")
 for epoch in range(10):
     total_loss = 0
     for batch_idx, batch in enumerate(dataloader):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
 
         if batch_idx % 2:
             # swap batches every second iteration

--- a/examples/pytorch/swav.py
+++ b/examples/pytorch/swav.py
@@ -42,7 +42,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=128,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/swav.py
+++ b/examples/pytorch/swav.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import SwaVLoss
 from lightly.models.modules import SwaVProjectionHead, SwaVPrototypes
 from lightly.transforms.swav_transform import SwaVTransform
@@ -35,21 +33,16 @@ model = SwaV(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = SwaVTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=128,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/swav.py
+++ b/examples/pytorch/swav.py
@@ -34,7 +34,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = SwaVTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/swav.py
+++ b/examples/pytorch/swav.py
@@ -35,7 +35,10 @@ model.to(device)
 
 transform = SwaVTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -54,7 +57,7 @@ optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for batch, _, _ in dataloader:
+    for batch, _ in dataloader:
         model.prototypes.normalize()
         multi_crop_features = [model(x.to(device)) for x in batch]
         high_resolution = multi_crop_features[:2]

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -6,8 +6,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import SwaVLoss
 from lightly.loss.memory_bank import MemoryBankModule
 from lightly.models.modules import SwaVProjectionHead, SwaVPrototypes
@@ -80,20 +78,16 @@ model = SwaV(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
+transform = SwaVTransform()
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
 )
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=SwaVTransform())
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=128,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -79,7 +79,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = SwaVTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -87,7 +87,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=128,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -80,7 +80,10 @@ model.to(device)
 
 transform = SwaVTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -99,7 +102,7 @@ optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for batch, _, _ in dataloader:
+    for batch, _ in dataloader:
         batch = [x.to(device) for x in batch]
         high_resolution, low_resolution = batch[:2], batch[2:]
         high_resolution, low_resolution, queue = model(

--- a/examples/pytorch/tico.py
+++ b/examples/pytorch/tico.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss.tico_loss import TiCoLoss
 from lightly.models.modules.heads import TiCoProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -49,18 +47,16 @@ model = TiCo(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/tico.py
+++ b/examples/pytorch/tico.py
@@ -72,7 +72,7 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         update_momentum(model.backbone, model.backbone_momentum, m=momentum_val)
         update_momentum(
             model.projection_head, model.projection_head_momentum, m=momentum_val

--- a/examples/pytorch/vicreg.py
+++ b/examples/pytorch/vicreg.py
@@ -50,7 +50,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _, _ in dataloader:
+    for (x0, x1), _ in dataloader:
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch/vicreg.py
+++ b/examples/pytorch/vicreg.py
@@ -2,9 +2,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
-
 ## The projection head is the same as the Barlow Twins one
 from lightly.loss import VICRegLoss
 
@@ -33,23 +30,20 @@ model = VICReg(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = VICRegTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,
 )
-
 criterion = VICRegLoss()
 optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 

--- a/examples/pytorch/vicregl.py
+++ b/examples/pytorch/vicregl.py
@@ -36,7 +36,10 @@ model.to(device)
 
 transform = VICRegLTransform(n_local_views=0)
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
@@ -55,7 +58,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for views_and_grids, _, _ in dataloader:
+    for views_and_grids, _ in dataloader:
         views_and_grids = [x.to(device) for x in views_and_grids]
         views = views_and_grids[: len(views_and_grids) // 2]
         grids = views_and_grids[len(views_and_grids) // 2 :]

--- a/examples/pytorch/vicregl.py
+++ b/examples/pytorch/vicregl.py
@@ -35,7 +35,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = VICRegLTransform(n_local_views=0)
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch/vicregl.py
+++ b/examples/pytorch/vicregl.py
@@ -2,8 +2,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import VICRegLLoss
 
 ## The global projection head is the same as the Barlow Twins one
@@ -36,20 +34,16 @@ model = VICRegL(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = VICRegLTransform(n_local_views=0)
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=256,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch/vicregl.py
+++ b/examples/pytorch/vicregl.py
@@ -43,7 +43,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=256,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/barlowtwins.py
+++ b/examples/pytorch_lightning/barlowtwins.py
@@ -26,7 +26,7 @@ class BarlowTwins(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning/barlowtwins.py
+++ b/examples/pytorch_lightning/barlowtwins.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import BarlowTwinsLoss
 from lightly.models.modules import BarlowTwinsProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
@@ -41,18 +39,16 @@ class BarlowTwins(pl.LightningModule):
 
 model = BarlowTwins()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/byol.py
+++ b/examples/pytorch_lightning/byol.py
@@ -9,8 +9,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import BYOLPredictionHead, BYOLProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -64,18 +62,16 @@ class BYOL(pl.LightningModule):
 
 model = BYOL()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/byol.py
+++ b/examples/pytorch_lightning/byol.py
@@ -48,7 +48,7 @@ class BYOL(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         p0 = self.forward(x0)
         z0 = self.forward_momentum(x0)
         p1 = self.forward(x1)

--- a/examples/pytorch_lightning/dcl.py
+++ b/examples/pytorch_lightning/dcl.py
@@ -7,9 +7,7 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
-from lightly.loss import DCLLoss, DCLWLoss
+from lightly.loss import DCLLoss
 from lightly.models.modules import SimCLRProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
 
@@ -43,23 +41,20 @@ class DCL(pl.LightningModule):
 
 model = DCL()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,
 )
-
 accelerator = "gpu" if torch.cuda.is_available() else "cpu"
 
 trainer = pl.Trainer(max_epochs=10, devices=1, accelerator=accelerator)

--- a/examples/pytorch_lightning/dcl.py
+++ b/examples/pytorch_lightning/dcl.py
@@ -28,7 +28,7 @@ class DCL(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning/dino.py
+++ b/examples/pytorch_lightning/dino.py
@@ -52,7 +52,7 @@ class DINO(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.student_backbone, self.teacher_backbone, m=momentum)
         update_momentum(self.student_head, self.teacher_head, m=momentum)
-        views, _, _ = batch
+        views, _ = batch
         views = [view.to(self.device) for view in views]
         global_views = views[:2]
         teacher_out = [self.forward_teacher(view) for view in global_views]
@@ -72,7 +72,10 @@ model = DINO()
 
 transform = DINOTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/dino.py
+++ b/examples/pytorch_lightning/dino.py
@@ -9,8 +9,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import DINOLoss
 from lightly.models.modules import DINOProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -72,21 +70,16 @@ class DINO(pl.LightningModule):
 
 model = DINO()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = DINOTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/dino.py
+++ b/examples/pytorch_lightning/dino.py
@@ -71,7 +71,8 @@ class DINO(pl.LightningModule):
 model = DINO()
 
 transform = DINOTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/fastsiam.py
+++ b/examples/pytorch_lightning/fastsiam.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
 from lightly.transforms import FastSiamTransform
@@ -51,18 +49,16 @@ class FastSiam(pl.LightningModule):
 
 model = FastSiam()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = FastSiamTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/fastsiam.py
+++ b/examples/pytorch_lightning/fastsiam.py
@@ -29,7 +29,7 @@ class FastSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        views, _, _ = batch
+        views, _ = batch
         features = [self.forward(view) for view in views]
         zs = torch.stack([z for z, _ in features])
         ps = torch.stack([p for _, p in features])

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -57,7 +57,7 @@ class MAE(pl.LightningModule):
         return x_pred
 
     def training_step(self, batch, batch_idx):
-        images, _, _ = batch
+        images, _ = batch
         images = images[0]  # images is a list containing only one view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
@@ -85,7 +85,10 @@ model = MAE()
 
 transform = MAETransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models import utils
 from lightly.models.modules import masked_autoencoder
 from lightly.transforms.mae_transform import MAETransform
@@ -85,21 +83,16 @@ class MAE(pl.LightningModule):
 
 model = MAE()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = MAETransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=256,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -84,7 +84,8 @@ class MAE(pl.LightningModule):
 model = MAE()
 
 transform = MAETransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -92,7 +92,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=256,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/moco.py
+++ b/examples/pytorch_lightning/moco.py
@@ -9,8 +9,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import MoCoProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -60,18 +58,16 @@ class MoCo(pl.LightningModule):
 
 model = MoCo()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = MoCoV2Transform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/msn.py
+++ b/examples/pytorch_lightning/msn.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import MSNLoss
 from lightly.models import utils
 from lightly.models.modules.heads import MSNProjectionHead
@@ -87,20 +85,16 @@ class MSN(pl.LightningModule):
 
 model = MSN()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
+transform = MSNTransform()
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
 )
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=MSNTransform())
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/msn.py
+++ b/examples/pytorch_lightning/msn.py
@@ -86,7 +86,8 @@ class MSN(pl.LightningModule):
 model = MSN()
 
 transform = MSNTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/msn.py
+++ b/examples/pytorch_lightning/msn.py
@@ -47,7 +47,7 @@ class MSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _, _ = batch
+        views, _ = batch
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]
@@ -87,7 +87,10 @@ model = MSN()
 
 transform = MSNTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/nnclr.py
+++ b/examples/pytorch_lightning/nnclr.py
@@ -35,7 +35,7 @@ class NNCLR(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         z0 = self.memory_bank(z0, update=False)

--- a/examples/pytorch_lightning/nnclr.py
+++ b/examples/pytorch_lightning/nnclr.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import (
     NNCLRPredictionHead,
@@ -52,18 +50,16 @@ class NNCLR(pl.LightningModule):
 
 model = NNCLR()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/pmsn.py
+++ b/examples/pytorch_lightning/pmsn.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import PMSNLoss
 from lightly.models import utils
 from lightly.models.modules.heads import MSNProjectionHead
@@ -87,21 +85,16 @@ class PMSN(pl.LightningModule):
 
 model = PMSN()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = MSNTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/pmsn.py
+++ b/examples/pytorch_lightning/pmsn.py
@@ -86,7 +86,8 @@ class PMSN(pl.LightningModule):
 model = PMSN()
 
 transform = MSNTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/pmsn.py
+++ b/examples/pytorch_lightning/pmsn.py
@@ -47,7 +47,7 @@ class PMSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _, _ = batch
+        views, _ = batch
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]
@@ -87,7 +87,10 @@ model = PMSN()
 
 transform = MSNTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/simclr.py
+++ b/examples/pytorch_lightning/simclr.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import SimCLRProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
@@ -41,18 +39,16 @@ class SimCLR(pl.LightningModule):
 
 model = SimCLR()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/simclr.py
+++ b/examples/pytorch_lightning/simclr.py
@@ -26,7 +26,7 @@ class SimCLR(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning/simmim.py
+++ b/examples/pytorch_lightning/simmim.py
@@ -74,7 +74,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MAETransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/simmim.py
+++ b/examples/pytorch_lightning/simmim.py
@@ -82,7 +82,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=8,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/simmim.py
+++ b/examples/pytorch_lightning/simmim.py
@@ -38,7 +38,7 @@ class SimMIM(pl.LightningModule):
         return self.decoder(x_encoded)
 
     def training_step(self, batch, batch_idx):
-        images, _, _ = batch
+        images, _ = batch
         images = images[0]  # images is a list containing only one view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
@@ -75,7 +75,10 @@ model.to(device)
 
 transform = MAETransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/simmim.py
+++ b/examples/pytorch_lightning/simmim.py
@@ -3,8 +3,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models import utils
 from lightly.models.modules import masked_autoencoder
 from lightly.transforms.mae_transform import MAETransform  # Same transform as MAE
@@ -75,21 +73,16 @@ model = SimMIM()
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "/home/ubuntu/datasets/pascal_voc", download=False, target_transform=lambda t: 0
-)
 transform = MAETransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=8,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/simsiam.py
+++ b/examples/pytorch_lightning/simsiam.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
 from lightly.transforms import SimSiamTransform
@@ -44,18 +42,16 @@ class SimSiam(pl.LightningModule):
 
 model = SimSiam()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimSiamTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/simsiam.py
+++ b/examples/pytorch_lightning/simsiam.py
@@ -29,7 +29,7 @@ class SimSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         loss = 0.5 * (self.criterion(z0, p1) + self.criterion(z1, p0))

--- a/examples/pytorch_lightning/smog.py
+++ b/examples/pytorch_lightning/smog.py
@@ -11,8 +11,6 @@ from sklearn.cluster import KMeans
 from torch import nn
 
 from lightly import loss, models
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models import utils
 from lightly.models.modules import heads
 from lightly.transforms.smog_transform import SMoGTransform
@@ -120,7 +118,6 @@ class SMoGModel(pl.LightningModule):
 
 model = SMoGModel()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SMoGTransform(
     crop_sizes=(32, 32),
     crop_counts=(1, 1),
@@ -128,19 +125,15 @@ transform = SMoGTransform(
     crop_min_scales=(0.2, 0.2),
     crop_max_scales=(1.0, 1.0),
 )
-dataset = LightlyDataset.from_torch_dataset(
-    cifar10,
-    transform=transform,
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
 )
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/smog.py
+++ b/examples/pytorch_lightning/smog.py
@@ -76,7 +76,7 @@ class SMoGModel(pl.LightningModule):
                 self.projection_head, self.projection_head_momentum, 0.99
             )
 
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
 
         if batch_idx % 2:
             # swap batches every second iteration

--- a/examples/pytorch_lightning/swav.py
+++ b/examples/pytorch_lightning/swav.py
@@ -45,7 +45,8 @@ class SwaV(pl.LightningModule):
 model = SwaV()
 
 transform = SwaVTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/swav.py
+++ b/examples/pytorch_lightning/swav.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import SwaVLoss
 from lightly.models.modules import SwaVProjectionHead, SwaVPrototypes
 from lightly.transforms.swav_transform import SwaVTransform
@@ -46,21 +44,16 @@ class SwaV(pl.LightningModule):
 
 model = SwaV()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = SwaVTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=128,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/swav.py
+++ b/examples/pytorch_lightning/swav.py
@@ -53,7 +53,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=128,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/swav.py
+++ b/examples/pytorch_lightning/swav.py
@@ -30,7 +30,7 @@ class SwaV(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         self.prototypes.normalize()
-        crops, _, _ = batch
+        crops, _ = batch
         multi_crop_features = [self.forward(x.to(self.device)) for x in crops]
         high_resolution = multi_crop_features[:2]
         low_resolution = multi_crop_features[2:]
@@ -46,7 +46,10 @@ model = SwaV()
 
 transform = SwaVTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -25,7 +25,7 @@ class SwaV(pl.LightningModule):
         self.criterion = SwaVLoss()
 
     def training_step(self, batch, batch_idx):
-        batch_swav, _, _ = batch
+        batch_swav, _ = batch
         high_resolution, low_resolution = batch_swav[:2], batch_swav[2:]
         self.prototypes.normalize()
 
@@ -90,7 +90,10 @@ model = SwaV()
 
 transform = SwaVTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -89,7 +89,8 @@ class SwaV(pl.LightningModule):
 model = SwaV()
 
 transform = SwaVTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -97,7 +97,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=128,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import SwaVLoss
 from lightly.loss.memory_bank import MemoryBankModule
 from lightly.models.modules import SwaVProjectionHead, SwaVPrototypes
@@ -90,26 +88,20 @@ class SwaV(pl.LightningModule):
 
 model = SwaV()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
+transform = SwaVTransform()
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
 )
-trasnform = SwaVTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=128,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,
 )
-
 accelerator = "gpu" if torch.cuda.is_available() else "cpu"
 
 trainer = pl.Trainer(max_epochs=10, devices=1, accelerator=accelerator)

--- a/examples/pytorch_lightning/tico.py
+++ b/examples/pytorch_lightning/tico.py
@@ -5,8 +5,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss.tico_loss import TiCoLoss
 from lightly.models.modules.heads import TiCoProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -58,18 +56,16 @@ class TiCo(pl.LightningModule):
 
 model = TiCo()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/tico.py
+++ b/examples/pytorch_lightning/tico.py
@@ -39,7 +39,7 @@ class TiCo(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)

--- a/examples/pytorch_lightning/vicreg.py
+++ b/examples/pytorch_lightning/vicreg.py
@@ -28,7 +28,7 @@ class VICReg(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning/vicreg.py
+++ b/examples/pytorch_lightning/vicreg.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss.vicreg_loss import VICRegLoss
 
 ## The projection head is the same as the Barlow Twins one
@@ -43,17 +41,16 @@ class VICReg(pl.LightningModule):
 
 model = VICReg()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
-dataset = LightlyDataset.from_torch_dataset(cifar10, VICRegTransform(input_size=32))
+transform = VICRegTransform(input_size=32)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import VICRegLLoss
 
 ## The global projection head is the same as the Barlow Twins one
@@ -55,20 +53,16 @@ class VICRegL(pl.LightningModule):
 
 model = VICRegL()
 
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = VICRegLTransform(n_local_views=0)
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=256,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -54,7 +54,8 @@ class VICRegL(pl.LightningModule):
 model = VICRegL()
 
 transform = VICRegLTransform(n_local_views=0)
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -62,7 +62,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=256,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -55,7 +55,10 @@ model = VICRegL()
 
 transform = VICRegLTransform(n_local_views=0)
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/barlowtwins.py
+++ b/examples/pytorch_lightning_distributed/barlowtwins.py
@@ -29,7 +29,7 @@ class BarlowTwins(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/barlowtwins.py
+++ b/examples/pytorch_lightning_distributed/barlowtwins.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import BarlowTwinsLoss
 from lightly.models.modules import BarlowTwinsProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
@@ -44,18 +42,16 @@ class BarlowTwins(pl.LightningModule):
 
 model = BarlowTwins()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/byol.py
+++ b/examples/pytorch_lightning_distributed/byol.py
@@ -9,8 +9,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import BYOLProjectionHead
 from lightly.models.modules.heads import BYOLPredictionHead
@@ -65,18 +63,16 @@ class BYOL(pl.LightningModule):
 
 model = BYOL()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/byol.py
+++ b/examples/pytorch_lightning_distributed/byol.py
@@ -49,7 +49,7 @@ class BYOL(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         p0 = self.forward(x0)
         z0 = self.forward_momentum(x0)
         p1 = self.forward(x1)

--- a/examples/pytorch_lightning_distributed/dcl.py
+++ b/examples/pytorch_lightning_distributed/dcl.py
@@ -7,9 +7,7 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
-from lightly.loss import DCLLoss, DCLWLoss
+from lightly.loss import DCLLoss
 from lightly.models.modules import SimCLRProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
 
@@ -46,18 +44,16 @@ class DCL(pl.LightningModule):
 
 model = DCL()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/dcl.py
+++ b/examples/pytorch_lightning_distributed/dcl.py
@@ -31,7 +31,7 @@ class DCL(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/dino.py
+++ b/examples/pytorch_lightning_distributed/dino.py
@@ -52,7 +52,7 @@ class DINO(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.student_backbone, self.teacher_backbone, m=momentum)
         update_momentum(self.student_head, self.teacher_head, m=momentum)
-        views, _, _ = batch
+        views, _ = batch
         views = [view.to(self.device) for view in views]
         global_views = views[:2]
         teacher_out = [self.forward_teacher(view) for view in global_views]
@@ -72,7 +72,10 @@ model = DINO()
 
 transform = DINOTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/dino.py
+++ b/examples/pytorch_lightning_distributed/dino.py
@@ -9,8 +9,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import DINOLoss
 from lightly.models.modules import DINOProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -72,21 +70,16 @@ class DINO(pl.LightningModule):
 
 model = DINO()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = DINOTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/dino.py
+++ b/examples/pytorch_lightning_distributed/dino.py
@@ -71,7 +71,8 @@ class DINO(pl.LightningModule):
 model = DINO()
 
 transform = DINOTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning_distributed/fastsiam.py
+++ b/examples/pytorch_lightning_distributed/fastsiam.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
 from lightly.transforms import FastSiamTransform
@@ -51,18 +49,16 @@ class FastSiam(pl.LightningModule):
 
 model = FastSiam()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = FastSiamTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/fastsiam.py
+++ b/examples/pytorch_lightning_distributed/fastsiam.py
@@ -29,7 +29,7 @@ class FastSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        views, _, _ = batch
+        views, _ = batch
         features = [self.forward(view) for view in views]
         zs = torch.stack([z for z, _ in features])
         ps = torch.stack([p for _, p in features])

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -57,7 +57,7 @@ class MAE(pl.LightningModule):
         return x_pred
 
     def training_step(self, batch, batch_idx):
-        images, _, _ = batch
+        images, _ = batch
         images = images[0]  # images is a list containing only one view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
@@ -85,7 +85,10 @@ model = MAE()
 
 transform = MAETransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models import utils
 from lightly.models.modules import masked_autoencoder
 from lightly.transforms.mae_transform import MAETransform
@@ -85,21 +83,16 @@ class MAE(pl.LightningModule):
 
 model = MAE()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = MAETransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=256,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -84,7 +84,8 @@ class MAE(pl.LightningModule):
 model = MAE()
 
 transform = MAETransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -92,7 +92,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=256,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/moco.py
+++ b/examples/pytorch_lightning_distributed/moco.py
@@ -9,8 +9,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import MoCoProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -60,18 +58,16 @@ class MoCo(pl.LightningModule):
 
 model = MoCo()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = MoCoV2Transform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/msn.py
+++ b/examples/pytorch_lightning_distributed/msn.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import MSNLoss
 from lightly.models import utils
 from lightly.models.modules.heads import MSNProjectionHead
@@ -89,20 +87,16 @@ class MSN(pl.LightningModule):
 
 model = MSN()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
+transform = MSNTransform()
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
 )
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=MSNTransform())
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/msn.py
+++ b/examples/pytorch_lightning_distributed/msn.py
@@ -49,7 +49,7 @@ class MSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _, _ = batch
+        views, _ = batch
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]
@@ -89,7 +89,10 @@ model = MSN()
 
 transform = MSNTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/msn.py
+++ b/examples/pytorch_lightning_distributed/msn.py
@@ -88,7 +88,8 @@ class MSN(pl.LightningModule):
 model = MSN()
 
 transform = MSNTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning_distributed/nnclr.py
+++ b/examples/pytorch_lightning_distributed/nnclr.py
@@ -35,7 +35,7 @@ class NNCLR(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         z0 = self.memory_bank(z0, update=False)

--- a/examples/pytorch_lightning_distributed/nnclr.py
+++ b/examples/pytorch_lightning_distributed/nnclr.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import (
     NNCLRPredictionHead,
@@ -52,18 +50,16 @@ class NNCLR(pl.LightningModule):
 
 model = NNCLR()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/pmsn.py
+++ b/examples/pytorch_lightning_distributed/pmsn.py
@@ -88,7 +88,8 @@ class PMSN(pl.LightningModule):
 model = PMSN()
 
 transform = MSNTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning_distributed/pmsn.py
+++ b/examples/pytorch_lightning_distributed/pmsn.py
@@ -49,7 +49,7 @@ class PMSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _, _ = batch
+        views, _ = batch
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]
@@ -89,7 +89,10 @@ model = PMSN()
 
 transform = MSNTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/pmsn.py
+++ b/examples/pytorch_lightning_distributed/pmsn.py
@@ -8,8 +8,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import PMSNLoss
 from lightly.models import utils
 from lightly.models.modules.heads import MSNProjectionHead
@@ -89,21 +87,16 @@ class PMSN(pl.LightningModule):
 
 model = PMSN()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = MSNTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=64,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/simclr.py
+++ b/examples/pytorch_lightning_distributed/simclr.py
@@ -25,7 +25,7 @@ class SimCLR(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/simclr.py
+++ b/examples/pytorch_lightning_distributed/simclr.py
@@ -3,8 +3,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NTXentLoss
 from lightly.models.modules import SimCLRProjectionHead
 from lightly.transforms.simclr_transform import SimCLRTransform
@@ -40,18 +38,16 @@ class SimCLR(pl.LightningModule):
 
 model = SimCLR()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/simmim.py
+++ b/examples/pytorch_lightning_distributed/simmim.py
@@ -74,7 +74,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MAETransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning_distributed/simmim.py
+++ b/examples/pytorch_lightning_distributed/simmim.py
@@ -82,7 +82,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=8,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/simmim.py
+++ b/examples/pytorch_lightning_distributed/simmim.py
@@ -38,7 +38,7 @@ class SimMIM(pl.LightningModule):
         return self.decoder(x_encoded)
 
     def training_step(self, batch, batch_idx):
-        images, _, _ = batch
+        images, _ = batch
         images = images[0]  # images is a list containing only one view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
@@ -75,7 +75,10 @@ model.to(device)
 
 transform = MAETransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/simmim.py
+++ b/examples/pytorch_lightning_distributed/simmim.py
@@ -3,8 +3,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.models import utils
 from lightly.models.modules import masked_autoencoder
 from lightly.transforms.mae_transform import MAETransform  # Same transform as MAE
@@ -75,21 +73,16 @@ model = SimMIM()
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "/home/ubuntu/datasets/pascal_voc", download=False, target_transform=lambda t: 0
-)
 transform = MAETransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=8,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/simsiam.py
+++ b/examples/pytorch_lightning_distributed/simsiam.py
@@ -29,7 +29,7 @@ class SimSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         loss = 0.5 * (self.criterion(z0, p1) + self.criterion(z1, p0))

--- a/examples/pytorch_lightning_distributed/simsiam.py
+++ b/examples/pytorch_lightning_distributed/simsiam.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import NegativeCosineSimilarity
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
 from lightly.transforms import SimSiamTransform
@@ -46,18 +44,16 @@ resnet = torchvision.models.resnet18()
 backbone = nn.Sequential(*list(resnet.children())[:-1])
 model = SimSiam()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimSiamTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/swav.py
+++ b/examples/pytorch_lightning_distributed/swav.py
@@ -48,7 +48,8 @@ class SwaV(pl.LightningModule):
 model = SwaV()
 
 transform = SwaVTransform()
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning_distributed/swav.py
+++ b/examples/pytorch_lightning_distributed/swav.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import SwaVLoss
 from lightly.models.modules import SwaVProjectionHead, SwaVPrototypes
 from lightly.transforms.swav_transform import SwaVTransform
@@ -49,21 +47,16 @@ class SwaV(pl.LightningModule):
 
 model = SwaV()
 
-# we ignore object detection annotations by setting target_transform to return 0
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = SwaVTransform()
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=128,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/swav.py
+++ b/examples/pytorch_lightning_distributed/swav.py
@@ -56,7 +56,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=128,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/swav.py
+++ b/examples/pytorch_lightning_distributed/swav.py
@@ -33,7 +33,7 @@ class SwaV(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         self.prototypes.normalize()
-        crops, _, _ = batch
+        crops, _ = batch
         multi_crop_features = [self.forward(x.to(self.device)) for x in crops]
         high_resolution = multi_crop_features[:2]
         low_resolution = multi_crop_features[2:]
@@ -49,7 +49,10 @@ model = SwaV()
 
 transform = SwaVTransform()
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/tico.py
+++ b/examples/pytorch_lightning_distributed/tico.py
@@ -5,8 +5,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss.tico_loss import TiCoLoss
 from lightly.models.modules.heads import TiCoProjectionHead
 from lightly.models.utils import deactivate_requires_grad, update_momentum
@@ -58,18 +56,16 @@ class TiCo(pl.LightningModule):
 
 model = TiCo()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = SimCLRTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/tico.py
+++ b/examples/pytorch_lightning_distributed/tico.py
@@ -39,7 +39,7 @@ class TiCo(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)

--- a/examples/pytorch_lightning_distributed/vicreg.py
+++ b/examples/pytorch_lightning_distributed/vicreg.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import VICRegLoss
 
 ## The projection head is the same as the Barlow Twins one
@@ -46,18 +44,16 @@ class VICReg(pl.LightningModule):
 
 model = VICReg()
 
-cifar10 = torchvision.datasets.CIFAR10("datasets/cifar10", download=True)
 transform = VICRegTransform(input_size=32)
-dataset = LightlyDataset.from_torch_dataset(cifar10, transform=transform)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
-# dataset = LightlyDataset("path/to/folder")
-
-collate_fn = MultiViewCollate()
+# dataset = LightlyDataset("path/to/folder", transform=transform)
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
     batch_size=256,
-    collate_fn=collate_fn,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/vicreg.py
+++ b/examples/pytorch_lightning_distributed/vicreg.py
@@ -31,7 +31,7 @@ class VICReg(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _, _ = batch
+        (x0, x1), _ = batch
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -7,8 +7,6 @@ import torch
 import torchvision
 from torch import nn
 
-from lightly.data import LightlyDataset
-from lightly.data.multi_view_collate import MultiViewCollate
 from lightly.loss import VICRegLLoss
 
 ## The global projection head is the same as the Barlow Twins one
@@ -55,20 +53,16 @@ class VICRegL(pl.LightningModule):
 
 model = VICRegL()
 
-pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, target_transform=lambda t: 0
-)
 transform = VICRegLTransform(n_local_views=0)
-dataset = LightlyDataset.from_torch_dataset(pascal_voc, transform=transform)
+dataset = pascal_voc = torchvision.datasets.VOCDetection(
+    "datasets/pascal_voc", download=True, transform=transform
+)
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
 
-collate_fn = MultiViewCollate()
-
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=256,
-    collate_fn=collate_fn,
+    batch_size=64,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -54,7 +54,8 @@ class VICRegL(pl.LightningModule):
 model = VICRegL()
 
 transform = VICRegLTransform(n_local_views=0)
-dataset = pascal_voc = torchvision.datasets.VOCDetection(
+# we ignore object detection annotations by setting target_transform to return 0
+dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -62,7 +62,7 @@ dataset = pascal_voc = torchvision.datasets.VOCDetection(
 
 dataloader = torch.utils.data.DataLoader(
     dataset,
-    batch_size=64,
+    batch_size=256,
     shuffle=True,
     drop_last=True,
     num_workers=8,

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -55,7 +55,10 @@ model = VICRegL()
 
 transform = VICRegLTransform(n_local_views=0)
 dataset = pascal_voc = torchvision.datasets.VOCDetection(
-    "datasets/pascal_voc", download=True, transform=transform
+    "datasets/pascal_voc",
+    download=True,
+    transform=transform,
+    target_transform=lambda t: 0,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -1348,7 +1348,6 @@ class VICRegLCollateFunction(nn.Module):
 def _deprecation_warning_collate_functions() -> None:
     warn(
         "Collate functions are deprecated and will be removed in favor of transforms in v1.4.0.\n"
-        "Please use MultiViewCollate in `lightly.data.multi_view_collate` together with the correct transform for your model instead.\n"
         "See https://docs.lightly.ai/self-supervised-learning/examples/models.html for examples.",
         category=DeprecationWarning,
     )


### PR DESCRIPTION
Closes #1235. 

* Remove MultiViewCollate from examples.
* Do not convert torchvision dataset to lightly dataset in examples.
* Remove MultiViewCollate from benchmarks.
* Remove MultiViewCollate from examples in docs.
* Keep MultiViewCollate in pip api docs.

## How has it been tested?

- [x] Test one Cifar10 and one Pascal VOC example.
- [X] Search for occurrences of `MultiViewCollate` 

```
$ grep -r MultiViewCollate ./
./docs/source/lightly.data.rst:.. autoclass:: lightly.data.multi_view_collate.MultiViewCollate
./tests/data/test_multi_view_collate.py:from lightly.data.multi_view_collate import MultiViewCollate
./tests/data/test_multi_view_collate.py:    multi_view_collate = MultiViewCollate()
./tests/data/test_multi_view_collate.py:    multi_view_collate = MultiViewCollate()
./tests/data/test_multi_view_collate.py:    multi_view_collate = MultiViewCollate()
./tests/data/test_data_collate.py:    MultiViewCollateFunction,
./tests/data/test_data_collate.py:        collate_fn = MultiViewCollateFunction(trans)
./lightly/data/collate.py:class MultiViewCollateFunction(nn.Module):
./lightly/data/collate.py:class MultiCropCollateFunction(MultiViewCollateFunction):
./lightly/data/collate.py:class DINOCollateFunction(MultiViewCollateFunction):
./lightly/data/collate.py:class MAECollateFunction(MultiViewCollateFunction):
./lightly/data/collate.py:class MSNCollateFunction(MultiViewCollateFunction):
./lightly/data/collate.py:class SMoGCollateFunction(MultiViewCollateFunction):
./lightly/data/multi_view_collate.py:class MultiViewCollate:
./lightly/data/multi_view_collate.py:        >>> dataloader = DataLoader(dataset, batch_size=4, collate_fn=MultiViewCollate())
./lightly/data/multi_view_collate.py:            warn("MultiViewCollate received empty batch.")
./lightly/utils/debug.py:from lightly.data.collate import BaseCollateFunction, MultiViewCollateFunction
./lightly/utils/debug.py:    collate_function: Union[BaseCollateFunction, MultiViewCollateFunction],
./lightly/utils/debug.py:            Must be of type BaseCollateFunction or MultiViewCollateFunction.
./lightly/utils/debug.py:    elif isinstance(collate_function, MultiViewCollateFunction):
./lightly/utils/debug.py:            "(BaseCollateFunction, MultiViewCollateFunction) "
./lightly/utils/debug.py:    collate_function: Union[BaseCollateFunction, MultiViewCollateFunction],
./lightly/utils/debug.py:            Must be of type BaseCollateFunction or MultiViewCollateFunction.
./lightly/utils/debug.py:        MultiViewCollateFunctions all the generated views are shown.
```