### PR TITLE
Add note about benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ tuned for maximum accuracy. For detailed results and more info about the benchma
 
 ### Imagenet
 
+**Note**: All results are obtained with SimCLR evaluation settings.
+
 | Model       | Backbone | Batch Size | Epochs | Linear Top1 | Finetune Top1 | KNN Top1 | Tensorboard | Checkpoint |
 |-------------|----------|------------|--------|-------------|---------------|----------|-------------|------------|
 | SimCLR      | Res50    |        256 |    100 |        63.2 |           N/A |     44.9 |      [link](https://tensorboard.dev/experiment/JwNs9E02TeeQkS7aljh8dA) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-05-04_09-02-54/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |

--- a/README.md
+++ b/README.md
@@ -280,7 +280,12 @@ tuned for maximum accuracy. For detailed results and more info about the benchma
 
 ### Imagenet
 
-**Note**: All results are obtained with SimCLR evaluation settings.
+> **Note**: Evaluation settings are based on these papers:
+> * Linear: [SimCLR](https://arxiv.org/abs/2002.05709)
+> * Finetune: [SimCLR](https://arxiv.org/abs/2002.05709)
+> * KNN: [InstDisc](https://arxiv.org/abs/1805.01978)
+> 
+> See the [benchmarking scripts](./benchmarks/imagenet/resnet50/) for details.
 
 | Model       | Backbone | Batch Size | Epochs | Linear Top1 | Finetune Top1 | KNN Top1 | Tensorboard | Checkpoint |
 |-------------|----------|------------|--------|-------------|---------------|----------|-------------|------------|

--- a/benchmarks/imagenet/resnet50/finetune_eval.py
+++ b/benchmarks/imagenet/resnet50/finetune_eval.py
@@ -49,7 +49,19 @@ def finetune_eval(
 ) -> None:
     """Runs fine-tune evaluation on the given model.
 
-    Parameters follow SimCLR settings.
+    Parameters follow SimCLR [0] settings.
+
+    The most important settings are:
+        - Backbone: Frozen
+        - Epochs: 30
+        - Optimizer: SGD
+        - Base Learning Rate: 0.05
+        - Momentum: 0.9
+        - Weight Decay: 0.0
+        - LR Schedule: Cosine without warmup
+
+    References:
+        - [0]: SimCLR, 2020, https://arxiv.org/abs/2002.05709
     """
     print("Running fine-tune evaluation...")
 

--- a/benchmarks/imagenet/resnet50/knn_eval.py
+++ b/benchmarks/imagenet/resnet50/knn_eval.py
@@ -23,6 +23,17 @@ def knn_eval(
     devices: int,
     num_classes: int,
 ) -> None:
+    """Runs KNN evaluation on the given model.
+
+    Parameters follow InstDisc [0] settings.
+
+    The most important settings are:
+        - Num nearest neighbors: 200
+        - Temperature: 0.1
+
+    References:
+       - [0]: InstDict, 2018, https://arxiv.org/abs/1805.01978
+    """
     print("Running KNN evaluation...")
 
     # Setup training data.

--- a/benchmarks/imagenet/resnet50/linear_eval.py
+++ b/benchmarks/imagenet/resnet50/linear_eval.py
@@ -26,7 +26,19 @@ def linear_eval(
 ) -> None:
     """Runs a linear evaluation on the given model.
 
-    Parameters follow SimCLR settings.
+    Parameters follow SimCLR [0] settings.
+
+    The most important settings are:
+        - Backbone: Frozen
+        - Epochs: 90
+        - Optimizer: SGD
+        - Base Learning Rate: 0.1
+        - Momentum: 0.9
+        - Weight Decay: 0.0
+        - LR Schedule: Cosine without warmup
+
+    References:
+        - [0]: SimCLR, 2020, https://arxiv.org/abs/2002.05709
     """
     print("Running linear evaluation...")
 

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -20,7 +20,14 @@ Self-supervised training of a SimCLR model for 100 epochs with total batch size 
 takes about two days on two GeForce RTX 4090 GPUs. You can reproduce the results with
 the code at `benchmarks/imagenet/resnet50 <https://github.com/lightly-ai/lightly/tree/master/benchmarks/imagenet/resnet50>`_.
 
-.. note:: All results are obtained with SimCLR evaluation settings.
+Evaluation settings are based on these papers:
+
+- Linear: `SimCLR <https://arxiv.org/abs/2002.05709>`_
+- Finetune: `SimCLR <https://arxiv.org/abs/2002.05709>`_
+- KNN: `InstDisc <https://arxiv.org/abs/1805.01978>`_
+
+See the `benchmarking scripts <https://github.com/lightly-ai/lightly/tree/master/benchmarks/imagenet/resnet50>`_ for details.
+
 
 .. csv-table:: Imagenet benchmark results.
   :header: "Model", "Backbone", "Batch Size", "Epochs", "Linear Top1", "Linear Top5", "Finetune Top1", "Finetune Top5", "KNN Top1", "KNN Top5", "Tensorboard", "Checkpoint"

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -20,6 +20,8 @@ Self-supervised training of a SimCLR model for 100 epochs with total batch size 
 takes about two days on two GeForce RTX 4090 GPUs. You can reproduce the results with
 the code at `benchmarks/imagenet/resnet50 <https://github.com/lightly-ai/lightly/tree/master/benchmarks/imagenet/resnet50>`_.
 
+.. note:: All results are obtained with SimCLR evaluation settings.
+
 .. csv-table:: Imagenet benchmark results.
   :header: "Model", "Backbone", "Batch Size", "Epochs", "Linear Top1", "Linear Top5", "Finetune Top1", "Finetune Top5", "KNN Top1", "KNN Top5", "Tensorboard", "Checkpoint"
   :widths: 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20

--- a/lightly/utils/benchmarking/knn_classifier.py
+++ b/lightly/utils/benchmarking/knn_classifier.py
@@ -23,11 +23,10 @@ class KNNClassifier(LightningModule):
     ):
         """KNN classifier for benchmarking.
 
-        Settings based on "Unsupervised Feature Learning via Non-Parametric Instance
-        Discrimination" [0]. Code adapted from MoCo [1].
+        Settings based on InstDisc [0]. Code adapted from MoCo [1].
 
-        - [0]: https://arxiv.org/pdf/1805.01978v1.pdf
-        - [1]: https://github.com/facebookresearch/moco
+        - [0]: InstDisc, 2018, https://arxiv.org/pdf/1805.01978v1.pdf
+        - [1]: MoCo, 2019, https://github.com/facebookresearch/moco
 
         Args:
             model:


### PR DESCRIPTION
## Changes

* Add note that benchmark results follow SimCLR evaluation settings


<img width="767" alt="Screen Shot 2023-06-07 at 10 51 08" src="https://github.com/lightly-ai/lightly/assets/43336610/aea58bc6-5cbd-4ed0-b044-b26acc038c57">
