### PR TITLE
Use transforms instead of collate function in tutorials

### DIFF
--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -313,7 +313,7 @@ class Classifier(pl.LightningModule):
         self.log("train_loss_fc", loss)
         return loss
 
-    def training_epoch_end(self, outputs):
+    def on_train_epoch_end(self):
         self.custom_histogram_weights()
 
     # We provide a helper method to log weights in tensorboard
@@ -331,14 +331,15 @@ class Classifier(pl.LightningModule):
         _, predicted = torch.max(y_hat, 1)
         num = predicted.shape[0]
         correct = (predicted == y).float().sum()
+        self.validation_step_outputs.append((num, correct))
         return num, correct
 
-    def validation_epoch_end(self, outputs):
+    def on_validation_epoch_end(self):
         # calculate and log top1 accuracy
-        if outputs:
+        if self.validation_step_outputs:
             total_num = 0
             total_correct = 0
-            for num, correct in outputs:
+            for num, correct in self.validation_step_outputs:
                 total_num += num
                 total_correct += correct
             acc = total_correct / total_num

--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -260,7 +260,7 @@ class MocoModel(pl.LightningModule):
         self.log("train_loss_ssl", loss)
         return loss
 
-    def training_epoch_end(self, outputs):
+    def on_train_epoch_end(self, outputs):
         self.custom_histogram_weights()
 
     # We provide a helper method to log weights in tensorboard

--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -49,7 +49,7 @@ import torch
 import torch.nn as nn
 import torchvision
 
-from lightly.data import LightlyDataset, SimCLRCollateFunction, collate
+from lightly.data import LightlyDataset
 from lightly.loss import NTXentLoss
 from lightly.models import ResNetGenerator
 from lightly.models.modules.heads import MoCoProjectionHead
@@ -59,6 +59,7 @@ from lightly.models.utils import (
     deactivate_requires_grad,
     update_momentum,
 )
+from lightly.transforms import MoCoV2Transform, utils
 
 # %%
 # Configuration
@@ -113,8 +114,7 @@ pl.seed_everything(seed)
 # ------------------------------------
 #
 # We start with our data preprocessing pipeline. We can implement augmentations
-# from the MOCO paper using the collate functions provided by lightly. For MoCo v2,
-# we can use the same augmentations as SimCLR but override the input size and blur.
+# from the MoCo paper using the transforms provided by lightly.
 # Images from the CIFAR-10 dataset have a resolution of 32x32 pixels. Let's use
 # this resolution to train our model.
 #
@@ -123,8 +123,8 @@ pl.seed_everything(seed)
 #   in increasing the resolution. A higher resolution results in higher memory
 #   consumption and to compensate for that we would need to reduce the batch size.
 
-# MoCo v2 uses SimCLR augmentations, additionally, disable blur
-collate_fn = SimCLRCollateFunction(
+# disable blur because we're working with tiny images
+transform = MoCoV2Transform(
     input_size=32,
     gaussian_blur=0.0,
 )
@@ -142,8 +142,8 @@ train_classifier_transforms = torchvision.transforms.Compose(
         torchvision.transforms.RandomHorizontalFlip(),
         torchvision.transforms.ToTensor(),
         torchvision.transforms.Normalize(
-            mean=collate.imagenet_normalize["mean"],
-            std=collate.imagenet_normalize["std"],
+            mean=utils.IMAGENET_NORMALIZE["mean"],
+            std=utils.IMAGENET_NORMALIZE["std"],
         ),
     ]
 )
@@ -154,14 +154,14 @@ test_transforms = torchvision.transforms.Compose(
         torchvision.transforms.Resize((32, 32)),
         torchvision.transforms.ToTensor(),
         torchvision.transforms.Normalize(
-            mean=collate.imagenet_normalize["mean"],
-            std=collate.imagenet_normalize["std"],
+            mean=utils.IMAGENET_NORMALIZE["mean"],
+            std=utils.IMAGENET_NORMALIZE["std"],
         ),
     ]
 )
 
 # We use the moco augmentations for training moco
-dataset_train_moco = LightlyDataset(input_dir=path_to_train)
+dataset_train_moco = LightlyDataset(input_dir=path_to_train, transform=transform)
 
 # Since we also train a linear classifier on the pre-trained moco model we
 # reuse the test augmentations here (MoCo augmentations are very strong and
@@ -182,7 +182,6 @@ dataloader_train_moco = torch.utils.data.DataLoader(
     dataset_train_moco,
     batch_size=batch_size,
     shuffle=True,
-    collate_fn=collate_fn,
     drop_last=True,
     num_workers=num_workers,
 )

--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -260,7 +260,7 @@ class MocoModel(pl.LightningModule):
         self.log("train_loss_ssl", loss)
         return loss
 
-    def on_train_epoch_end(self, outputs):
+    def on_train_epoch_end(self):
         self.custom_histogram_weights()
 
     # We provide a helper method to log weights in tensorboard

--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -345,6 +345,7 @@ class Classifier(pl.LightningModule):
                 total_correct += correct
             acc = total_correct / total_num
             self.log("val_acc", acc, on_epoch=True, prog_bar=True)
+            self.validation_step_outputs.clear()
 
     def configure_optimizers(self):
         optim = torch.optim.SGD(self.fc.parameters(), lr=30.0)

--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -300,6 +300,7 @@ class Classifier(pl.LightningModule):
         self.fc = nn.Linear(512, 10)
 
         self.criterion = nn.CrossEntropyLoss()
+        self.validation_step_outputs = []
 
     def forward(self, x):
         y_hat = self.backbone(x).flatten(start_dim=1)

--- a/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
+++ b/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
@@ -261,7 +261,7 @@ checkpointer.save("my_model")
 
 # %%
 #
-# The :py:class:`lightly.transforms.simclr.SimCLRTransform` applies an ImageNet
+# The :py:class:`~lightly.transforms.simclr.SimCLRTransform` applies an ImageNet
 # normalization of the input images by default. Therefore, we have to normalize
 # the input images at training time, too. Since Detectron2 uses an input space
 # in the range 0 - 255, we use the numbers above.

--- a/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
+++ b/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
@@ -63,7 +63,8 @@ import torch
 from detectron2 import config, modeling
 from detectron2.checkpoint import DetectionCheckpointer
 
-from lightly.data import LightlyDataset, SimCLRCollateFunction
+from lightly.data import LightlyDataset
+from lightly.transforms import SimCLRTransform
 from lightly.loss import NTXentLoss
 from lightly.models.modules import SimCLRProjectionHead
 
@@ -176,15 +177,14 @@ projection_head = SimCLRProjectionHead(
 # We don't go into detail here about using the optimal augmentations.
 # You can learn more about the different augmentations and learned invariances
 # here: :ref:`lightly-advanced`.
-collate_fn = SimCLRCollateFunction(input_size=input_size)
+transform = SimCLRTransform(input_size=input_size)
 
-dataset_train_simclr = LightlyDataset(input_dir=data_path)
+dataset_train_simclr = LightlyDataset(input_dir=data_path, transform=transform)
 
 dataloader_train_simclr = torch.utils.data.DataLoader(
     dataset_train_simclr,
     batch_size=batch_size,
     shuffle=True,
-    collate_fn=collate_fn,
     drop_last=True,
     num_workers=num_workers,
 )
@@ -261,7 +261,7 @@ checkpointer.save("my_model")
 
 # %%
 #
-# The :py:class:`lightly.data.collate.SimCLRCollateFunction` applies an ImageNet
+# The :py:class:`lightly.transforms.simclr.SimCLRTransform` applies an ImageNet
 # normalization of the input images by default. Therefore, we have to normalize
 # the input images at training time, too. Since Detectron2 uses an input space
 # in the range 0 - 255, we use the numbers above.

--- a/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
+++ b/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
@@ -64,9 +64,9 @@ from detectron2 import config, modeling
 from detectron2.checkpoint import DetectionCheckpointer
 
 from lightly.data import LightlyDataset
-from lightly.transforms import SimCLRTransform
 from lightly.loss import NTXentLoss
 from lightly.models.modules import SimCLRProjectionHead
+from lightly.transforms import SimCLRTransform
 
 # %%
 # Configuration

--- a/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
+++ b/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
@@ -46,7 +46,7 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.preprocessing import normalize
 
 from lightly.data import LightlyDataset
-from lightly.transforms import SimCLRTransform , utils
+from lightly.transforms import SimCLRTransform, utils
 
 # %%
 # Configuration

--- a/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
+++ b/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
@@ -43,8 +43,8 @@ import torchvision
 
 from lightly.data import LightlyDataset
 from lightly.loss import NegativeCosineSimilarity
-from lightly.transforms import SimCLRTransform, utils
 from lightly.models.modules.heads import SimSiamPredictionHead, SimSiamProjectionHead
+from lightly.transforms import SimCLRTransform, utils
 
 # %%
 # Configuration

--- a/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
+++ b/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
@@ -41,8 +41,9 @@ import torch
 import torch.nn as nn
 import torchvision
 
-from lightly.data import ImageCollateFunction, LightlyDataset, collate
+from lightly.data import LightlyDataset
 from lightly.loss import NegativeCosineSimilarity
+from lightly.transforms import SimCLRTransform, utils
 from lightly.models.modules.heads import SimSiamPredictionHead, SimSiamProjectionHead
 
 # %%
@@ -89,7 +90,7 @@ path_to_data = "/datasets/sentinel-2-italy-v1/"
 #
 
 # define the augmentations for self-supervised learning
-collate_fn = ImageCollateFunction(
+transform = SimCLRTransform(
     input_size=input_size,
     # require invariance to flips and rotations
     hf_prob=0.5,
@@ -106,16 +107,14 @@ collate_fn = ImageCollateFunction(
     cj_sat=0.1,
 )
 
-# create a lightly dataset for training, since the augmentations are handled
-# by the collate function, there is no need to apply additional ones here
-dataset_train_simsiam = LightlyDataset(input_dir=path_to_data)
+# create a lightly dataset for training with augmentations
+dataset_train_simsiam = LightlyDataset(input_dir=path_to_data, transform=transform)
 
 # create a dataloader for training
 dataloader_train_simsiam = torch.utils.data.DataLoader(
     dataset_train_simsiam,
     batch_size=batch_size,
     shuffle=True,
-    collate_fn=collate_fn,
     drop_last=True,
     num_workers=num_workers,
 )
@@ -128,8 +127,8 @@ test_transforms = torchvision.transforms.Compose(
         torchvision.transforms.Resize((input_size, input_size)),
         torchvision.transforms.ToTensor(),
         torchvision.transforms.Normalize(
-            mean=collate.imagenet_normalize["mean"],
-            std=collate.imagenet_normalize["std"],
+            mean=utils.IMAGENET_NORMALIZE["mean"],
+            std=utils.IMAGENET_NORMALIZE["std"],
         ),
     ]
 )


### PR DESCRIPTION
# Use transforms instead of collate function in tutorials

Fix all tutorials to use transforms instead of collate functions. I ran all tutorials to make sure they work as expected.