### PR TITLE
lig-3659: align import style

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -8,6 +8,7 @@ import requests
 from requests import Response
 
 from lightly.__init__ import __version__
+from lightly.api import utils, version_checking
 from lightly.api.api_workflow_artifacts import _ArtifactsMixin
 from lightly.api.api_workflow_collaboration import _CollaborationMixin
 from lightly.api.api_workflow_compute_worker import _ComputeWorkerMixin
@@ -22,15 +23,8 @@ from lightly.api.api_workflow_upload_dataset import _UploadDatasetMixin
 from lightly.api.api_workflow_upload_embeddings import _UploadEmbeddingsMixin
 from lightly.api.api_workflow_upload_metadata import _UploadCustomMetadataMixin
 from lightly.api.swagger_api_client import LightlySwaggerApiClient
-from lightly.api.utils import (
-    DatasourceType,
-    get_api_client_configuration,
-    get_signed_url_destination,
-)
-from lightly.api.version_checking import (
-    LightlyAPITimeoutException,
-    is_compatible_version,
-)
+from lightly.api.utils import DatasourceType
+from lightly.api.version_checking import LightlyAPITimeoutException
 from lightly.openapi_generated.swagger_client.api import (
     CollaborationApi,
     DatasetsApi,
@@ -49,7 +43,7 @@ from lightly.openapi_generated.swagger_client.api import (
 )
 from lightly.openapi_generated.swagger_client.models import Creator, DatasetData
 from lightly.openapi_generated.swagger_client.rest import ApiException
-from lightly.utils.reordering import sort_items_by_keys
+from lightly.utils import reordering
 
 # Env variable for server side encryption on S3
 LIGHTLY_S3_SSE_KMS_KEY = "LIGHTLY_S3_SSE_KMS_KEY"
@@ -101,7 +95,7 @@ class ApiWorkflowClient(
         creator: str = Creator.USER_PIP,
     ):
         try:
-            if not is_compatible_version(__version__):
+            if not version_checking.is_compatible_version(__version__):
                 warnings.warn(
                     UserWarning(
                         (
@@ -119,7 +113,7 @@ class ApiWorkflowClient(
         ):
             pass
 
-        configuration = get_api_client_configuration(token=token)
+        configuration = utils.get_api_client_configuration(token=token)
         self.api_client = LightlySwaggerApiClient(configuration=configuration)
         self.api_client.user_agent = f"Lightly/{__version__} ({platform.system()}/{platform.release()}; {platform.platform()}; {platform.processor()};) python/{platform.python_version()}"
 
@@ -210,7 +204,7 @@ class ApiWorkflowClient(
 
         """
         filenames_on_server = self.get_filenames()
-        list_ordered = sort_items_by_keys(
+        list_ordered = reordering.sort_items_by_keys(
             filenames_for_list, list_to_order, filenames_on_server
         )
         return list_ordered
@@ -259,7 +253,7 @@ class ApiWorkflowClient(
         lightly_s3_sse_kms_key = os.environ.get(LIGHTLY_S3_SSE_KMS_KEY, "").strip()
         # Only set s3 related headers when we are talking with s3
         if (
-            get_signed_url_destination(signed_write_url) == DatasourceType.S3
+            utils.get_signed_url_destination(signed_write_url) == DatasourceType.S3
             and lightly_s3_sse_kms_key
         ):
             if headers is None:

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -1,16 +1,16 @@
 import io
 import os
+import urllib.request
 import warnings
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Dict, List, Optional
-from urllib.request import Request, urlopen
+from urllib.request import Request
 
 import tqdm
 from PIL import Image
 
-from lightly.api import download
+from lightly.api import download, utils
 from lightly.api.bitmask import BitMask
-from lightly.api.utils import paginate_endpoint
 from lightly.openapi_generated.swagger_client.models import (
     DatasetEmbeddingData,
     ImageType,
@@ -33,7 +33,7 @@ def _make_dir_and_save_image(output_dir: str, filename: str, img: Image):
 def _get_image_from_read_url(read_url: str):
     """Makes a get request to the signed read url and returns the image."""
     request = Request(read_url, method="GET")
-    with urlopen(request) as response:
+    with urllib.request.urlopen(request) as response:
         blob = response.read()
         img = Image.open(io.BytesIO(blob))
     return img
@@ -293,7 +293,7 @@ class _DownloadDatasetMixin:
             [{'id': 0, 'data': {'image': '...', ...}}]
         """
         label_studio_tasks = list(
-            paginate_endpoint(
+            utils.paginate_endpoint(
                 self._tags_api.export_tag_to_label_studio_tasks,
                 page_size=20000,
                 dataset_id=self.dataset_id,

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -1,7 +1,8 @@
 import warnings
 from typing import Dict, List
 
-from lightly.api.utils import paginate_endpoint, retry
+from lightly.api import utils
+from lightly.api.utils import retry
 from lightly.openapi_generated.swagger_client.models import (
     FileNameFormat,
     LabelBoxDataRow,
@@ -39,7 +40,7 @@ class _ExportDatasetMixin:
             [{'id': 0, 'data': {'image': '...', ...}}]
         """
         label_studio_tasks: List[LabelStudioTask] = list(
-            paginate_endpoint(
+            utils.paginate_endpoint(
                 self._tags_api.export_tag_to_label_studio_tasks,
                 page_size=20000,
                 dataset_id=self.dataset_id,
@@ -114,7 +115,7 @@ class _ExportDatasetMixin:
             )
         )
         label_box_data_rows: List[LabelBoxDataRow] = list(
-            paginate_endpoint(
+            utils.paginate_endpoint(
                 self._tags_api.export_tag_to_label_box_data_rows,
                 page_size=20000,
                 dataset_id=self.dataset_id,
@@ -187,7 +188,7 @@ class _ExportDatasetMixin:
             [{'row_data': '...', 'global_key': 'image-1.jpg', 'media_type': 'IMAGE'}
         """
         label_box_data_rows: List[LabelBoxV4DataRow] = list(
-            paginate_endpoint(
+            utils.paginate_endpoint(
                 self._tags_api.export_tag_to_label_box_v4_data_rows,
                 page_size=20000,
                 dataset_id=self.dataset_id,

--- a/lightly/api/api_workflow_upload_dataset.py
+++ b/lightly/api/api_workflow_upload_dataset.py
@@ -10,12 +10,8 @@ from typing import Any, Dict, Optional, Union
 import tqdm
 from lightly_utils import image_processing
 
-from lightly.api.utils import (
-    MAXIMUM_FILENAME_LENGTH,
-    build_azure_signed_url_write_headers,
-    check_filename,
-    retry,
-)
+from lightly.api import utils
+from lightly.api.utils import MAXIMUM_FILENAME_LENGTH, retry
 from lightly.openapi_generated.swagger_client.models import (
     DatasourceConfigBase,
     InitialTagCreateRequest,
@@ -247,7 +243,7 @@ class _UploadDatasetMixin:
     ) -> None:
         """Uploads a single image to the Lightly platform."""
         # check whether the filepath is too long
-        if not check_filename(filepath):
+        if not utils.check_filename(filepath):
             msg = (
                 "Filepath {filepath} is longer than the allowed maximum of "
                 f"{MAXIMUM_FILENAME_LENGTH} characters and will be skipped."
@@ -291,7 +287,7 @@ class _UploadDatasetMixin:
                 if datasource_type == "AZURE":
                     # build headers for Azure blob storage
                     size_in_bytes = str(image_to_upload.getbuffer().nbytes)
-                    headers = build_azure_signed_url_write_headers(size_in_bytes)
+                    headers = utils.build_azure_signed_url_write_headers(size_in_bytes)
                 retry(
                     self.upload_file_with_signed_url,
                     image_to_upload,
@@ -308,7 +304,9 @@ class _UploadDatasetMixin:
                         image_to_upload.seek(0, 2)
                         size_in_bytes = str(image_to_upload.tell())
                         image_to_upload.seek(0, 0)
-                        headers = build_azure_signed_url_write_headers(size_in_bytes)
+                        headers = utils.build_azure_signed_url_write_headers(
+                            size_in_bytes
+                        )
                     retry(
                         self.upload_file_with_signed_url,
                         image_to_upload,

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -11,7 +11,7 @@ from lightly.openapi_generated.swagger_client.models import (
     SamplePartialMode,
     SampleUpdateRequest,
 )
-from lightly.utils.hipify import print_as_warning
+from lightly.utils import hipify
 from lightly.utils.io import COCO_ANNOTATION_KEYS
 
 
@@ -168,7 +168,7 @@ class _UploadCustomMetadataMixin:
             image_id = metadata[COCO_ANNOTATION_KEYS.custom_metadata_image_id]
             filename = image_id_to_filename.get(image_id, None)
             if filename is None:
-                print_as_warning(
+                hipify.print_as_warning(
                     "No image found for custom metadata annotation "
                     f"with image_id {image_id}. "
                     "This custom metadata annotation is skipped. ",
@@ -177,7 +177,7 @@ class _UploadCustomMetadataMixin:
                 continue
             sample_id = filename_to_sample_id.get(filename, None)
             if sample_id is None:
-                print_as_warning(
+                hipify.print_as_warning(
                     "You tried to upload custom metadata for a sample with "
                     f"filename {{{filename}}}, "
                     "but a sample with this filename "

--- a/lightly/api/bitmask.py
+++ b/lightly/api/bitmask.py
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
-from copy import deepcopy
+import copy
 from typing import List
 
 
@@ -175,7 +175,7 @@ class BitMask:
         self.x = self.x - other.x
 
     def __sub__(self, other):
-        ret = deepcopy(self)
+        ret = copy.deepcopy(self)
         ret.difference(other)
         return ret
 

--- a/lightly/api/version_checking.py
+++ b/lightly/api/version_checking.py
@@ -40,7 +40,7 @@ def is_compatible_version(current_version: str) -> bool:
     with TimeoutDecorator(1):
         versioning_api = get_versioning_api()
         minimum_version: str = versioning_api.get_minimum_compatible_pip_version()
-    return version_compare(current_version, minimum_version) >= 0
+    return version_compare.version_compare(current_version, minimum_version) >= 0
 
 
 def get_versioning_api() -> VersioningApi:

--- a/lightly/api/version_checking.py
+++ b/lightly/api/version_checking.py
@@ -5,7 +5,7 @@ from typing import Tuple
 from lightly.api import utils
 from lightly.api.swagger_api_client import LightlySwaggerApiClient
 from lightly.openapi_generated.swagger_client.api import VersioningApi
-from lightly.utils.version_compare import version_compare
+from lightly.utils import version_compare
 
 
 class LightlyAPITimeoutException(Exception):
@@ -33,7 +33,7 @@ def is_latest_version(current_version: str) -> bool:
         latest_version: str = versioning_api.get_latest_pip_version(
             current_version=current_version
         )
-    return version_compare(current_version, latest_version) >= 0
+    return version_compare.version_compare(current_version, latest_version) >= 0
 
 
 def is_compatible_version(current_version: str) -> bool:

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -83,7 +83,7 @@ from lightly.openapi_generated.swagger_client.models import (
     WriteCSVUrlData,
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import utils
 
 
 def _check_dataset_id(dataset_id: str):
@@ -99,13 +99,13 @@ class MockedEmbeddingsApi(EmbeddingsApi):
         EmbeddingsApi.__init__(self, api_client=api_client)
         self.embeddings = [
             DatasetEmbeddingData(
-                id=generate_id(),
+                id=utils.generate_id(),
                 name="embedding_newest",
                 is_processed=True,
                 created_at=1111111,
             ),
             DatasetEmbeddingData(
-                id=generate_id(),
+                id=utils.generate_id(),
                 name="default",
                 is_processed=True,
                 created_at=0,
@@ -116,7 +116,7 @@ class MockedEmbeddingsApi(EmbeddingsApi):
         _check_dataset_id(dataset_id)
         assert isinstance(dataset_id, str)
         response_ = WriteCSVUrlData(
-            signed_write_url="signed_write_url_valid", embedding_id=generate_id()
+            signed_write_url="signed_write_url_valid", embedding_id=utils.generate_id()
         )
         return response_
 
@@ -189,7 +189,7 @@ class MockedTagsApi(TagsApi):
         _check_dataset_id(dataset_id)
         assert isinstance(initial_tag_create_request, InitialTagCreateRequest)
         assert isinstance(dataset_id, str)
-        response_ = CreateEntityResponse(id=generate_id())
+        response_ = CreateEntityResponse(id=utils.generate_id())
         return response_
 
     def get_tag_by_tag_id(self, dataset_id, tag_id, **kwargs):
@@ -199,7 +199,7 @@ class MockedTagsApi(TagsApi):
         response_ = TagData(
             id=tag_id,
             dataset_id=dataset_id,
-            prev_tag_id=generate_id(),
+            prev_tag_id=utils.generate_id(),
             bit_mask_data="0x80bda23e9",
             name="second-tag",
             tot_size=15,
@@ -212,7 +212,7 @@ class MockedTagsApi(TagsApi):
         _check_dataset_id(dataset_id)
 
         tag_1 = TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=None,
             bit_mask_data="0xf",
@@ -222,7 +222,7 @@ class MockedTagsApi(TagsApi):
             changes=[],
         )
         tag_2 = TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=tag_1.id,
             bit_mask_data="0xf",
@@ -232,7 +232,7 @@ class MockedTagsApi(TagsApi):
             changes=[],
         )
         tag_3 = TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=tag_1.id,
             bit_mask_data="0x1",
@@ -242,7 +242,7 @@ class MockedTagsApi(TagsApi):
             changes=[],
         )
         tag_4 = TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=tag_3.id,
             bit_mask_data="0x3",
@@ -252,7 +252,7 @@ class MockedTagsApi(TagsApi):
             changes=[],
         )
         tag_5 = TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=None,
             bit_mask_data="0x1",
@@ -295,7 +295,7 @@ class MockedTagsApi(TagsApi):
     ) -> TagData:
         _check_dataset_id(dataset_id)
         tag = TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=tag_create_request["prev_tag_id"],
             bit_mask_data=tag_create_request["bit_mask_data"],
@@ -520,7 +520,7 @@ class MockedDatasetsApi(DatasetsApi):
         self._default_datasets = [
             DatasetData(
                 name=f"dataset_{i}",
-                id=generate_id(),
+                id=utils.generate_id(),
                 last_modified_at=i,
                 type="Images",
                 img_type="full",
@@ -534,7 +534,7 @@ class MockedDatasetsApi(DatasetsApi):
         self._shared_datasets = [
             DatasetData(
                 name=f"shared_dataset_{i}",
-                id=generate_id(),
+                id=utils.generate_id(),
                 last_modified_at=0,
                 type="Images",
                 img_type="full",
@@ -572,7 +572,7 @@ class MockedDatasetsApi(DatasetsApi):
 
     def create_dataset(self, dataset_create_request: DatasetCreateRequest, **kwargs):
         assert isinstance(dataset_create_request, DatasetCreateRequest)
-        id = generate_id()
+        id = utils.generate_id()
         if dataset_create_request.name == "xyz-no-tags":
             id = "xyz-no-tags"
         dataset = DatasetData(
@@ -583,7 +583,7 @@ class MockedDatasetsApi(DatasetsApi):
             size_in_bytes=-1,
             n_samples=-1,
             created_at=-1,
-            user_id=generate_id(),
+            user_id=utils.generate_id(),
         )
         self.datasets.append(dataset)
         response_ = CreateEntityResponse(id=id)
@@ -819,10 +819,10 @@ class MockedComputeWorkerApi(DockerApi):
         super().__init__(api_client=api_client)
         self._compute_worker_runs = [
             DockerRunData(
-                id=generate_id(),
+                id=utils.generate_id(),
                 user_id="user-id",
                 docker_version="v1",
-                dataset_id=generate_id(),
+                dataset_id=utils.generate_id(),
                 state=DockerRunState.TRAINING,
                 created_at=0,
                 last_modified_at=100,
@@ -832,20 +832,20 @@ class MockedComputeWorkerApi(DockerApi):
         ]
         self._scheduled_compute_worker_runs = [
             DockerRunScheduledData(
-                id=generate_id(),
-                dataset_id=generate_id(),
-                config_id=generate_id(),
+                id=utils.generate_id(),
+                dataset_id=utils.generate_id(),
+                config_id=utils.generate_id(),
                 priority=DockerRunScheduledPriority.MID,
                 state=DockerRunScheduledState.OPEN,
                 created_at=0,
                 last_modified_at=100,
-                owner=generate_id(),
+                owner=utils.generate_id(),
                 runs_on=[],
             )
         ]
         self._registered_workers = [
             DockerWorkerRegistryEntryData(
-                id=generate_id(),
+                id=utils.generate_id(),
                 user_id="user-id",
                 name="worker-name-1",
                 worker_type=DockerWorkerType.FULL,
@@ -858,18 +858,18 @@ class MockedComputeWorkerApi(DockerApi):
 
     def register_docker_worker(self, body, **kwargs):
         assert isinstance(body, CreateDockerWorkerRegistryEntryRequest)
-        return CreateEntityResponse(id=generate_id())
+        return CreateEntityResponse(id=utils.generate_id())
 
     def get_docker_worker_registry_entries(self, **kwargs):
         return self._registered_workers
 
     def create_docker_worker_config(self, body, **kwargs):
         assert isinstance(body, DockerWorkerConfigCreateRequest)
-        return CreateEntityResponse(id=generate_id())
+        return CreateEntityResponse(id=utils.generate_id())
 
     def create_docker_worker_config_v3(self, body, **kwargs):
         assert isinstance(body, DockerWorkerConfigV3CreateRequest)
-        return CreateEntityResponse(id=generate_id())
+        return CreateEntityResponse(id=utils.generate_id())
 
     def create_docker_run_scheduled_by_dataset_id(
         self, docker_run_scheduled_create_request, dataset_id, **kwargs
@@ -878,7 +878,7 @@ class MockedComputeWorkerApi(DockerApi):
             docker_run_scheduled_create_request, DockerRunScheduledCreateRequest
         )
         _check_dataset_id(dataset_id)
-        return CreateEntityResponse(id=generate_id())
+        return CreateEntityResponse(id=utils.generate_id())
 
     def get_docker_runs(
         self,
@@ -1005,11 +1005,11 @@ class MockedAPICollaboration(CollaborationApi):
         assert isinstance(
             shared_access_config_create_request, SharedAccessConfigCreateRequest
         )
-        return CreateEntityResponse(id=generate_id())
+        return CreateEntityResponse(id=utils.generate_id())
 
     def get_shared_access_configs_by_dataset_id(self, dataset_id, **kwargs):
         write_config = SharedAccessConfigData(
-            id=generate_id(),
+            id=utils.generate_id(),
             owner="owner-id",
             users=["user1@gmail.com", "user2@something.com"],
             teams=["some-id"],

--- a/tests/api_workflow/test_api_workflow.py
+++ b/tests/api_workflow/test_api_workflow.py
@@ -4,11 +4,11 @@ from unittest import mock
 import numpy as np
 
 import lightly
+from tests.api_workflow import utils
 from tests.api_workflow.mocked_api_workflow_client import (
     MockedApiWorkflowClient,
     MockedApiWorkflowSetup,
 )
-from tests.api_workflow.utils import generate_id
 
 
 class TestApiWorkflow(MockedApiWorkflowSetup):
@@ -44,7 +44,7 @@ class TestApiWorkflow(MockedApiWorkflowSetup):
         assert dataset_id == self.api_workflow_client._datasets_api.datasets[-1].id
 
     def test_dataset_id_existing(self):
-        id = generate_id()
+        id = utils.generate_id()
         self.api_workflow_client._dataset_id = id
         assert self.api_workflow_client.dataset_id == id
 

--- a/tests/api_workflow/test_api_workflow_artifacts.py
+++ b/tests/api_workflow/test_api_workflow_artifacts.py
@@ -9,7 +9,7 @@ from lightly.openapi_generated.swagger_client.models import (
     DockerRunData,
     DockerRunState,
 )
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import utils
 
 
 def test_download_compute_worker_run_artifacts(mocker: MockerFixture) -> None:
@@ -20,12 +20,12 @@ def test_download_compute_worker_run_artifacts(mocker: MockerFixture) -> None:
     client._download_compute_worker_run_artifact = (
         mock_download_compute_worker_run_artifact
     )
-    run_id = generate_id()
-    artifact_ids = [generate_id(), generate_id()]
+    run_id = utils.generate_id()
+    artifact_ids = [utils.generate_id(), utils.generate_id()]
     run = DockerRunData(
         id=run_id,
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
         state=DockerRunState.COMPUTING_METADATA,
         created_at=0,
@@ -72,12 +72,12 @@ def test__download_compute_worker_run_artifact_by_type(
     client._download_compute_worker_run_artifact = (
         mock_download_compute_worker_run_artifact
     )
-    run_id = generate_id()
-    artifact_ids = [generate_id(), generate_id()]
+    run_id = utils.generate_id()
+    artifact_ids = [utils.generate_id(), utils.generate_id()]
     run = DockerRunData(
         id=run_id,
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
         state=DockerRunState.COMPUTING_METADATA,
         created_at=0,
@@ -120,9 +120,9 @@ def test__download_compute_worker_run_artifact_by_type__no_artifacts(
         mock_download_compute_worker_run_artifact
     )
     run = DockerRunData(
-        id=generate_id(),
+        id=utils.generate_id(),
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
         state=DockerRunState.COMPUTING_METADATA,
         created_at=0,
@@ -149,16 +149,16 @@ def test__download_compute_worker_run_artifact_by_type__no_artifact_with_type(
         mock_download_compute_worker_run_artifact
     )
     run = DockerRunData(
-        id=generate_id(),
+        id=utils.generate_id(),
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
         state=DockerRunState.COMPUTING_METADATA,
         created_at=0,
         last_modified_at=0,
         artifacts=[
             DockerRunArtifactData(
-                id=generate_id(),
+                id=utils.generate_id(),
                 file_name="report.pdf",
                 type=DockerRunArtifactType.REPORT_PDF,
             ),
@@ -178,7 +178,7 @@ def test__get_compute_worker_run_checkpoint_url(
 ) -> None:
     mocked_client = mocker.MagicMock(spec=ApiWorkflowClient)
     mocked_artifact = DockerRunArtifactData(
-        id=generate_id(),
+        id=utils.generate_id(),
         file_name="report.pdf",
         type=DockerRunArtifactType.REPORT_PDF,
     )
@@ -189,9 +189,9 @@ def test__get_compute_worker_run_checkpoint_url(
     )
 
     run = DockerRunData(
-        id=generate_id(),
+        id=utils.generate_id(),
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
         state=DockerRunState.COMPUTING_METADATA,
         created_at=0,

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -86,7 +86,9 @@ class TestApiWorkflowClient(unittest.TestCase):
 def test_user_agent_header(mocker: MockerFixture) -> None:
     mocker.patch.object(lightly.api.api_workflow_client, "__version__", new="VERSION")
     mocker.patch.object(
-        lightly.api.api_workflow_client, "is_compatible_version", new=lambda _: True
+        lightly.api.api_workflow_client.version_checking,
+        "is_compatible_version",
+        new=lambda _: True,
     )
     mocked_platform = mocker.patch.object(
         lightly.api.api_workflow_client, "platform", spec_set=platform

--- a/tests/api_workflow/test_api_workflow_collaboration.py
+++ b/tests/api_workflow/test_api_workflow_collaboration.py
@@ -1,8 +1,8 @@
+from tests.api_workflow import utils
 from tests.api_workflow.mocked_api_workflow_client import (
     MockedApiWorkflowClient,
     MockedApiWorkflowSetup,
 )
-from tests.api_workflow.utils import generate_id
 
 
 class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
@@ -11,16 +11,16 @@ class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
 
     def test_share_empty_dataset(self):
         self.api_workflow_client.share_dataset_only_with(
-            dataset_id=generate_id(), user_emails=[]
+            dataset_id=utils.generate_id(), user_emails=[]
         )
 
     def test_share_dataset(self):
         self.api_workflow_client.share_dataset_only_with(
-            dataset_id=generate_id(), user_emails=["someone@something.com"]
+            dataset_id=utils.generate_id(), user_emails=["someone@something.com"]
         )
 
     def test_get_shared_users(self):
         user_emails = self.api_workflow_client.get_shared_users(
-            dataset_id=generate_id()
+            dataset_id=utils.generate_id()
         )
         assert user_emails == ["user1@gmail.com", "user2@something.com"]

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -44,8 +44,8 @@ from lightly.openapi_generated.swagger_client.models import (
     TagData,
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
+from tests.api_workflow import utils
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
-from tests.api_workflow.utils import generate_id
 
 
 class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
@@ -81,7 +81,7 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
                     {
                         "input": {
                             "type": "EMBEDDINGS",
-                            "dataset_id": generate_id(),
+                            "dataset_id": utils.generate_id(),
                             "tag_name": "some-tag-name",
                         },
                         "strategy": {"type": "SIMILARITY"},
@@ -107,7 +107,7 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
                     SelectionConfigEntry(
                         input=SelectionConfigEntryInput(
                             type=SelectionInputType.EMBEDDINGS,
-                            dataset_id=generate_id(),
+                            dataset_id=utils.generate_id(),
                             tag_name="some-tag-name",
                         ),
                         strategy=SelectionConfigEntryStrategy(
@@ -254,7 +254,7 @@ class TestApiWorkflowComputeWorker(MockedApiWorkflowSetup):
 
 
 def test_selection_config_from_dict() -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     cfg = {
         "n_samples": 10,
         "proportion_samples": 0.1,
@@ -364,12 +364,12 @@ def test_selection_config_from_dict__multiple_references() -> None:
 
 
 def test_get_scheduled_run_by_id() -> None:
-    run_ids = [generate_id() for _ in range(3)]
+    run_ids = [utils.generate_id() for _ in range(3)]
     scheduled_runs = [
         DockerRunScheduledData(
             id=run_id,
-            dataset_id=generate_id(),
-            config_id=generate_id(),
+            dataset_id=utils.generate_id(),
+            config_id=utils.generate_id(),
             priority=DockerRunScheduledPriority.MID,
             state=DockerRunScheduledState.OPEN,
             created_at=0,
@@ -395,9 +395,9 @@ def test_get_scheduled_run_by_id() -> None:
 def test_get_scheduled_run_by_id_not_found() -> None:
     scheduled_runs = [
         DockerRunScheduledData(
-            id=generate_id(),
-            dataset_id=generate_id(),
-            config_id=generate_id(),
+            id=utils.generate_id(),
+            dataset_id=utils.generate_id(),
+            config_id=utils.generate_id(),
             priority=DockerRunScheduledPriority.LOW,
             state=DockerRunScheduledState.OPEN,
             created_at=0,
@@ -424,11 +424,11 @@ def test_get_scheduled_run_by_id_not_found() -> None:
 
 
 def test_get_compute_worker_state_and_message_OPEN() -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     scheduled_run = DockerRunScheduledData(
-        id=generate_id(),
+        id=utils.generate_id(),
         dataset_id=dataset_id,
-        config_id=generate_id(),
+        config_id=utils.generate_id(),
         priority=DockerRunScheduledPriority.MID,
         state=DockerRunScheduledState.OPEN,
         created_at=0,
@@ -475,7 +475,7 @@ def test_create_docker_worker_config_v3_api_error() -> None:
         )
 
     client = ApiWorkflowClient(token="123")
-    client._dataset_id = generate_id()
+    client._dataset_id = utils.generate_id()
     client._compute_worker_api.create_docker_worker_config_v3 = mocked_raise_exception
     with pytest.raises(
         ValueError,
@@ -511,7 +511,7 @@ def test_create_docker_worker_config_v3_5xx_api_error() -> None:
         )
 
     client = ApiWorkflowClient(token="123")
-    client._dataset_id = generate_id()
+    client._dataset_id = utils.generate_id()
     client._compute_worker_api.create_docker_worker_config_v3 = mocked_raise_exception
     with pytest.raises(
         ApiException,
@@ -532,7 +532,7 @@ def test_create_docker_worker_config_v3_no_body_api_error() -> None:
         raise ApiException
 
     client = ApiWorkflowClient(token="123")
-    client._dataset_id = generate_id()
+    client._dataset_id = utils.generate_id()
     client._compute_worker_api.create_docker_worker_config_v3 = mocked_raise_exception
     with pytest.raises(
         ApiException,
@@ -552,7 +552,7 @@ def test_get_compute_worker_state_and_message_CANCELED() -> None:
         raise ApiException
 
     mocked_api_client = MagicMock(
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         _compute_worker_api=MagicMock(
             get_docker_run_by_scheduled_id=mocked_raise_exception
         ),
@@ -569,7 +569,7 @@ def test_get_compute_worker_state_and_message_CANCELED() -> None:
 def test_get_compute_worker_state_and_message_docker_state() -> None:
     message = "SOME_MESSAGE"
     docker_run = DockerRunData(
-        id=generate_id(),
+        id=utils.generate_id(),
         user_id="user-id",
         state=DockerRunState.GENERATING_REPORT,
         docker_version="",
@@ -578,14 +578,14 @@ def test_get_compute_worker_state_and_message_docker_state() -> None:
         message=message,
     )
     mocked_api_client = MagicMock(
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         _compute_worker_api=MagicMock(
             get_docker_run_by_scheduled_id=lambda scheduled_id: docker_run
         ),
     )
 
     run_info = ApiWorkflowClient.get_compute_worker_run_info(
-        self=mocked_api_client, scheduled_run_id=generate_id()
+        self=mocked_api_client, scheduled_run_id=utils.generate_id()
     )
     assert run_info.state == DockerRunState.GENERATING_REPORT
     assert run_info.message == message
@@ -626,8 +626,8 @@ def test_compute_worker_run_info_generator(mocker) -> None:
 
 def test_get_compute_worker_runs(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    dataset_id = generate_id()
-    run_ids = [generate_id(), generate_id()]
+    dataset_id = utils.generate_id()
+    run_ids = [utils.generate_id(), utils.generate_id()]
     client = ApiWorkflowClient(token="123")
     mock_compute_worker_api = mocker.create_autospec(
         DockerApi, spec_set=True
@@ -682,8 +682,8 @@ def test_get_compute_worker_runs(mocker: MockerFixture) -> None:
 
 def test_get_compute_worker_runs__dataset(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    dataset_id = generate_id()
-    run_id = generate_id()
+    dataset_id = utils.generate_id()
+    run_id = utils.generate_id()
     client = ApiWorkflowClient(token="123")
     mock_compute_worker_api = mocker.create_autospec(
         DockerApi, spec_set=True
@@ -721,8 +721,8 @@ def test_get_compute_worker_runs__dataset(mocker: MockerFixture) -> None:
 
 def test_get_compute_worker_run_tags__no_tags(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    run_id = generate_id()
-    client = ApiWorkflowClient(token="123", dataset_id=generate_id())
+    run_id = utils.generate_id()
+    client = ApiWorkflowClient(token="123", dataset_id=utils.generate_id())
     mock_compute_worker_api = mocker.create_autospec(
         DockerApi, spec_set=True
     ).return_value
@@ -734,8 +734,8 @@ def test_get_compute_worker_run_tags__no_tags(mocker: MockerFixture) -> None:
 
 
 def test_get_compute_worker_run_tags__single_tag(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
-    run_id = generate_id()
+    dataset_id = utils.generate_id()
+    run_id = utils.generate_id()
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     client = ApiWorkflowClient(token="123", dataset_id=dataset_id)
     client._dataset_id = dataset_id
@@ -744,7 +744,7 @@ def test_get_compute_worker_run_tags__single_tag(mocker: MockerFixture) -> None:
     ).return_value
     mock_compute_worker_api.get_docker_run_tags.return_value = [
         TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=None,
             bit_mask_data="0x1",
@@ -763,15 +763,15 @@ def test_get_compute_worker_run_tags__single_tag(mocker: MockerFixture) -> None:
 
 def test_get_compute_worker_run_tags__multiple_tags(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    run_id = generate_id()
-    dataset_id = generate_id()
+    run_id = utils.generate_id()
+    dataset_id = utils.generate_id()
     client = ApiWorkflowClient(token="123", dataset_id=dataset_id)
     client._dataset_id = dataset_id
     mock_compute_worker_api = mocker.create_autospec(
         DockerApi, spec_set=True
     ).return_value
 
-    tag_ids = [generate_id() for _ in range(3)]
+    tag_ids = [utils.generate_id() for _ in range(3)]
     tag_0 = TagData(
         id=tag_ids[0],
         dataset_id=dataset_id,
@@ -797,7 +797,7 @@ def test_get_compute_worker_run_tags__multiple_tags(mocker: MockerFixture) -> No
     # tag from a different dataset
     tag_2 = TagData(
         id=tag_ids[2],
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         prev_tag_id=None,
         bit_mask_data="0x1",
         name="tag-2",

--- a/tests/api_workflow/test_api_workflow_datasets.py
+++ b/tests/api_workflow/test_api_workflow_datasets.py
@@ -12,15 +12,15 @@ from lightly.openapi_generated.swagger_client.models import (
     DatasetType,
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
+from tests.api_workflow import utils
 from tests.api_workflow.mocked_api_workflow_client import MockedApiWorkflowSetup
-from tests.api_workflow.utils import generate_id
 
 
 def _get_datasets(count: int) -> List[DatasetData]:
     return [
         DatasetData(
             name=f"mock_dataset_{i}",
-            id=generate_id(),
+            id=utils.generate_id(),
             last_modified_at=0,
             type=DatasetType.IMAGES,
             img_type="full",

--- a/tests/api_workflow/test_api_workflow_download_dataset.py
+++ b/tests/api_workflow/test_api_workflow_download_dataset.py
@@ -9,18 +9,18 @@ from lightly.openapi_generated.swagger_client.models import (
     ImageType,
     TagData,
 )
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import utils
 
 
 def test_download_dataset__no_image(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocked_api = mocker.MagicMock()
     mocked_get_dataset_by_id = mocker.MagicMock(
         return_value=DatasetData(
             name="dataset",
             id=dataset_id,
-            user_id=generate_id(),
+            user_id=utils.generate_id(),
             last_modified_at=0,
             type=DatasetType.IMAGES,
             img_type=ImageType.META,
@@ -47,8 +47,8 @@ def test_download_dataset__tag_missing(mocker: MockerFixture) -> None:
     mocked_get_dataset_by_id = mocker.MagicMock(
         return_value=DatasetData(
             name="dataset",
-            id=generate_id(),
-            user_id=generate_id(),
+            id=utils.generate_id(),
+            user_id=utils.generate_id(),
             last_modified_at=0,
             type=DatasetType.IMAGES,
             img_type=ImageType.FULL,
@@ -68,13 +68,13 @@ def test_download_dataset__tag_missing(mocker: MockerFixture) -> None:
 
 
 def test_download_dataset__ok(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
 
     mocked_get_dataset_by_id = mocker.MagicMock(
         return_value=DatasetData(
             name="dataset",
             id=dataset_id,
-            user_id=generate_id(),
+            user_id=utils.generate_id(),
             last_modified_at=0,
             type=DatasetType.IMAGES,
             img_type=ImageType.FULL,
@@ -106,7 +106,7 @@ def test_download_dataset__ok(mocker: MockerFixture) -> None:
         "get_all_tags",
         return_value=[
             TagData(
-                id=generate_id(),
+                id=utils.generate_id(),
                 dataset_id=dataset_id,
                 prev_tag_id=None,
                 bit_mask_data="0x1",
@@ -149,13 +149,13 @@ def test_download_dataset__ok(mocker: MockerFixture) -> None:
 
 def test_get_embedding_data_by_name(mocker: MockerFixture) -> None:
     embedding_0 = DatasetEmbeddingData(
-        id=generate_id(),
+        id=utils.generate_id(),
         name="embedding_0",
         created_at=0,
         is_processed=False,
     )
     embedding_1 = DatasetEmbeddingData(
-        id=generate_id(),
+        id=utils.generate_id(),
         name="embedding_1",
         created_at=1,
         is_processed=False,
@@ -177,7 +177,7 @@ def test_get_embedding_data_by_name__no_embedding_with_name(
     mocker: MockerFixture,
 ) -> None:
     embedding = DatasetEmbeddingData(
-        id=generate_id(),
+        id=utils.generate_id(),
         name="embedding",
         created_at=0,
         is_processed=False,
@@ -230,7 +230,7 @@ def test_download_embeddings_csv_by_id(mocker: MockerFixture) -> None:
 
 
 def test_download_embeddings_csv(mocker: MockerFixture) -> None:
-    embedding_id = generate_id()
+    embedding_id = utils.generate_id()
 
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mock_get_all_embedding_data = mocker.patch.object(
@@ -282,7 +282,7 @@ def test_download_embeddings_csv__no_default_embedding(mocker: MockerFixture) ->
 
 def test__get_latest_default_embedding_data__no_default_embedding() -> None:
     custom_embedding = DatasetEmbeddingData(
-        id=generate_id(),
+        id=utils.generate_id(),
         name="custom-name",
         created_at=0,
         is_processed=False,

--- a/tests/api_workflow/test_api_workflow_export.py
+++ b/tests/api_workflow/test_api_workflow_export.py
@@ -79,7 +79,7 @@ def test_export_filenames_by_tag_name(mocker: MockerFixture) -> None:
 
 def test_export_label_box_data_rows_by_tag_id(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_paginate = mocker.patch.object(api_workflow_export, "paginate_endpoint")
+    mocked_paginate = mocker.patch.object(api_workflow_export.utils, "paginate_endpoint")
     mocked_api = mocker.MagicMock()
     mocked_warning = mocker.patch("warnings.warn")
 
@@ -125,7 +125,7 @@ def test_export_label_box_data_rows_by_tag_name(mocker: MockerFixture) -> None:
 
 def test_export_label_box_v4_data_rows_by_tag_id(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_paginate = mocker.patch.object(api_workflow_export, "paginate_endpoint")
+    mocked_paginate = mocker.patch.object(api_workflow_export.utils, "paginate_endpoint")
     mocked_api = mocker.MagicMock()
 
     client = ApiWorkflowClient()

--- a/tests/api_workflow/test_api_workflow_export.py
+++ b/tests/api_workflow/test_api_workflow_export.py
@@ -79,7 +79,9 @@ def test_export_filenames_by_tag_name(mocker: MockerFixture) -> None:
 
 def test_export_label_box_data_rows_by_tag_id(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_paginate = mocker.patch.object(api_workflow_export.utils, "paginate_endpoint")
+    mocked_paginate = mocker.patch.object(
+        api_workflow_export.utils, "paginate_endpoint"
+    )
     mocked_api = mocker.MagicMock()
     mocked_warning = mocker.patch("warnings.warn")
 
@@ -125,7 +127,9 @@ def test_export_label_box_data_rows_by_tag_name(mocker: MockerFixture) -> None:
 
 def test_export_label_box_v4_data_rows_by_tag_id(mocker: MockerFixture) -> None:
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_paginate = mocker.patch.object(api_workflow_export.utils, "paginate_endpoint")
+    mocked_paginate = mocker.patch.object(
+        api_workflow_export.utils, "paginate_endpoint"
+    )
     mocked_api = mocker.MagicMock()
 
     client = ApiWorkflowClient()

--- a/tests/api_workflow/test_api_workflow_export.py
+++ b/tests/api_workflow/test_api_workflow_export.py
@@ -2,12 +2,12 @@ from pytest_mock import MockerFixture
 
 from lightly.api import ApiWorkflowClient, api_workflow_export
 from lightly.openapi_generated.swagger_client.models import FileNameFormat, TagData
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import utils
 
 
 def _get_tag(dataset_id: str, tag_name: str) -> TagData:
     return TagData(
-        id=generate_id(),
+        id=utils.generate_id(),
         dataset_id=dataset_id,
         prev_tag_id=None,
         bit_mask_data="0x1",
@@ -19,7 +19,7 @@ def _get_tag(dataset_id: str, tag_name: str) -> TagData:
 
 
 def test_export_tag_to_basic_filenames_and_read_urls(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     mocked_retry = mocker.patch.object(
         api_workflow_export,
         "retry",
@@ -62,7 +62,7 @@ def test_export_tag_to_basic_filenames_and_read_urls(mocker: MockerFixture) -> N
 
 
 def test_export_filenames_by_tag_name(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     tag_name = "some-tag"
     tag = _get_tag(dataset_id=dataset_id, tag_name=tag_name)
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
@@ -84,7 +84,7 @@ def test_export_label_box_data_rows_by_tag_id(mocker: MockerFixture) -> None:
     mocked_warning = mocker.patch("warnings.warn")
 
     client = ApiWorkflowClient()
-    client._dataset_id = generate_id()
+    client._dataset_id = utils.generate_id()
     client._tags_api = mocked_api
     client.export_label_box_data_rows_by_tag_id(tag_id="tag_id")
     mocked_paginate.assert_called_once()
@@ -99,7 +99,7 @@ def test_export_label_box_data_rows_by_tag_id(mocker: MockerFixture) -> None:
 
 
 def test_export_label_box_data_rows_by_tag_name(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     tag_name = "some-tag"
     tag = _get_tag(dataset_id=dataset_id, tag_name=tag_name)
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
@@ -129,7 +129,7 @@ def test_export_label_box_v4_data_rows_by_tag_id(mocker: MockerFixture) -> None:
     mocked_api = mocker.MagicMock()
 
     client = ApiWorkflowClient()
-    client._dataset_id = generate_id()
+    client._dataset_id = utils.generate_id()
     client._tags_api = mocked_api
     client.export_label_box_v4_data_rows_by_tag_id(tag_id="tag_id")
     mocked_paginate.assert_called_once()
@@ -138,7 +138,7 @@ def test_export_label_box_v4_data_rows_by_tag_id(mocker: MockerFixture) -> None:
 
 
 def test_export_label_box_v4_data_rows_by_tag_name(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     tag_name = "some-tag"
     tag = _get_tag(dataset_id=dataset_id, tag_name=tag_name)
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
@@ -156,7 +156,7 @@ def test_export_label_box_v4_data_rows_by_tag_name(mocker: MockerFixture) -> Non
 
 
 def test_export_label_studio_tasks_by_tag_name(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     tag_name = "some-tag"
     tag = _get_tag(dataset_id=dataset_id, tag_name=tag_name)
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)

--- a/tests/api_workflow/test_api_workflow_selection.py
+++ b/tests/api_workflow/test_api_workflow_selection.py
@@ -14,13 +14,13 @@ from lightly.openapi_generated.swagger_client.models import (
     SamplingMethod,
     TagData,
 )
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import utils
 
 
 def _get_tags(dataset_id: str, tag_name: str = "just-a-tag") -> List[TagData]:
     return [
         TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=None,
             bit_mask_data="0x1",
@@ -46,7 +46,7 @@ def test_selection__tag_exists(mocker: MockerFixture) -> None:
     mocker.patch.object(
         ApiWorkflowClient,
         "get_all_tags",
-        return_value=_get_tags(dataset_id=generate_id(), tag_name=tag_name),
+        return_value=_get_tags(dataset_id=utils.generate_id(), tag_name=tag_name),
     )
 
     client = ApiWorkflowClient()
@@ -71,7 +71,7 @@ def test_selection__no_tags(mocker: MockerFixture) -> None:
 
 def test_selection(mocker: MockerFixture) -> None:
     tag_name = "some-tag"
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     mocker.patch("time.sleep")
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocker.patch.object(
@@ -86,13 +86,13 @@ def test_selection(mocker: MockerFixture) -> None:
 
     mocked_selection_api = mocker.MagicMock()
     mocked_sampling_response = mocker.MagicMock()
-    mocked_sampling_response.job_id = generate_id()
+    mocked_sampling_response.job_id = utils.generate_id()
     mocked_selection_api.trigger_sampling_by_id.return_value = mocked_sampling_response
 
     mocked_jobs_api = mocker.MagicMock()
     mocked_get_job_status = mocker.MagicMock(
         return_value=JobStatusData(
-            id=generate_id(),
+            id=utils.generate_id(),
             wait_time_till_next_poll=1,
             created_at=0,
             status=JobState.FINISHED,
@@ -118,7 +118,7 @@ def test_selection(mocker: MockerFixture) -> None:
 
 
 def test_selection__job_failed(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     job_id = "some-job-id"
     mocker.patch("time.sleep")
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
@@ -140,7 +140,7 @@ def test_selection__job_failed(mocker: MockerFixture) -> None:
     mocked_jobs_api = mocker.MagicMock()
     mocked_get_job_status = mocker.MagicMock(
         return_value=JobStatusData(
-            id=generate_id(),
+            id=utils.generate_id(),
             wait_time_till_next_poll=1,
             created_at=0,
             status=JobState.FAILED,
@@ -162,7 +162,7 @@ def test_selection__job_failed(mocker: MockerFixture) -> None:
 
 
 def test_selection__too_many_errors(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     job_id = "some-job-id"
     mocker.patch("time.sleep")
     mocked_print = mocker.patch("builtins.print")
@@ -203,7 +203,7 @@ def test_selection__too_many_errors(mocker: MockerFixture) -> None:
 
 
 def test_upload_scores(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     tags = _get_tags(dataset_id=dataset_id, tag_name="initial-tag")
     tag_id = tags[0].id
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)

--- a/tests/api_workflow/test_api_workflow_tags.py
+++ b/tests/api_workflow/test_api_workflow_tags.py
@@ -6,7 +6,7 @@ from pytest_mock import MockerFixture
 from lightly.api import ApiWorkflowClient
 from lightly.api.api_workflow_tags import TagDoesNotExistError
 from lightly.openapi_generated.swagger_client.models import TagCreator, TagData
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import utils
 
 
 def _get_tags(
@@ -14,7 +14,7 @@ def _get_tags(
 ) -> List[TagData]:
     return [
         TagData(
-            id=generate_id(),
+            id=utils.generate_id(),
             dataset_id=dataset_id,
             prev_tag_id=prev_tag_id,
             bit_mask_data="0x5",
@@ -27,7 +27,7 @@ def _get_tags(
 
 
 def test_create_tag_from_filenames(mocker: MockerFixture) -> None:
-    dataset_id = generate_id()
+    dataset_id = utils.generate_id()
     tags = _get_tags(dataset_id=dataset_id, tag_name="initial-tag")
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocker.patch.object(ApiWorkflowClient, "get_all_tags", return_value=tags)
@@ -51,7 +51,7 @@ def test_create_tag_from_filenames(mocker: MockerFixture) -> None:
 
 def test_create_tag_from_filenames__tag_exists(mocker: MockerFixture) -> None:
     tag_name = "some-tag"
-    tags = _get_tags(dataset_id=generate_id(), tag_name=tag_name)
+    tags = _get_tags(dataset_id=utils.generate_id(), tag_name=tag_name)
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocker.patch.object(ApiWorkflowClient, "get_all_tags", return_value=tags)
 
@@ -78,7 +78,7 @@ def test_create_tag_from_filenames__no_tags(mocker: MockerFixture) -> None:
 
 
 def test_create_tag_from_filenames__file_not_found(mocker: MockerFixture) -> None:
-    tags = _get_tags(dataset_id=generate_id(), tag_name="initial-tag")
+    tags = _get_tags(dataset_id=utils.generate_id(), tag_name="initial-tag")
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocker.patch.object(ApiWorkflowClient, "get_all_tags", return_value=tags)
     mocked_get_filenames = mocker.patch.object(
@@ -101,7 +101,7 @@ def test_create_tag_from_filenames__file_not_found(mocker: MockerFixture) -> Non
 
 
 def test_get_filenames_in_tag(mocker: MockerFixture) -> None:
-    tag = _get_tags(dataset_id=generate_id())[0]
+    tag = _get_tags(dataset_id=utils.generate_id())[0]
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocked_get_filenames = mocker.patch.object(
         ApiWorkflowClient, "get_filenames", return_value=[f"file{i}" for i in range(3)]
@@ -115,7 +115,7 @@ def test_get_filenames_in_tag(mocker: MockerFixture) -> None:
 
 
 def test_get_filenames_in_tag__filenames_given(mocker: MockerFixture) -> None:
-    tag = _get_tags(dataset_id=generate_id())[0]
+    tag = _get_tags(dataset_id=utils.generate_id())[0]
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocked_get_filenames = mocker.patch.object(ApiWorkflowClient, "get_filenames")
 
@@ -129,8 +129,8 @@ def test_get_filenames_in_tag__filenames_given(mocker: MockerFixture) -> None:
 
 
 def test_get_filenames_in_tag__exclude_parent_tag(mocker: MockerFixture) -> None:
-    prev_tag_id = generate_id()
-    dataset_id = generate_id()
+    prev_tag_id = utils.generate_id()
+    dataset_id = utils.generate_id()
     tag = _get_tags(dataset_id=dataset_id, prev_tag_id=prev_tag_id)[0]
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocked_get_filenames = mocker.patch.object(
@@ -180,7 +180,7 @@ def test_get_tag_by_id(mocker: MockerFixture) -> None:
 
 def test_get_tag_name(mocker: MockerFixture) -> None:
     tag_name = "some-tag"
-    tags = _get_tags(dataset_id=generate_id(), tag_name=tag_name)
+    tags = _get_tags(dataset_id=utils.generate_id(), tag_name=tag_name)
     mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
     mocker.patch.object(ApiWorkflowClient, "get_all_tags", return_value=tags)
     mocked_get_tag = mocker.patch.object(ApiWorkflowClient, "get_tag_by_id")

--- a/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
+++ b/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
@@ -50,7 +50,7 @@ def test_upload_custom_metadata(mocker: MockerFixture) -> None:
         ],
     )
     mocked_print_warning = mocker.patch.object(
-        api_workflow_upload_metadata, "print_as_warning"
+        api_workflow_upload_metadata.hipify, "print_as_warning"
     )
     mocked_executor = mocker.patch.object(
         api_workflow_upload_metadata, "ThreadPoolExecutor"

--- a/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
+++ b/tests/api_workflow/test_api_workflow_upload_custom_metadata.py
@@ -6,7 +6,7 @@ from lightly.openapi_generated.swagger_client.models import (
     SampleUpdateRequest,
 )
 from lightly.utils.io import COCO_ANNOTATION_KEYS
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import utils
 
 
 def test_index_custom_metadata_by_filename(mocker: MockerFixture) -> None:
@@ -45,7 +45,7 @@ def test_upload_custom_metadata(mocker: MockerFixture) -> None:
         api_workflow_upload_metadata,
         "retry",
         side_effect=[
-            [SampleDataModes(id=generate_id(), file_name="file1")],
+            [SampleDataModes(id=utils.generate_id(), file_name="file1")],
             None,
         ],
     )

--- a/tests/api_workflow/test_api_workflow_upload_embeddings.py
+++ b/tests/api_workflow/test_api_workflow_upload_embeddings.py
@@ -3,11 +3,8 @@ import tempfile
 
 import numpy as np
 
-from lightly.utils.io import (
-    INVALID_FILENAME_CHARACTERS,
-    load_embeddings,
-    save_embeddings,
-)
+from lightly.utils import io as io_utils
+from lightly.utils.io import INVALID_FILENAME_CHARACTERS
 from tests.api_workflow.mocked_api_workflow_client import (
     N_FILES_ON_SERVER,
     MockedApiWorkflowSetup,
@@ -37,7 +34,7 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
                 f"_{special_char_in_first_filename}" f"{self.sample_names[0]}"
             )
         labels = [0] * len(self.sample_names)
-        save_embeddings(
+        io_utils.save_embeddings(
             self.path_to_embeddings,
             np.random.randn(n_data, n_dims),
             labels,
@@ -160,13 +157,13 @@ class TestApiWorkflowUploadEmbeddings(MockedApiWorkflowSetup):
         )
 
         # load the new (appended) embeddings
-        _, labels_appended, filenames_appended = load_embeddings(
+        _, labels_appended, filenames_appended = io_utils.load_embeddings(
             self.path_to_embeddings
         )
 
         # define the expected filenames and labels
         self.create_fake_embeddings(n_data=n_data_local + n_data_start_local)
-        _, _, filenames_expected = load_embeddings(self.path_to_embeddings)
+        _, _, filenames_expected = io_utils.load_embeddings(self.path_to_embeddings)
         labels_expected = list(range(n_data_start_local)) + [0] * n_data_local
 
         # make sure the list of filenames and labels equal


### PR DESCRIPTION
Some functions are still imported directly, which is against the convention where we prefer to import modules and then reference the functions through the modules. This PR updates those lines.