### PR TITLE
Update value constraints for bounding boxes and keypoints

### DIFF
--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation.py
@@ -28,7 +28,7 @@ class PredictionSingletonInstanceSegmentation(PredictionSingletonBase):
     PredictionSingletonInstanceSegmentation
     """
     segmentation: conlist(conint(strict=True, ge=0)) = Field(..., description="Run Length Encoding (RLE) as outlined by https://docs.lightly.ai/docs/prediction-format#semantic-segmentation ")
-    bbox: conlist(conint(strict=True, ge=0), max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
+    bbox: conlist(Union[confloat(ge=0, strict=True), conint(ge=0, strict=True)], max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
     probabilities: Optional[conlist(Union[confloat(le=1, ge=0, strict=True), conint(le=1, ge=0, strict=True)])] = Field(None, description="The probabilities of it being a certain category other than the one which was selected. The sum of all probabilities should equal 1.")
     __properties = ["type", "taskName", "cropDatasetId", "cropSampleId", "categoryId", "score", "segmentation", "bbox", "probabilities"]
 

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation_all_of.py
@@ -27,7 +27,7 @@ class PredictionSingletonInstanceSegmentationAllOf(BaseModel):
     PredictionSingletonInstanceSegmentationAllOf
     """
     segmentation: conlist(conint(strict=True, ge=0)) = Field(..., description="Run Length Encoding (RLE) as outlined by https://docs.lightly.ai/docs/prediction-format#semantic-segmentation ")
-    bbox: conlist(conint(strict=True, ge=0), max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
+    bbox: conlist(Union[confloat(ge=0, strict=True), conint(ge=0, strict=True)], max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
     probabilities: Optional[conlist(Union[confloat(le=1, ge=0, strict=True), conint(le=1, ge=0, strict=True)])] = Field(None, description="The probabilities of it being a certain category other than the one which was selected. The sum of all probabilities should equal 1.")
     __properties = ["segmentation", "bbox", "probabilities"]
 

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection.py
@@ -20,14 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictInt, confloat, conint, conlist
+from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_base import PredictionSingletonBase
 
 class PredictionSingletonKeypointDetection(PredictionSingletonBase):
     """
     PredictionSingletonKeypointDetection
     """
-    keypoints: conlist(StrictInt, min_items=3) = Field(..., description="[x1, y2, v1, ..., xk, yk, vk] as outlined by the coco format https://cocodataset.org/#format-results ")
+    keypoints: conlist(Union[confloat(ge=0, strict=True), conint(ge=0, strict=True)], min_items=3) = Field(..., description="[x1, y2, v1, ..., xk, yk, vk] as outlined by the coco format https://cocodataset.org/#format-results ")
     probabilities: Optional[conlist(Union[confloat(le=1, ge=0, strict=True), conint(le=1, ge=0, strict=True)])] = Field(None, description="The probabilities of it being a certain category other than the one which was selected. The sum of all probabilities should equal 1.")
     __properties = ["type", "taskName", "cropDatasetId", "cropSampleId", "categoryId", "score", "keypoints", "probabilities"]
 

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection_all_of.py
@@ -20,13 +20,13 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictInt, confloat, conint, conlist
+from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
 
 class PredictionSingletonKeypointDetectionAllOf(BaseModel):
     """
     PredictionSingletonKeypointDetectionAllOf
     """
-    keypoints: conlist(StrictInt, min_items=3) = Field(..., description="[x1, y2, v1, ..., xk, yk, vk] as outlined by the coco format https://cocodataset.org/#format-results ")
+    keypoints: conlist(Union[confloat(ge=0, strict=True), conint(ge=0, strict=True)], min_items=3) = Field(..., description="[x1, y2, v1, ..., xk, yk, vk] as outlined by the coco format https://cocodataset.org/#format-results ")
     probabilities: Optional[conlist(Union[confloat(le=1, ge=0, strict=True), conint(le=1, ge=0, strict=True)])] = Field(None, description="The probabilities of it being a certain category other than the one which was selected. The sum of all probabilities should equal 1.")
     __properties = ["keypoints", "probabilities"]
 

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection.py
@@ -27,7 +27,7 @@ class PredictionSingletonObjectDetection(PredictionSingletonBase):
     """
     PredictionSingletonObjectDetection
     """
-    bbox: conlist(conint(strict=True, ge=0), max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
+    bbox: conlist(Union[confloat(ge=0, strict=True), conint(ge=0, strict=True)], max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
     probabilities: Optional[conlist(Union[confloat(le=1, ge=0, strict=True), conint(le=1, ge=0, strict=True)])] = Field(None, description="The probabilities of it being a certain category other than the one which was selected. The sum of all probabilities should equal 1.")
     __properties = ["type", "taskName", "cropDatasetId", "cropSampleId", "categoryId", "score", "bbox", "probabilities"]
 

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection_all_of.py
@@ -26,7 +26,7 @@ class PredictionSingletonObjectDetectionAllOf(BaseModel):
     """
     PredictionSingletonObjectDetectionAllOf
     """
-    bbox: conlist(conint(strict=True, ge=0), max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
+    bbox: conlist(Union[confloat(ge=0, strict=True), conint(ge=0, strict=True)], max_items=4, min_items=4) = Field(..., description="The bbox of where a prediction task yielded a finding. [x, y, width, height]")
     probabilities: Optional[conlist(Union[confloat(le=1, ge=0, strict=True), conint(le=1, ge=0, strict=True)])] = Field(None, description="The probabilities of it being a certain category other than the one which was selected. The sum of all probabilities should equal 1.")
     __properties = ["bbox", "probabilities"]
 


### PR DESCRIPTION
According to COCO's [description](https://cocodataset.org/#format-results), coordinates in bounding boxes and keypoints can be floating point values. This PR updates the value constraints accordingly.