### PR TITLE
openapi: setuptools not required at run-time

### DIFF
--- a/requirements/openapi.txt
+++ b/requirements/openapi.txt
@@ -1,5 +1,4 @@
 python_dateutil >= 2.5.3
-setuptools >= 21.0.0
 urllib3 >= 1.25.3
 pydantic >= 1.10.5, < 2
 aenum >= 3.1.11


### PR DESCRIPTION
The new openapi interface requirements include setuptools and are added to `install_requires`. However, `setuptools` isn't required at run-time, only at build-time. It's already listed under `setup_requires`, so I think it can be safely removed.

This was previously fixed in #1149 but seems to have crept back.