### PR TITLE
lig-3522: Add `use_datapool` to config

### DIFF
--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -111,6 +111,9 @@ environment_variable_names:
 # seed
 seed: 1
 
+# use datapool
+use_datapool: True
+
 ### hydra
 # The arguments below are built-ins from the hydra-core Python package.
 hydra:

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -111,8 +111,6 @@ environment_variable_names:
 # seed
 seed: 1
 
-# use datapool
-use_datapool: True
 
 ### hydra
 # The arguments below are built-ins from the hydra-core Python package.

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -111,7 +111,6 @@ environment_variable_names:
 # seed
 seed: 1
 
-
 ### hydra
 # The arguments below are built-ins from the hydra-core Python package.
 hydra:

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker.py
@@ -44,7 +44,8 @@ class DockerWorkerConfigV3Docker(BaseModel):
     relevant_filenames_file: Optional[StrictStr] = Field(None, alias="relevantFilenamesFile")
     selected_sequence_length: Optional[conint(strict=True, ge=1)] = Field(None, alias="selectedSequenceLength")
     upload_report: Optional[StrictBool] = Field(None, alias="uploadReport")
-    __properties = ["checkpoint", "corruptnessCheck", "datasource", "embeddings", "enableTraining", "training", "normalizeEmbeddings", "numProcesses", "numThreads", "outputImageFormat", "pretagging", "pretaggingUpload", "relevantFilenamesFile", "selectedSequenceLength", "uploadReport"]
+    use_datapool: Optional[StrictBool] = Field(None, alias="useDatapool")
+    __properties = ["checkpoint", "corruptnessCheck", "datasource", "embeddings", "enableTraining", "training", "normalizeEmbeddings", "numProcesses", "numThreads", "outputImageFormat", "pretagging", "pretaggingUpload", "relevantFilenamesFile", "selectedSequenceLength", "uploadReport", "useDatapool"]
 
     class Config:
         """Pydantic configuration"""
@@ -112,7 +113,8 @@ class DockerWorkerConfigV3Docker(BaseModel):
             "pretagging_upload": obj.get("pretaggingUpload"),
             "relevant_filenames_file": obj.get("relevantFilenamesFile"),
             "selected_sequence_length": obj.get("selectedSequenceLength"),
-            "upload_report": obj.get("uploadReport")
+            "upload_report": obj.get("uploadReport"),
+            "use_datapool": obj.get("useDatapool")
         })
         return _obj
 


### PR DESCRIPTION
Add a new flag `use_datapool` to Lightly config. This flag tells the worker if it should use the datapool during a run.