### PR TITLE
Memory bank distributed training support

### DIFF
--- a/benchmarks/imagenet/resnet50/mocov2.py
+++ b/benchmarks/imagenet/resnet50/mocov2.py
@@ -33,7 +33,7 @@ class MoCoV2(LightningModule):
         self.projection_head = MoCoProjectionHead()
         self.query_backbone = copy.deepcopy(self.backbone)
         self.query_projection_head = MoCoProjectionHead()
-        self.criterion = NTXentLoss(temperature=0.2, memory_bank_size=65536)
+        self.criterion = NTXentLoss(temperature=0.2, memory_bank_size=(65536, 128))
 
         self.online_classifier = OnlineLinearClassifier(num_classes=num_classes)
 

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -40,7 +40,7 @@ class SwAV(LightningModule):
         self.queues = ModuleList(
             [
                 MemoryBankModule(
-                    size=self.n_batches_in_queue * self.batch_size_per_device
+                    size=(self.n_batches_in_queue * self.batch_size_per_device, 128)
                 )
                 for _ in range(CROP_COUNTS[0])
             ]

--- a/docs/source/getting_started/advanced.rst
+++ b/docs/source/getting_started/advanced.rst
@@ -298,9 +298,9 @@ For more information check the documentation:
 .. code-block:: python
 
   # to create a NTXentLoss with a memory bank (like for MoCo) set the 
-  # memory_bank_size parameter to a value > 0
+  # memory_bank_size parameter to a value > 0 and specify the feature dimension
   from lightly.loss import NTXentLoss
-  criterion = NTXentLoss(memory_bank_size=4096)
+  criterion = NTXentLoss(memory_bank_size=(4096, 128))
   # the memory bank is used automatically for every forward pass
   y0, y1 = resnet_moco(x0, x1)
   loss = criterion(y0, y1)

--- a/docs/source/getting_started/benchmarks/cifar10_benchmark.py
+++ b/docs/source/getting_started/benchmarks/cifar10_benchmark.py
@@ -790,7 +790,7 @@ class SMoGModel(BenchmarkModule):
         # smog
         self.n_groups = 300
         memory_bank_size = 10000
-        self.memory_bank = memory_bank.MemoryBankModule(size=memory_bank_size)
+        self.memory_bank = memory_bank.MemoryBankModule(size=(memory_bank_size, 128))
         # create our loss
         group_features = torch.nn.functional.normalize(
             torch.rand(self.n_groups, 128), dim=1

--- a/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
@@ -221,7 +221,9 @@ class MocoModel(BenchmarkModule):
         utils.deactivate_requires_grad(self.projection_head_momentum)
 
         # create our loss with the optional memory bank
-        self.criterion = NTXentLoss(temperature=0.07, memory_bank_size=memory_bank_size)
+        self.criterion = NTXentLoss(
+            temperature=0.07, memory_bank_size=(memory_bank_size, 128)
+        )
 
     def forward(self, x):
         x = self.backbone(x).flatten(start_dim=1)
@@ -501,7 +503,7 @@ class NNCLRModel(BenchmarkModule):
         self.projection_head = heads.NNCLRProjectionHead(feature_dim, 4096, 256)
 
         self.criterion = NTXentLoss()
-        self.memory_bank = modules.NNMemoryBankModule(size=memory_bank_size)
+        self.memory_bank = modules.NNMemoryBankModule(size=(memory_bank_size, 256))
 
     def forward(self, x):
         y = self.backbone(x).flatten(start_dim=1)

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -320,7 +320,9 @@ class MocoModel(BenchmarkModule):
         utils.deactivate_requires_grad(self.projection_head_momentum)
 
         # create our loss with the optional memory bank
-        self.criterion = NTXentLoss(temperature=0.1, memory_bank_size=memory_bank_size)
+        self.criterion = NTXentLoss(
+            temperature=0.1, memory_bank_size=(memory_bank_size, 128)
+        )
 
     def forward(self, x):
         x = self.backbone(x).flatten(start_dim=1)

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1005,7 +1005,7 @@ class SMoGModel(BenchmarkModule):
         # smog
         self.n_groups = 300
         memory_bank_size = 10000
-        self.memory_bank = memory_bank.MemoryBankModule(size=memory_bank_size)
+        self.memory_bank = memory_bank.MemoryBankModule(size=(memory_bank_size, 128))
         # create our loss
         group_features = torch.nn.functional.normalize(
             torch.rand(self.n_groups, 128), dim=1
@@ -1310,7 +1310,7 @@ class SwaVQueueModel(BenchmarkModule):
         self.prototypes = heads.SwaVPrototypes(128, 3000, 1)
         self.start_queue_at_epoch = 15
         self.queues = nn.ModuleList(
-            [memory_bank.MemoryBankModule(size=384) for _ in range(2)]
+            [memory_bank.MemoryBankModule(size=(384, 128)) for _ in range(2)]
         )  # Queue size reduced in order to work with a smaller dataset
         self.criterion = SwaVLoss()
 

--- a/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
+++ b/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
@@ -268,7 +268,7 @@ class MoCoModel(pl.LightningModule):
         deactivate_requires_grad(self.projection_head_momentum)
 
         # Create the loss function with memory bank.
-        self.criterion = NTXentLoss(temperature=0.1, memory_bank_size=4096)
+        self.criterion = NTXentLoss(temperature=0.1, memory_bank_size=(4096, 128))
 
     def training_step(self, batch, batch_idx):
         (x_q, x_k), _, _ = batch

--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -237,7 +237,9 @@ class MocoModel(pl.LightningModule):
         deactivate_requires_grad(self.projection_head_momentum)
 
         # create our loss with the optional memory bank
-        self.criterion = NTXentLoss(temperature=0.1, memory_bank_size=memory_bank_size)
+        self.criterion = NTXentLoss(
+            temperature=0.1, memory_bank_size=(memory_bank_size, 128)
+        )
 
     def training_step(self, batch, batch_idx):
         (x_q, x_k), _, _ = batch

--- a/examples/pytorch/moco.py
+++ b/examples/pytorch/moco.py
@@ -62,7 +62,7 @@ dataloader = torch.utils.data.DataLoader(
     num_workers=8,
 )
 
-criterion = NTXentLoss(memory_bank_size=4096)
+criterion = NTXentLoss(memory_bank_size=(4096, 128))
 optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
 
 epochs = 10

--- a/examples/pytorch/nnclr.py
+++ b/examples/pytorch/nnclr.py
@@ -38,7 +38,7 @@ model = NNCLR(backbone)
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
-memory_bank = NNMemoryBankModule(size=4096)
+memory_bank = NNMemoryBankModule(size=(4096, 128))
 memory_bank.to(device)
 
 transform = SimCLRTransform(input_size=32)

--- a/examples/pytorch/smog.py
+++ b/examples/pytorch/smog.py
@@ -80,7 +80,7 @@ model = SMoGModel(backbone)
 
 # memory bank because we reset the group features every 300 iterations
 memory_bank_size = 300 * batch_size
-memory_bank = MemoryBankModule(size=memory_bank_size)
+memory_bank = MemoryBankModule(size=(memory_bank_size, 128))
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -20,7 +20,9 @@ class SwaV(nn.Module):
         self.prototypes = SwaVPrototypes(128, 512, 1)
 
         self.start_queue_at_epoch = 2
-        self.queues = nn.ModuleList([MemoryBankModule(size=3840) for _ in range(2)])
+        self.queues = nn.ModuleList(
+            [MemoryBankModule(size=(3840, 128)) for _ in range(2)]
+        )
 
     def forward(self, high_resolution, low_resolution, epoch):
         self.prototypes.normalize()

--- a/examples/pytorch_lightning/moco.py
+++ b/examples/pytorch_lightning/moco.py
@@ -29,7 +29,7 @@ class MoCo(pl.LightningModule):
         deactivate_requires_grad(self.backbone_momentum)
         deactivate_requires_grad(self.projection_head_momentum)
 
-        self.criterion = NTXentLoss(memory_bank_size=4096)
+        self.criterion = NTXentLoss(memory_bank_size=(4096, 128))
 
     def forward(self, x):
         query = self.backbone(x).flatten(start_dim=1)

--- a/examples/pytorch_lightning/nnclr.py
+++ b/examples/pytorch_lightning/nnclr.py
@@ -23,7 +23,7 @@ class NNCLR(pl.LightningModule):
         self.backbone = nn.Sequential(*list(resnet.children())[:-1])
         self.projection_head = NNCLRProjectionHead(512, 512, 128)
         self.prediction_head = NNCLRPredictionHead(128, 512, 128)
-        self.memory_bank = NNMemoryBankModule(size=4096)
+        self.memory_bank = NNMemoryBankModule(size=(4096, 128))
 
         self.criterion = NTXentLoss()
 

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -21,7 +21,9 @@ class SwaV(pl.LightningModule):
         self.projection_head = SwaVProjectionHead(512, 512, 128)
         self.prototypes = SwaVPrototypes(128, 512, 1)
         self.start_queue_at_epoch = 2
-        self.queues = nn.ModuleList([MemoryBankModule(size=3840) for _ in range(2)])
+        self.queues = nn.ModuleList(
+            [MemoryBankModule(size=(3840, 128)) for _ in range(2)]
+        )
         self.criterion = SwaVLoss()
 
     def training_step(self, batch, batch_idx):

--- a/examples/pytorch_lightning_distributed/moco.py
+++ b/examples/pytorch_lightning_distributed/moco.py
@@ -29,7 +29,7 @@ class MoCo(pl.LightningModule):
         deactivate_requires_grad(self.backbone_momentum)
         deactivate_requires_grad(self.projection_head_momentum)
 
-        self.criterion = NTXentLoss(memory_bank_size=4096)
+        self.criterion = NTXentLoss(memory_bank_size=(4096, 128))
 
     def forward(self, x):
         query = self.backbone(x).flatten(start_dim=1)

--- a/examples/pytorch_lightning_distributed/nnclr.py
+++ b/examples/pytorch_lightning_distributed/nnclr.py
@@ -23,7 +23,7 @@ class NNCLR(pl.LightningModule):
         self.backbone = nn.Sequential(*list(resnet.children())[:-1])
         self.projection_head = NNCLRProjectionHead(512, 512, 128)
         self.prediction_head = NNCLRPredictionHead(128, 512, 128)
-        self.memory_bank = NNMemoryBankModule(size=4096)
+        self.memory_bank = NNMemoryBankModule(size=(4096, 128))
 
         self.criterion = NTXentLoss()
 

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+from typing import Sequence, Union
+
 import torch
 from torch import distributed as torch_dist
 from torch import nn
@@ -25,8 +27,14 @@ class NTXentLoss(MemoryBankModule):
         temperature:
             Scale logits by the inverse of the temperature.
         memory_bank_size:
-            Number of negative samples to store in the memory bank.
-            Use 0 for SimCLR. For MoCo we typically use numbers like 4096 or 65536.
+            Size of the memory bank as (num_features, dim) tuple. num_features are the
+            number of negative samples stored in the memory bank. If num_features is 0,
+            the memory bank is disabled. Use 0 for SimCLR. For MoCo we typically use
+            numbers like 4096 or 65536.
+            Deprecated: If only a single integer is passed, it is interpreted as the
+            number of features and the feature dimension is inferred from the first
+            batch stored in the memory bank. Leaving out the feature dimension might
+            lead to errors in distributed training.
         gather_distributed:
             If True then negatives from all gpus are gathered before the
             loss calculation. If a memory bank is used and gather_distributed is True,
@@ -56,12 +64,10 @@ class NTXentLoss(MemoryBankModule):
     def __init__(
         self,
         temperature: float = 0.5,
-        memory_bank_size: int = 0,
+        memory_bank_size: Union[int, Sequence[int]] = 0,
         gather_distributed: bool = False,
     ):
-        super(NTXentLoss, self).__init__(
-            size=memory_bank_size, gather_distributed=gather_distributed
-        )
+        super().__init__(size=memory_bank_size, gather_distributed=gather_distributed)
         self.temperature = temperature
         self.gather_distributed = gather_distributed
         self.cross_entropy = nn.CrossEntropyLoss(reduction="mean")

--- a/lightly/loss/regularizer/co2.py
+++ b/lightly/loss/regularizer/co2.py
@@ -4,6 +4,7 @@
 # All Rights Reserved
 
 from typing import Sequence, Union
+
 import torch
 
 from lightly.models.modules.memory_bank import MemoryBankModule
@@ -29,10 +30,10 @@ class CO2Regularizer(MemoryBankModule):
 
     Examples:
         >>> # initialize loss function for MoCo
-        >>> loss_fn = NTXentLoss(memory_bank_size=4096)
+        >>> loss_fn = NTXentLoss(memory_bank_size=(4096, 128))
         >>>
         >>> # initialize CO2 regularizer
-        >>> co2 = CO2Regularizer(alpha=1.0, memory_bank_size=4096)
+        >>> co2 = CO2Regularizer(alpha=1.0, memory_bank_size=(4096, 128))
         >>>
         >>> # generate two random trasnforms of images
         >>> t0 = transforms(images)

--- a/lightly/loss/regularizer/co2.py
+++ b/lightly/loss/regularizer/co2.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+from typing import Sequence, Union
 import torch
 
 from lightly.models.modules.memory_bank import MemoryBankModule
@@ -19,8 +20,12 @@ class CO2Regularizer(MemoryBankModule):
         t_consistency:
             Temperature used during softmax calculations.
         memory_bank_size:
-            Number of negative samples to store in the memory bank.
-            Use 0 to use the second batch for negative samples.
+            Size of the memory bank as (num_features, dim) tuple. num_features is the
+            number of negatives stored in the bank. If set to 0, the memory bank is
+            disabled. Deprecated: If only a single integer is passed, it is interpreted
+            as the number of features and the feature dimension is inferred from the
+            first batch stored in the memory bank. Leaving out the feature dimension
+            might lead to errors in distributed training.
 
     Examples:
         >>> # initialize loss function for MoCo
@@ -42,7 +47,10 @@ class CO2Regularizer(MemoryBankModule):
     """
 
     def __init__(
-        self, alpha: float = 1, t_consistency: float = 0.05, memory_bank_size: int = 0
+        self,
+        alpha: float = 1,
+        t_consistency: float = 0.05,
+        memory_bank_size: Union[int, Sequence[int]] = 0,
     ):
         super(CO2Regularizer, self).__init__(size=memory_bank_size)
         # try-catch the KLDivLoss construction for backwards compatability

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -22,14 +22,21 @@ class MemoryBankModule(Module):
 
     Attributes:
         size:
-            Number of keys the memory bank can store. If set to 0,
-            memory bank is not used.
+            Size of the memory bank as (num_features, dim) tuple. If num_features is 0
+            then the memory bank is disabled. Deprecated: If only a single integer is
+            passed, it is interpreted as the number of features and the feature
+            dimension is inferred from the first batch stored in the memory bank.
+            Leaving out the feature dimension might lead to errors in distributed
+            training.
         gather_distributed:
             If True then negatives from all gpus are gathered before the memory bank
             is updated. This results in more frequent updates of the memory bank and
             keeps the memory bank contents independent of the number of gpus. But it has
             the drawback that synchronization between processes is required and
             diversity of the memory bank content is reduced.
+        dim_first:
+            If True, the memory bank returns features with shape (dim, num_features).
+            If False, the memory bank returns features with shape (num_features, dim).
 
     Examples:
         >>> class MyLossFunction(MemoryBankModule):

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -60,7 +60,7 @@ class MemoryBankModule(Module):
 
         if any(x < 0 for x in size_tuple):
             raise ValueError(
-                f"Illegal memory bank size {size}, entries must be non-negative."
+                f"Illegal memory bank size {size}, all entries must be non-negative."
             )
 
         self.size = size_tuple

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -34,7 +34,7 @@ class MemoryBankModule(Module):
             keeps the memory bank contents independent of the number of gpus. But it has
             the drawback that synchronization between processes is required and
             diversity of the memory bank content is reduced.
-        dim_first:
+        feature_dim_first:
             If True, the memory bank returns features with shape (dim, num_features).
             If False, the memory bank returns features with shape (num_features, dim).
 
@@ -58,7 +58,7 @@ class MemoryBankModule(Module):
         self,
         size: Union[int, Sequence[int]] = 65536,
         gather_distributed: bool = False,
-        dim_first: bool = True,
+        feature_dim_first: bool = True,
     ):
         super().__init__()
         size_tuple = (size,) if isinstance(size, int) else tuple(size)
@@ -70,7 +70,7 @@ class MemoryBankModule(Module):
 
         self.size = size_tuple
         self.gather_distributed = gather_distributed
-        self.dim_first = dim_first
+        self.feature_dim_first = feature_dim_first
         self.register_buffer(
             "bank",
             tensor=torch.empty(size=self.size, dtype=torch.float),
@@ -151,7 +151,9 @@ class MemoryBankModule(Module):
 
         Returns:
             The output if the memory bank is of size 0, otherwise the output
-            and the entries from the memory bank.
+            and the entries from the memory bank. Entries from the memory bank have
+            shape (dim, num_features) if feature_dim_first is True and
+            (num_features, dim) otherwise.
 
         """
 
@@ -166,7 +168,7 @@ class MemoryBankModule(Module):
 
         # query and update memory bank
         bank = self.bank.clone().detach()
-        if self.dim_first:
+        if self.feature_dim_first:
             # swap bank size and feature dimension for backwards compatibility
             bank = bank.transpose(0, -1)
 

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -54,6 +54,7 @@ class MemoryBankModule(Module):
         self,
         size: Union[int, Sequence[int]] = 65536,
         gather_distributed: bool = False,
+        dim_first: bool = True,
     ):
         super(MemoryBankModule, self).__init__()
         size_tuple = (size,) if isinstance(size, int) else tuple(size)
@@ -65,6 +66,7 @@ class MemoryBankModule(Module):
 
         self.size = size_tuple
         self.gather_distributed = gather_distributed
+        self.dim_first = dim_first
         self.register_buffer(
             "bank",
             tensor=torch.empty(size=self.size, dtype=torch.float),
@@ -160,6 +162,9 @@ class MemoryBankModule(Module):
 
         # query and update memory bank
         bank = self.bank.clone().detach()
+        if self.dim_first:
+            # swap bank size and feature dimension for backwards compatibility
+            bank = bank.transpose(0, -1)
 
         # only update memory bank if we later do backward pass (gradient)
         if update:

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -63,7 +63,7 @@ class MemoryBankModule(Module):
         gather_distributed: bool = False,
         dim_first: bool = True,
     ):
-        super(MemoryBankModule, self).__init__()
+        super().__init__()
         size_tuple = (size,) if isinstance(size, int) else tuple(size)
 
         if any(x < 0 for x in size_tuple):

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -41,14 +41,11 @@ class MemoryBankModule(Module):
     Examples:
         >>> class MyLossFunction(MemoryBankModule):
         >>>
-        >>>     def __init__(self, memory_bank_size: int = 2 ** 16):
-        >>>         super(MyLossFunction, self).__init__(memory_bank_size)
+        >>>     def __init__(self, memory_bank_size: Tuple[int, int] = (2 ** 16, 128)):
+        >>>         super().__init__(memory_bank_size)
         >>>
-        >>>     def forward(self, output: Tensor,
-        >>>                 labels: Tensor = None):
-        >>>
-        >>>         output, negatives = super(
-        >>>             MyLossFunction, self).forward(output)
+        >>>     def forward(self, output: Tensor, labels: Union[Tensor, None] = None):
+        >>>         output, negatives = super().forward(output)
         >>>
         >>>         if negatives is not None:
         >>>             # evaluate loss with negative samples

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -3,12 +3,17 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import warnings
+from typing import Sequence, Union
+
 import torch
+from torch import Tensor
+from torch.nn import Module
 
 from lightly.models import utils
 
 
-class MemoryBankModule(torch.nn.Module):
+class MemoryBankModule(Module):
     """Memory bank implementation
 
     This is a parent class to all loss functions implemented by the lightly
@@ -32,8 +37,8 @@ class MemoryBankModule(torch.nn.Module):
         >>>     def __init__(self, memory_bank_size: int = 2 ** 16):
         >>>         super(MyLossFunction, self).__init__(memory_bank_size)
         >>>
-        >>>     def forward(self, output: torch.Tensor,
-        >>>                 labels: torch.Tensor = None):
+        >>>     def forward(self, output: Tensor,
+        >>>                 labels: Tensor = None):
         >>>
         >>>         output, negatives = super(
         >>>             MyLossFunction, self).forward(output)
@@ -45,41 +50,66 @@ class MemoryBankModule(torch.nn.Module):
 
     """
 
-    def __init__(self, size: int = 65536, gather_distributed: bool = False):
+    def __init__(
+        self,
+        size: Union[int, Sequence[int]] = 65536,
+        gather_distributed: bool = False,
+    ):
         super(MemoryBankModule, self).__init__()
+        size_tuple = (size,) if isinstance(size, int) else tuple(size)
 
-        if size < 0:
-            msg = f"Illegal memory bank size {size}, must be non-negative."
-            raise ValueError(msg)
+        if any(x < 0 for x in size_tuple):
+            raise ValueError(
+                f"Illegal memory bank size {size}, entries must be non-negative."
+            )
 
-        self.size = size
+        self.size = size_tuple
         self.gather_distributed = gather_distributed
         self.register_buffer(
-            "bank", tensor=torch.empty(0, dtype=torch.float), persistent=False
+            "bank",
+            tensor=torch.empty(size=self.size, dtype=torch.float),
+            persistent=False,
         )
         self.register_buffer(
-            "bank_ptr", tensor=torch.empty(0, dtype=torch.long), persistent=False
+            "bank_ptr",
+            tensor=torch.empty(1, dtype=torch.long),
+            persistent=False,
         )
 
+        if isinstance(size, int) and size > 0:
+            warnings.warn(
+                (
+                    f"Memory bank size 'size={size}' does not specify feature "
+                    "dimension. It is recommended to set the feature dimension with "
+                    "'size=(n, dim)' when creating the memory bank. Distributed "
+                    "training might fail if the feature dimension is not set."
+                ),
+                UserWarning,
+            )
+        else:
+            self._init_memory_bank(dim=None)
+
     @torch.no_grad()
-    def _init_memory_bank(self, dim: int):
-        """Initialize the memory bank if it's empty
+    def _init_memory_bank(self, dim: Union[Sequence[int], None]):
+        """Initialize the memory bank if it's empty.
 
         Args:
             dim:
                 The dimension of the which are stored in the bank.
 
         """
-        # create memory bank
-        # we could use register buffers like in the moco repo
-        # https://github.com/facebookresearch/moco but we don't
-        # want to pollute our checkpoints
-        self.bank = torch.randn(dim, self.size).type_as(self.bank)
-        self.bank = torch.nn.functional.normalize(self.bank, dim=0)
+        if dim is None:
+            # Feature dimension has been specified when initializing the memory bank.
+            size = self.size
+        else:
+            # Feature dimension was inferred from batch.
+            size = (self.size[0], *dim)
+        self.bank = torch.randn(size).type_as(self.bank)
+        self.bank = torch.nn.functional.normalize(self.bank, dim=-1)
         self.bank_ptr = torch.zeros(1).type_as(self.bank_ptr)
 
     @torch.no_grad()
-    def _dequeue_and_enqueue(self, batch: torch.Tensor):
+    def _dequeue_and_enqueue(self, batch: Tensor):
         """Dequeue the oldest batch and add the latest one
 
         Args:
@@ -89,18 +119,21 @@ class MemoryBankModule(torch.nn.Module):
         """
         if self.gather_distributed:
             batch = utils.concat_all_gather(batch)
+
         batch_size = batch.shape[0]
         ptr = int(self.bank_ptr)
-
-        if ptr + batch_size >= self.size:
-            self.bank[:, ptr:] = batch[: self.size - ptr].T.detach()
+        if ptr + batch_size >= self.size[0]:
+            self.bank[ptr:] = batch[: self.size[0] - ptr].detach()
             self.bank_ptr[0] = 0
         else:
-            self.bank[:, ptr : ptr + batch_size] = batch.T.detach()
+            self.bank[ptr : ptr + batch_size] = batch.detach()
             self.bank_ptr[0] = ptr + batch_size
 
     def forward(
-        self, output: torch.Tensor, labels: torch.Tensor = None, update: bool = False
+        self,
+        output: Tensor,
+        labels: Union[Tensor, None] = None,
+        update: bool = False,
     ):
         """Query memory bank for additional negative samples
 
@@ -117,13 +150,12 @@ class MemoryBankModule(torch.nn.Module):
         """
 
         # no memory bank, return the output
-        if self.size == 0:
+        if self.size[0] == 0:
             return output, None
 
-        _, dim = output.shape
-
         # initialize the memory bank if it is not already done
-        if self.bank.nelement() == 0:
+        if self.bank.ndim == 1:
+            dim = output.shape[1:]
             self._init_memory_bank(dim)
 
         # query and update memory bank

--- a/lightly/models/modules/nn_memory_bank.py
+++ b/lightly/models/modules/nn_memory_bank.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
+from typing import Sequence, Union
 import torch
 
 from lightly.models.modules.memory_bank import MemoryBankModule
@@ -19,8 +20,12 @@ class NNMemoryBankModule(MemoryBankModule):
 
     Attributes:
         size:
-            Number of keys the memory bank can store. If set to 0,
-            memory bank is not used.
+            Size of the memory bank as (num_features, dim) tuple. If num_features is 0
+            then the memory bank is disabled. Deprecated: If only a single integer is
+            passed, it is interpreted as the number of features and the feature
+            dimension is inferred from the first batch stored in the memory bank.
+            Leaving out the feature dimension might lead to errors in distributed
+            training.
 
     Examples:
         >>> model = NNCLR(backbone)
@@ -37,7 +42,7 @@ class NNMemoryBankModule(MemoryBankModule):
 
     """
 
-    def __init__(self, size: int = 2**16):
+    def __init__(self, size: Union[int, Sequence[int]] = 2**16):
         super(NNMemoryBankModule, self).__init__(size)
 
     def forward(self, output: torch.Tensor, update: bool = False):

--- a/lightly/models/modules/nn_memory_bank.py
+++ b/lightly/models/modules/nn_memory_bank.py
@@ -4,6 +4,7 @@
 # All Rights Reserved
 
 from typing import Sequence, Union
+
 import torch
 
 from lightly.models.modules.memory_bank import MemoryBankModule
@@ -31,7 +32,7 @@ class NNMemoryBankModule(MemoryBankModule):
         >>> model = NNCLR(backbone)
         >>> criterion = NTXentLoss(temperature=0.1)
         >>>
-        >>> nn_replacer = NNmemoryBankModule(size=2 ** 16)
+        >>> nn_replacer = NNmemoryBankModule(size=(2 ** 16, 128))
         >>>
         >>> # forward pass
         >>> (z0, p0), (z1, p1) = model(x0, x1)

--- a/tests/loss/test_CO2Regularizer.py
+++ b/tests/loss/test_CO2Regularizer.py
@@ -18,7 +18,7 @@ class TestCO2Regularizer(unittest.TestCase):
             self.assertAlmostEqual((l1 - l2).pow(2).item(), 0.0)
 
     def test_forward_pass_memory_bank(self):
-        reg = CO2Regularizer(memory_bank_size=4096)
+        reg = CO2Regularizer(memory_bank_size=(4096, 32))
         for bsz in range(1, 20):
             batch_1 = torch.randn((bsz, 32))
             batch_2 = torch.randn((bsz, 32))
@@ -44,7 +44,7 @@ class TestCO2Regularizer(unittest.TestCase):
         if not torch.cuda.is_available():
             return
 
-        reg = CO2Regularizer(memory_bank_size=4096)
+        reg = CO2Regularizer(memory_bank_size=(4096, 32))
         for bsz in range(1, 20):
             batch_1 = torch.randn((bsz, 32)).cuda()
             batch_2 = torch.randn((bsz, 32)).cuda()

--- a/tests/models/modules/test_memory_bank.py
+++ b/tests/models/modules/test_memory_bank.py
@@ -95,7 +95,7 @@ class TestMemoryBank:
 
     def test_forward(self) -> None:
         torch.manual_seed(0)
-        memory_bank = MemoryBankModule(size=(5, 2), dim_first=False)
+        memory_bank = MemoryBankModule(size=(5, 2), feature_dim_first=False)
         x0 = torch.randn(3, 2)
         out0, bank0 = memory_bank(x0, update=True)
         # Verify that output is same as input.
@@ -136,7 +136,7 @@ class TestMemoryBank:
     def test_forward__no_dim(self) -> None:
         torch.manual_seed(0)
         # Only specify size but not feature dimension.
-        memory_bank = MemoryBankModule(size=5, dim_first=False)
+        memory_bank = MemoryBankModule(size=5, feature_dim_first=False)
         x0 = torch.randn(3, 2)
         out0, bank0 = memory_bank(x0, update=True)
         # Verify that output is same as input.
@@ -151,7 +151,7 @@ class TestMemoryBank:
 
     def test_forward__dim_first(self) -> None:
         torch.manual_seed(0)
-        memory_bank = MemoryBankModule(size=(5, 2), dim_first=True)
+        memory_bank = MemoryBankModule(size=(5, 2), feature_dim_first=True)
         x0 = torch.randn(3, 2)
         out0, bank0 = memory_bank(x0, update=True)
         assert bank0.shape == (2, 5)

--- a/tests/models/modules/test_memory_bank.py
+++ b/tests/models/modules/test_memory_bank.py
@@ -25,8 +25,8 @@ class TestNTXentLoss(unittest.TestCase):
             _, curr_memory_bank = memory_bank(out1, update=True)
             next_memory_bank = memory_bank.bank
 
-            curr_diff = out0.T - curr_memory_bank[:, ptr : ptr + bsz]
-            next_diff = out1.T - next_memory_bank[:, ptr : ptr + bsz]
+            curr_diff = out0 - curr_memory_bank[ptr : ptr + bsz]
+            next_diff = out1 - next_memory_bank[ptr : ptr + bsz]
 
             # the current memory bank should not hold the batch yet
             self.assertGreater(curr_diff.norm(), 1e-5)

--- a/tests/models/modules/test_memory_bank.py
+++ b/tests/models/modules/test_memory_bank.py
@@ -1,8 +1,9 @@
 import unittest
 
 import torch
-
+import pytest
 from lightly.models.modules.memory_bank import MemoryBankModule
+import re
 
 
 class TestNTXentLoss(unittest.TestCase):
@@ -61,3 +62,88 @@ class TestNTXentLoss(unittest.TestCase):
             # is no multiple of the batch size
             output = torch.randn(bsz, dim, device=device)
             _, _ = memory_bank(output)
+
+
+class TestMemoryBank:
+    def test_init__negative_size(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="Illegal memory bank size -1, all entries must be non-negative.",
+        ):
+            MemoryBankModule(size=-1)
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Illegal memory bank size (10, -1), all entries must be non-negative."
+            ),
+        ):
+            MemoryBankModule(size=(10, -1))
+
+    def test_init__no_dim_warning(self) -> None:
+        with pytest.warns(
+            UserWarning,
+            match=re.escape(
+                "Memory bank size 'size=10' does not specify feature "
+                "dimension. It is recommended to set the feature dimension with "
+                "'size=(n, dim)' when creating the memory bank. Distributed "
+                "training might fail if the feature dimension is not set."
+            ),
+        ):
+            MemoryBankModule(size=10)
+
+    def test_forward(self) -> None:
+        torch.manual_seed(0)
+        memory_bank = MemoryBankModule(size=(5, 2))
+        x0 = torch.randn(3, 2)
+        out0, bank0 = memory_bank(x0, update=True)
+        # Verify that output is same as input.
+        assert out0.tolist() == x0.tolist()
+        # Verify that memory bank was initialized and has correct shape.
+        assert bank0.shape == (5, 2)
+        assert memory_bank.bank.shape == (5, 2)
+        # Verify that output bank does not contain features from x0.
+        assert bank0[:3].tolist() != x0.tolist()
+        # Verify that memory bank was updated.
+        assert memory_bank.bank[:3].tolist() == x0.tolist()
+
+        x1 = torch.randn(3, 2)
+        out1, bank1 = memory_bank(x1, update=True)
+        # Verify that output is same as input.
+        assert out1.tolist() == x1.tolist()
+        # Verify that output bank contains features from x0.
+        assert bank1[:3].tolist() == x0.tolist()
+        # Verify that output bank does not contain features from x1.
+        assert bank1[3:].tolist() != x1[:2].tolist()
+        # Verify that memory bank was updated.
+        assert memory_bank.bank[:3].tolist() == x0.tolist()
+        assert memory_bank.bank[3:].tolist() == x1[:2].tolist()
+
+        # At this point the memory bank is full.
+        # Adding more features will start overwriting the bank from the beginning.
+
+        x2 = torch.randn(3, 2)
+        out2, bank2 = memory_bank(x2, update=True)
+        # Verify that output is same as input.
+        assert out2.tolist() == x2.tolist()
+        # Verify that output bank contains features from x0 and x1.
+        assert bank2[:3].tolist() == x0.tolist()
+        assert bank2[3:].tolist() == x1[:2].tolist()
+        # Verify that memory bank is overwritten.
+        assert memory_bank.bank[:3].tolist() == x2.tolist()
+
+    def test_forward__no_dim(self) -> None:
+        torch.manual_seed(0)
+        # Only specify size but not feature dimension.
+        memory_bank = MemoryBankModule(size=5)
+        x0 = torch.randn(3, 2)
+        out0, bank0 = memory_bank(x0, update=True)
+        # Verify that output is same as input.
+        assert out0.tolist() == x0.tolist()
+        # Verify that memory bank was initialized and has correct shape.
+        assert bank0.shape == (5, 2)
+        assert memory_bank.bank.shape == (5, 2)
+        # Verify that output bank does not contain features from x0.
+        assert bank0[:3].tolist() != x0.tolist()
+        # Verify that memory bank was updated.
+        assert memory_bank.bank[:3].tolist() == x0.tolist()

--- a/tests/models/modules/test_memory_bank.py
+++ b/tests/models/modules/test_memory_bank.py
@@ -148,3 +148,14 @@ class TestMemoryBank:
         assert bank0[:3].tolist() != x0.tolist()
         # Verify that memory bank was updated.
         assert memory_bank.bank[:3].tolist() == x0.tolist()
+
+    def test_forward__dim_first(self) -> None:
+        torch.manual_seed(0)
+        memory_bank = MemoryBankModule(size=(5, 2), dim_first=True)
+        x0 = torch.randn(3, 2)
+        out0, bank0 = memory_bank(x0, update=True)
+        assert bank0.shape == (2, 5)
+        x1 = torch.randn(3, 2)
+        out1, bank1 = memory_bank(x1, update=True)
+        assert bank1.shape == (2, 5)
+        assert bank1[:, :3].tolist() == x0.T.tolist()

--- a/tests/models/test_ModelsNNCLR.py
+++ b/tests/models/test_ModelsNNCLR.py
@@ -115,7 +115,7 @@ class TestNNCLR(unittest.TestCase):
             model = NNCLR(get_backbone(resnet), **config).to(device)
 
             for nn_size in [2**3, 2**8]:
-                nn_replacer = NNMemoryBankModule(size=nn_size)
+                nn_replacer = NNMemoryBankModule(size=(nn_size, config["out_dim"]))
 
                 with torch.no_grad():
                     for i in range(10):


### PR DESCRIPTION
## Changes

* Add feature dimension when setting memory bank size. This is required for distributed training because the buffer size cannot be changed dynamically.
* Cleanup memory bank implementation.
* Add `feature_dim_first` argument to memory bank. This is required for backwards compatibility. In the future we should be able to set `feature_dim_first=False` and remove the requirement for transposing features coming from the feature bank.
* Update classes/functions using memory bank  from `size=num_features` to `size=(num_features, dim)`.

## How was it tested?
* Added unit tests