### PR TITLE
Update example batch unpacking

### DIFF
--- a/examples/pytorch/barlowtwins.py
+++ b/examples/pytorch/barlowtwins.py
@@ -51,7 +51,8 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch/byol.py
+++ b/examples/pytorch/byol.py
@@ -73,7 +73,8 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         update_momentum(model.backbone, model.backbone_momentum, m=momentum_val)
         update_momentum(
             model.projection_head, model.projection_head_momentum, m=momentum_val

--- a/examples/pytorch/dcl.py
+++ b/examples/pytorch/dcl.py
@@ -54,7 +54,8 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch/dino.py
+++ b/examples/pytorch/dino.py
@@ -85,7 +85,8 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for views, _ in dataloader:
+    for batch in dataloader:
+        views = batch[0]
         update_momentum(model.student_backbone, model.teacher_backbone, m=momentum_val)
         update_momentum(model.student_head, model.teacher_head, m=momentum_val)
         views = [view.to(device) for view in views]

--- a/examples/pytorch/fastsiam.py
+++ b/examples/pytorch/fastsiam.py
@@ -54,7 +54,8 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for views, _ in dataloader:
+    for batch in dataloader:
+        views = batch[0]
         features = [model(view.to(device)) for view in views]
         zs = torch.stack([z for z, _ in features])
         ps = torch.stack([p for _, p in features])

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -101,8 +101,9 @@ optimizer = torch.optim.AdamW(model.parameters(), lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for images, _ in dataloader:
-        images = images[0].to(device)  # images is a list containing only one view
+    for batch in dataloader:
+        views = batch[0]
+        images = views[0].to(device)  # views contains only a single view
         predictions, targets = model(images)
         loss = criterion(predictions, targets)
         total_loss += loss.detach()

--- a/examples/pytorch/moco.py
+++ b/examples/pytorch/moco.py
@@ -71,7 +71,8 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for (x_query, x_key), _ in dataloader:
+    for batch in dataloader:
+        x_query, x_key = batch[0]
         update_momentum(model.backbone, model.backbone_momentum, m=momentum_val)
         update_momentum(
             model.projection_head, model.projection_head_momentum, m=momentum_val

--- a/examples/pytorch/msn.py
+++ b/examples/pytorch/msn.py
@@ -94,7 +94,8 @@ optimizer = torch.optim.AdamW(params, lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for views, _ in dataloader:
+    for batch in dataloader:
+        views = batch[0]
         utils.update_momentum(model.anchor_backbone, model.backbone, 0.996)
         utils.update_momentum(
             model.anchor_projection_head, model.projection_head, 0.996

--- a/examples/pytorch/nnclr.py
+++ b/examples/pytorch/nnclr.py
@@ -62,7 +62,8 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0, p0 = model(x0)

--- a/examples/pytorch/pmsn.py
+++ b/examples/pytorch/pmsn.py
@@ -94,7 +94,8 @@ optimizer = torch.optim.AdamW(params, lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for views, _ in dataloader:
+    for batch in dataloader:
+        views = batch[0]
         utils.update_momentum(model.anchor_backbone, model.backbone, 0.996)
         utils.update_momentum(
             model.anchor_projection_head, model.projection_head, 0.996

--- a/examples/pytorch/simclr.py
+++ b/examples/pytorch/simclr.py
@@ -51,7 +51,8 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch/simmim.py
+++ b/examples/pytorch/simmim.py
@@ -88,8 +88,9 @@ optimizer = torch.optim.AdamW(model.parameters(), lr=1.5e-4)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for images, _ in dataloader:
-        images = images[0].to(device)  # images is a list containing only one view
+    for batch in dataloader:
+        views = batch[0]
+        images = views[0].to(device)  # views contains only a single view
         predictions, targets = model(images)
 
         loss = criterion(predictions, targets)

--- a/examples/pytorch/simsiam.py
+++ b/examples/pytorch/simsiam.py
@@ -54,7 +54,8 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0, p0 = model(x0)

--- a/examples/pytorch/smog.py
+++ b/examples/pytorch/smog.py
@@ -117,7 +117,7 @@ print("Starting Training")
 for epoch in range(10):
     total_loss = 0
     for batch_idx, batch in enumerate(dataloader):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
 
         if batch_idx % 2:
             # swap batches every second iteration

--- a/examples/pytorch/swav.py
+++ b/examples/pytorch/swav.py
@@ -58,9 +58,10 @@ optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for batch, _ in dataloader:
+    for batch in dataloader:
+        views = batch[0]
         model.prototypes.normalize()
-        multi_crop_features = [model(x.to(device)) for x in batch]
+        multi_crop_features = [model(view.to(device)) for view in views]
         high_resolution = multi_crop_features[:2]
         low_resolution = multi_crop_features[2:]
         loss = criterion(high_resolution, low_resolution)

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -103,9 +103,10 @@ optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for batch, _ in dataloader:
-        batch = [x.to(device) for x in batch]
-        high_resolution, low_resolution = batch[:2], batch[2:]
+    for batch in dataloader:
+        views = batch[0]
+        views = [view.to(device) for view in views]
+        high_resolution, low_resolution = views[:2], views[2:]
         high_resolution, low_resolution, queue = model(
             high_resolution, low_resolution, epoch
         )

--- a/examples/pytorch/tico.py
+++ b/examples/pytorch/tico.py
@@ -72,7 +72,8 @@ print("Starting Training")
 for epoch in range(epochs):
     total_loss = 0
     momentum_val = cosine_schedule(epoch, epochs, 0.996, 1)
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         update_momentum(model.backbone, model.backbone_momentum, m=momentum_val)
         update_momentum(
             model.projection_head, model.projection_head_momentum, m=momentum_val

--- a/examples/pytorch/vicreg.py
+++ b/examples/pytorch/vicreg.py
@@ -50,7 +50,8 @@ optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 print("Starting Training")
 for epoch in range(10):
     total_loss = 0
-    for (x0, x1), _ in dataloader:
+    for batch in dataloader:
+        x0, x1 = batch[0]
         x0 = x0.to(device)
         x1 = x1.to(device)
         z0 = model(x0)

--- a/examples/pytorch_lightning/barlowtwins.py
+++ b/examples/pytorch_lightning/barlowtwins.py
@@ -26,7 +26,7 @@ class BarlowTwins(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning/byol.py
+++ b/examples/pytorch_lightning/byol.py
@@ -48,7 +48,7 @@ class BYOL(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         p0 = self.forward(x0)
         z0 = self.forward_momentum(x0)
         p1 = self.forward(x1)

--- a/examples/pytorch_lightning/dcl.py
+++ b/examples/pytorch_lightning/dcl.py
@@ -28,7 +28,7 @@ class DCL(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning/dino.py
+++ b/examples/pytorch_lightning/dino.py
@@ -52,7 +52,7 @@ class DINO(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.student_backbone, self.teacher_backbone, m=momentum)
         update_momentum(self.student_head, self.teacher_head, m=momentum)
-        views, _ = batch
+        views = batch[0]
         views = [view.to(self.device) for view in views]
         global_views = views[:2]
         teacher_out = [self.forward_teacher(view) for view in global_views]

--- a/examples/pytorch_lightning/fastsiam.py
+++ b/examples/pytorch_lightning/fastsiam.py
@@ -29,7 +29,7 @@ class FastSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        views, _ = batch
+        views = batch[0]
         features = [self.forward(view) for view in views]
         zs = torch.stack([z for z, _ in features])
         ps = torch.stack([p for _, p in features])

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -57,8 +57,8 @@ class MAE(pl.LightningModule):
         return x_pred
 
     def training_step(self, batch, batch_idx):
-        images, _ = batch
-        images = images[0]  # images is a list containing only one view
+        views = batch[0]
+        images = views[0]  # views contains only a single view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
             size=(batch_size, self.sequence_length),

--- a/examples/pytorch_lightning/moco.py
+++ b/examples/pytorch_lightning/moco.py
@@ -45,7 +45,7 @@ class MoCo(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)
-        (x_query, x_key), _, _ = batch
+        x_query, x_key = batch[0]
         query = self.forward(x_query)
         key = self.forward_momentum(x_key)
         loss = self.criterion(query, key)

--- a/examples/pytorch_lightning/msn.py
+++ b/examples/pytorch_lightning/msn.py
@@ -47,7 +47,7 @@ class MSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _ = batch
+        views = batch[0]
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]

--- a/examples/pytorch_lightning/nnclr.py
+++ b/examples/pytorch_lightning/nnclr.py
@@ -35,7 +35,7 @@ class NNCLR(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         z0 = self.memory_bank(z0, update=False)

--- a/examples/pytorch_lightning/pmsn.py
+++ b/examples/pytorch_lightning/pmsn.py
@@ -47,7 +47,7 @@ class PMSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _ = batch
+        views = batch[0]
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]

--- a/examples/pytorch_lightning/simclr.py
+++ b/examples/pytorch_lightning/simclr.py
@@ -26,7 +26,7 @@ class SimCLR(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning/simmim.py
+++ b/examples/pytorch_lightning/simmim.py
@@ -38,8 +38,8 @@ class SimMIM(pl.LightningModule):
         return self.decoder(x_encoded)
 
     def training_step(self, batch, batch_idx):
-        images, _ = batch
-        images = images[0]  # images is a list containing only one view
+        views = batch[0]
+        images = views[0]  # views contains only a single view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
             size=(batch_size, self.sequence_length),

--- a/examples/pytorch_lightning/simsiam.py
+++ b/examples/pytorch_lightning/simsiam.py
@@ -29,7 +29,7 @@ class SimSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         loss = 0.5 * (self.criterion(z0, p1) + self.criterion(z1, p0))

--- a/examples/pytorch_lightning/smog.py
+++ b/examples/pytorch_lightning/smog.py
@@ -76,7 +76,7 @@ class SMoGModel(pl.LightningModule):
                 self.projection_head, self.projection_head_momentum, 0.99
             )
 
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
 
         if batch_idx % 2:
             # swap batches every second iteration

--- a/examples/pytorch_lightning/swav.py
+++ b/examples/pytorch_lightning/swav.py
@@ -30,8 +30,8 @@ class SwaV(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         self.prototypes.normalize()
-        crops, _ = batch
-        multi_crop_features = [self.forward(x.to(self.device)) for x in crops]
+        views = batch[0]
+        multi_crop_features = [self.forward(view.to(self.device)) for view in views]
         high_resolution = multi_crop_features[:2]
         low_resolution = multi_crop_features[2:]
         loss = self.criterion(high_resolution, low_resolution)

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -25,8 +25,8 @@ class SwaV(pl.LightningModule):
         self.criterion = SwaVLoss()
 
     def training_step(self, batch, batch_idx):
-        batch_swav, _ = batch
-        high_resolution, low_resolution = batch_swav[:2], batch_swav[2:]
+        views = batch[0]
+        high_resolution, low_resolution = views[:2], views[2:]
         self.prototypes.normalize()
 
         high_resolution_features = [self._subforward(x) for x in high_resolution]

--- a/examples/pytorch_lightning/tico.py
+++ b/examples/pytorch_lightning/tico.py
@@ -39,7 +39,7 @@ class TiCo(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)

--- a/examples/pytorch_lightning/vicreg.py
+++ b/examples/pytorch_lightning/vicreg.py
@@ -28,7 +28,7 @@ class VICReg(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/barlowtwins.py
+++ b/examples/pytorch_lightning_distributed/barlowtwins.py
@@ -29,7 +29,7 @@ class BarlowTwins(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/byol.py
+++ b/examples/pytorch_lightning_distributed/byol.py
@@ -49,7 +49,7 @@ class BYOL(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         p0 = self.forward(x0)
         z0 = self.forward_momentum(x0)
         p1 = self.forward(x1)

--- a/examples/pytorch_lightning_distributed/dcl.py
+++ b/examples/pytorch_lightning_distributed/dcl.py
@@ -31,7 +31,7 @@ class DCL(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/dino.py
+++ b/examples/pytorch_lightning_distributed/dino.py
@@ -52,7 +52,7 @@ class DINO(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.student_backbone, self.teacher_backbone, m=momentum)
         update_momentum(self.student_head, self.teacher_head, m=momentum)
-        views, _ = batch
+        views = batch[0]
         views = [view.to(self.device) for view in views]
         global_views = views[:2]
         teacher_out = [self.forward_teacher(view) for view in global_views]

--- a/examples/pytorch_lightning_distributed/fastsiam.py
+++ b/examples/pytorch_lightning_distributed/fastsiam.py
@@ -29,7 +29,7 @@ class FastSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        views, _ = batch
+        views = batch[0]
         features = [self.forward(view) for view in views]
         zs = torch.stack([z for z, _ in features])
         ps = torch.stack([p for _, p in features])

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -57,8 +57,8 @@ class MAE(pl.LightningModule):
         return x_pred
 
     def training_step(self, batch, batch_idx):
-        images, _ = batch
-        images = images[0]  # images is a list containing only one view
+        views = batch[0]
+        images = views[0]  # views contains only a single view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
             size=(batch_size, self.sequence_length),

--- a/examples/pytorch_lightning_distributed/moco.py
+++ b/examples/pytorch_lightning_distributed/moco.py
@@ -45,7 +45,7 @@ class MoCo(pl.LightningModule):
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)
-        (x_query, x_key), _, _ = batch
+        x_query, x_key = batch[0]
         query = self.forward(x_query)
         key = self.forward_momentum(x_key)
         loss = self.criterion(query, key)

--- a/examples/pytorch_lightning_distributed/msn.py
+++ b/examples/pytorch_lightning_distributed/msn.py
@@ -49,7 +49,7 @@ class MSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _ = batch
+        views = batch[0]
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]

--- a/examples/pytorch_lightning_distributed/nnclr.py
+++ b/examples/pytorch_lightning_distributed/nnclr.py
@@ -35,7 +35,7 @@ class NNCLR(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         z0 = self.memory_bank(z0, update=False)

--- a/examples/pytorch_lightning_distributed/pmsn.py
+++ b/examples/pytorch_lightning_distributed/pmsn.py
@@ -49,7 +49,7 @@ class PMSN(pl.LightningModule):
         utils.update_momentum(self.anchor_backbone, self.backbone, 0.996)
         utils.update_momentum(self.anchor_projection_head, self.projection_head, 0.996)
 
-        views, _ = batch
+        views = batch[0]
         views = [view.to(self.device, non_blocking=True) for view in views]
         targets = views[0]
         anchors = views[1]

--- a/examples/pytorch_lightning_distributed/simclr.py
+++ b/examples/pytorch_lightning_distributed/simclr.py
@@ -25,7 +25,7 @@ class SimCLR(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)

--- a/examples/pytorch_lightning_distributed/simmim.py
+++ b/examples/pytorch_lightning_distributed/simmim.py
@@ -38,8 +38,8 @@ class SimMIM(pl.LightningModule):
         return self.decoder(x_encoded)
 
     def training_step(self, batch, batch_idx):
-        images, _ = batch
-        images = images[0]  # images is a list containing only one view
+        views = batch[0]
+        images = views[0]  # views contains only a single view
         batch_size = images.shape[0]
         idx_keep, idx_mask = utils.random_token_mask(
             size=(batch_size, self.sequence_length),

--- a/examples/pytorch_lightning_distributed/simsiam.py
+++ b/examples/pytorch_lightning_distributed/simsiam.py
@@ -29,7 +29,7 @@ class SimSiam(pl.LightningModule):
         return z, p
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0, p0 = self.forward(x0)
         z1, p1 = self.forward(x1)
         loss = 0.5 * (self.criterion(z0, p1) + self.criterion(z1, p0))

--- a/examples/pytorch_lightning_distributed/swav.py
+++ b/examples/pytorch_lightning_distributed/swav.py
@@ -33,8 +33,8 @@ class SwaV(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         self.prototypes.normalize()
-        crops, _ = batch
-        multi_crop_features = [self.forward(x.to(self.device)) for x in crops]
+        views = batch[0]
+        multi_crop_features = [self.forward(view.to(self.device)) for view in views]
         high_resolution = multi_crop_features[:2]
         low_resolution = multi_crop_features[2:]
         loss = self.criterion(high_resolution, low_resolution)

--- a/examples/pytorch_lightning_distributed/tico.py
+++ b/examples/pytorch_lightning_distributed/tico.py
@@ -39,7 +39,7 @@ class TiCo(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_idx):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         momentum = cosine_schedule(self.current_epoch, 10, 0.996, 1)
         update_momentum(self.backbone, self.backbone_momentum, m=momentum)
         update_momentum(self.projection_head, self.projection_head_momentum, m=momentum)

--- a/examples/pytorch_lightning_distributed/vicreg.py
+++ b/examples/pytorch_lightning_distributed/vicreg.py
@@ -31,7 +31,7 @@ class VICReg(pl.LightningModule):
         return z
 
     def training_step(self, batch, batch_index):
-        (x0, x1), _ = batch
+        (x0, x1) = batch[0]
         z0 = self.forward(x0)
         z1 = self.forward(x1)
         loss = self.criterion(z0, z1)


### PR DESCRIPTION
Closes #1279 

## Changes

* Use index to access views from batch

The change makes the examples compatible with normal torch datasets that return `(image, target)` and the lightly dataset that returns `(image, target, filename)`