### PR TITLE
hide ApiException stack trace for config validation problems

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -307,12 +307,13 @@ class _ComputeWorkerMixin:
             eb = json.loads(e.body)
             eb_code = eb.get("code")
             eb_error = eb.get("error")
-            if str(e.status)[0] == '4' and eb_code is not None and eb_error is not None:
+            if str(e.status)[0] == "4" and eb_code is not None and eb_error is not None:
                 eb = json.loads(e.body)
-                raise ValueError(f'Trying to schedule your job resulted in\n'
-                                 f'{eb_code}\n{eb_error}\n'
-                                 f'Please fix the issue mentioned above and see our docs '
-                                 f'https://docs.lightly.ai/docs/all-configuration-options for more help.'
+                raise ValueError(
+                    f"Trying to schedule your job resulted in\n"
+                    f"{eb_code}\n{eb_error}\n"
+                    f"Please fix the issue mentioned above and see our docs "
+                    f"https://docs.lightly.ai/docs/all-configuration-options for more help."
                 ) from None
             else:
                 raise e

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -255,7 +255,7 @@ class _ComputeWorkerMixin:
             if str(e.status)[0] == "4" and eb_code is not None and eb_error is not None:
                 raise ValueError(
                     f"Trying to schedule your job resulted in\n"
-                    f">> {eb_code}\n>> {eb_error}\n"
+                    f">> {eb_code}\n>> {json.dumps(eb_error, indent=4)}\n"
                     f">> Please fix the issue mentioned above and see our docs "
                     f"https://docs.lightly.ai/docs/all-configuration-options for more help."
                 ) from None

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -249,6 +249,8 @@ class _ComputeWorkerMixin:
             response = self._compute_worker_api.create_docker_worker_config_v3(request)
             return response.id
         except ApiException as e:
+            if e.body is None:
+                raise e
             eb = json.loads(e.body)
             eb_code = eb.get("code")
             eb_error = eb.get("error")
@@ -258,7 +260,7 @@ class _ComputeWorkerMixin:
                     f">> {eb_code}\n>> {json.dumps(eb_error, indent=4)}\n"
                     f">> Please fix the issue mentioned above and see our docs "
                     f"https://docs.lightly.ai/docs/all-configuration-options for more help."
-                ) from None
+                ) from e
             else:
                 raise e
 

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -326,7 +326,6 @@ class _ComputeWorkerMixin:
             docker_run_scheduled_create_request=request,
             dataset_id=self.dataset_id,
         )
-
         return response.id
 
     def get_compute_worker_runs_iter(

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -308,7 +308,6 @@ class _ComputeWorkerMixin:
             eb_code = eb.get("code")
             eb_error = eb.get("error")
             if str(e.status)[0] == "4" and eb_code is not None and eb_error is not None:
-                eb = json.loads(e.body)
                 raise ValueError(
                     f"Trying to schedule your job resulted in\n"
                     f"{eb_code}\n{eb_error}\n"

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -473,7 +473,7 @@ def test_schedule_compute_worker_run_api_error() -> None:
     )
     with pytest.raises(
         ValueError,
-        match=r"Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account.\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.",
+        match=r'Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> "Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.',
     ):
         r = ApiWorkflowClient.create_compute_worker_config(
             self=mocked_api_client,

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -504,7 +504,7 @@ def test_create_docker_worker_config_v3_5xx_api_error() -> None:
     client._compute_worker_api.create_docker_worker_config_v3 = mocked_raise_exception
     with pytest.raises(
         ApiException,
-        match=r'Server pains',
+        match=r"Server pains",
     ):
         r = client.create_compute_worker_config(
             selection_config={
@@ -514,6 +514,7 @@ def test_create_docker_worker_config_v3_5xx_api_error() -> None:
                 ],
             },
         )
+
 
 def test_create_docker_worker_config_v3_no_body_api_error() -> None:
     def mocked_raise_exception(*args, **kwargs):
@@ -533,6 +534,7 @@ def test_create_docker_worker_config_v3_no_body_api_error() -> None:
                 ],
             },
         )
+
 
 def test_get_compute_worker_state_and_message_CANCELED() -> None:
     def mocked_raise_exception(*args, **kwargs):

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -443,17 +443,25 @@ def test_get_compute_worker_state_and_message_OPEN() -> None:
     assert run_info.message.startswith("Waiting for pickup by Lightly Worker.")
     assert run_info.in_end_state() == False
 
+
 def test_schedule_compute_worker_run_api_error() -> None:
     class HttpThing:
         def __init__(self, status, reason, data):
             self.status = status
             self.reason = reason
             self.data = data
+
         def getheaders(self):
             return []
 
     def mocked_raise_exception(*args, **kwargs):
-        raise ApiException(http_resp=HttpThing(403, "Not everything has a reason", '{"code": "ACCOUNT_SUBSCRIPTION_INSUFFICIENT", "error": "Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."}'))
+        raise ApiException(
+            http_resp=HttpThing(
+                403,
+                "Not everything has a reason",
+                '{"code": "ACCOUNT_SUBSCRIPTION_INSUFFICIENT", "error": "Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."}',
+            )
+        )
 
     mocked_api_client = MagicMock(
         dataset_id=generate_id(),
@@ -461,28 +469,22 @@ def test_schedule_compute_worker_run_api_error() -> None:
             create_docker_worker_config_v3=mocked_raise_exception
         ),
         _get_scheduled_run_by_id=mocked_raise_exception,
-        _creator='USER_PIP'
+        _creator="USER_PIP",
     )
     with pytest.raises(
         ValueError,
-        match=r"Trying to schedule your job resulted in\nACCOUNT_SUBSCRIPTION_INSUFFICIENT\nYour current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account.\nPlease fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.",
+        match=r"Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account.\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.",
     ):
         r = ApiWorkflowClient.create_compute_worker_config(
             self=mocked_api_client,
             selection_config={
                 "n_samples": 2000000,
                 "strategies": [
-                    {
-                        "input": {
-                            "type": "EMBEDDINGS"
-                        },
-                        "strategy": {
-                            "type": "DIVERSITY"
-                        }
-                    }
-                ]
+                    {"input": {"type": "EMBEDDINGS"}, "strategy": {"type": "DIVERSITY"}}
+                ],
             },
         )
+
 
 def test_get_compute_worker_state_and_message_CANCELED() -> None:
     def mocked_raise_exception(*args, **kwargs):

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -462,6 +462,7 @@ def test_schedule_compute_worker_run_api_error() -> None:
                 '{"code": "ACCOUNT_SUBSCRIPTION_INSUFFICIENT", "error": "Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."}',
             )
         )
+
     client = ApiWorkflowClient(token="123")
     client._dataset_id = generate_id()
     client._compute_worker_api.create_docker_worker_config_v3 = mocked_raise_exception

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -459,7 +459,7 @@ def test_schedule_compute_worker_run_api_error() -> None:
             http_resp=HttpThing(
                 403,
                 "Not everything has a reason",
-                '{"code": "ACCOUNT_SUBSCRIPTION_INSUFFICIENT", "error": "Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."}',
+                '{"code": "ACCOUNT_SUBSCRIPTION_INSUFFICIENT", "error": "Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."}',
             )
         )
 

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -462,21 +462,22 @@ def test_schedule_compute_worker_run_api_error() -> None:
                 '{"code": "ACCOUNT_SUBSCRIPTION_INSUFFICIENT", "error": "Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."}',
             )
         )
+    client = ApiWorkflowClient(token="123")
+    client._dataset_id = generate_id()
+    client._compute_worker_api.create_docker_worker_config_v3 = mocked_raise_exception
 
-    mocked_api_client = MagicMock(
-        dataset_id=generate_id(),
-        _compute_worker_api=MagicMock(
-            create_docker_worker_config_v3=mocked_raise_exception
-        ),
-        _get_scheduled_run_by_id=mocked_raise_exception,
-        _creator="USER_PIP",
-    )
+#     mocked_api_client = MagicMock(
+#         dataset_id=generate_id(),
+#         _compute_worker_api=MagicMock(
+#             create_docker_worker_config_v3=mocked_raise_exception
+#         ),
+#         _creator="USER_PIP",
+#     )
     with pytest.raises(
         ValueError,
         match=r'Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> "Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.',
     ):
-        r = ApiWorkflowClient.create_compute_worker_config(
-            self=mocked_api_client,
+        r = client.create_compute_worker_config(
             selection_config={
                 "n_samples": 2000000,
                 "strategies": [

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -473,7 +473,7 @@ def test_schedule_compute_worker_run_api_error() -> None:
     )
     with pytest.raises(
         ValueError,
-        match=r'Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> "Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.',
+        match=r'Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> "Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.',
     ):
         r = ApiWorkflowClient.create_compute_worker_config(
             self=mocked_api_client,

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -465,14 +465,6 @@ def test_schedule_compute_worker_run_api_error() -> None:
     client = ApiWorkflowClient(token="123")
     client._dataset_id = generate_id()
     client._compute_worker_api.create_docker_worker_config_v3 = mocked_raise_exception
-
-#     mocked_api_client = MagicMock(
-#         dataset_id=generate_id(),
-#         _compute_worker_api=MagicMock(
-#             create_docker_worker_config_v3=mocked_raise_exception
-#         ),
-#         _creator="USER_PIP",
-#     )
     with pytest.raises(
         ValueError,
         match=r'Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> "Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.',


### PR DESCRIPTION
When the user has a config issue that fails API-side validation, our errors are too verbose, so that users fail to see the problem and quickly blame us. See [the issue](https://linear.app/lightly/issue/LIG-3563/when-there-is-a-config-error-dont-print-http-trace).


Example:

Given `repro.py`
```
from lightly.api import ApiWorkflowClient

client = ApiWorkflowClient(token="MY_TOKEN", dataset_id="MY_DATASET_ID")
scheduled_run_id = client.schedule_compute_worker_run(
    selection_config={
        "n_samples": 2000000,
        "strategies": [
            {
                "input": {
                    "type": "EMBEDDINGS"
                },
                "strategy": {
                    "type": "DIVERSITY"
                }
            }
        ]
    },
)

```

```
$ python repro.py 
Traceback (most recent call last):
  File "repro2.py", line 13, in <module>
    "type": "DIVERSITY"
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/api/api_workflow_compute_worker.py", line 303, in schedule_compute_worker_run
    selection_config=selection_config,
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/api/api_workflow_compute_worker.py", line 247, in create_compute_worker_config
    response = self._compute_worker_api.create_docker_worker_config_v3(request)
  File "pydantic/decorator.py", line 40, in pydantic.decorator.validate_arguments.validate.wrapper_function
  File "pydantic/decorator.py", line 134, in pydantic.decorator.ValidatedFunction.call
  File "pydantic/decorator.py", line 206, in pydantic.decorator.ValidatedFunction.execute
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/api/docker_api.py", line 1165, in create_docker_worker_config_v3
    return self.create_docker_worker_config_v3_with_http_info(docker_worker_config_v3_create_request, **kwargs)  # noqa: E501
  File "pydantic/decorator.py", line 40, in pydantic.decorator.validate_arguments.validate.wrapper_function
  File "pydantic/decorator.py", line 134, in pydantic.decorator.ValidatedFunction.call
  File "pydantic/decorator.py", line 206, in pydantic.decorator.ValidatedFunction.execute
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/api/docker_api.py", line 1285, in create_docker_worker_config_v3_with_http_info
    _request_auth=_params.get('_request_auth'))
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/api_client.py", line 413, in call_api
    _request_auth)
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/api_client.py", line 222, in __call_api
    raise e
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/api_client.py", line 218, in __call_api
    _request_timeout=_request_timeout)
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/api_client.py", line 457, in request
    body=body)
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/rest.py", line 281, in post_request
    body=body)
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/api/swagger_rest_client.py", line 72, in request
    _request_timeout=_request_timeout,
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/openapi_generated/swagger_client/rest.py", line 234, in request
    raise ApiException(http_resp=r)
lightly.openapi_generated.swagger_client.exceptions.ApiException: (402)
Reason: Payment Required
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json; charset=utf-8', 'Vary': 'Origin, Accept-Encoding', 'Access-Control-Expose-Headers': 'Content-Disposition', 'Content-Security-Policy': "script-src https://*.lightly.ai undefined https://*.youtube.com https://*.gstatic.com https://*.google.com https://*.doubleclick.net https://*.google-analytics.com https://*.googletagmanager.com https://edge.fullstory.com https://rs.fullstory.com;img-src *;connect-src self https://edge.fullstory.com https://rs.fullstory.com;default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests", 'X-DNS-Prefetch-Control': 'off', 'Expect-CT': 'max-age=0', 'X-Frame-Options': 'SAMEORIGIN', 'Strict-Transport-Security': 'max-age=15552000; includeSubDomains', 'X-Download-Options': 'noopen', 'X-Content-Type-Options': 'nosniff', 'X-Permitted-Cross-Domain-Policies': 'none', 'Origin-Agent-Cluster': '?1', 'X-XSS-Protection': '0', 'Cross-Origin-Opener-Policy': 'same-origin-allow-popups', 'Cross-Origin-Resource-Policy': 'same-site', 'ETag': 'W/"dd-JmhvJgytgGlKt0QuWCLonxgLrTo"', 'X-Cloud-Trace-Context': '922e4e7eaab8f4d2fea1ad64fa89b127', 'Date': 'Wed, 28 Jun 2023 09:29:24 GMT', 'Server': 'Google Frontend', 'Content-Length': '221'})
HTTP response body: {
    "code": "ACCOUNT_SUBSCRIPTION_INSUFFICIENT",
    "error": "Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."
}
```

With the change here, that becomes:
```
$ python repro.py 
Traceback (most recent call last):
  File "repro.py", line 13, in <module>
    "type": "DIVERSITY"
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/api/api_workflow_compute_worker.py", line 317, in schedule_compute_worker_run
    selection_config=selection_config,
  File "/home/sdaley/.conda/envs/lightly/lib/python3.7/site-packages/lightly/api/api_workflow_compute_worker.py", line 261, in create_compute_worker_config
    ) from None
ValueError: Trying to schedule your job resulted in
>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT
>> Your current plan allow for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account.
>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.
```

Note: the linear issue suggests coloured printing. That hasn't been done - this will be imported and used in the user's codebase, and exception handling, log formatting and printing will vary depending on the user.