### PR TITLE
lig-3659: align import style - part 2

### DIFF
--- a/lightly/api/api_workflow_artifacts.py
+++ b/lightly/api/api_workflow_artifacts.py
@@ -1,11 +1,7 @@
 import os
 
 from lightly.api import download
-from lightly.openapi_generated.swagger_client.models import (
-    DockerRunArtifactData,
-    DockerRunArtifactType,
-    DockerRunData,
-)
+from lightly.openapi_generated.swagger_client import models
 
 
 class ArtifactNotExist(Exception):
@@ -15,7 +11,7 @@ class ArtifactNotExist(Exception):
 class _ArtifactsMixin:
     def download_compute_worker_run_artifacts(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_dir: str,
         timeout: int = 60,
     ) -> None:
@@ -54,7 +50,7 @@ class _ArtifactsMixin:
 
     def download_compute_worker_run_checkpoint(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_path: str,
         timeout: int = 60,
     ) -> None:
@@ -91,14 +87,14 @@ class _ArtifactsMixin:
         """
         self._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.CHECKPOINT,
+            artifact_type=models.DockerRunArtifactType.CHECKPOINT,
             output_path=output_path,
             timeout=timeout,
         )
 
     def download_compute_worker_run_report_pdf(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_path: str,
         timeout: int = 60,
     ) -> None:
@@ -132,14 +128,14 @@ class _ArtifactsMixin:
         """
         self._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.REPORT_PDF,
+            artifact_type=models.DockerRunArtifactType.REPORT_PDF,
             output_path=output_path,
             timeout=timeout,
         )
 
     def download_compute_worker_run_report_json(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_path: str,
         timeout: int = 60,
     ) -> None:
@@ -173,14 +169,14 @@ class _ArtifactsMixin:
         """
         self._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.REPORT_JSON,
+            artifact_type=models.DockerRunArtifactType.REPORT_JSON,
             output_path=output_path,
             timeout=timeout,
         )
 
     def download_compute_worker_run_log(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_path: str,
         timeout: int = 60,
     ) -> None:
@@ -214,14 +210,14 @@ class _ArtifactsMixin:
         """
         self._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.LOG,
+            artifact_type=models.DockerRunArtifactType.LOG,
             output_path=output_path,
             timeout=timeout,
         )
 
     def download_compute_worker_run_memory_log(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_path: str,
         timeout: int = 60,
     ) -> None:
@@ -255,14 +251,14 @@ class _ArtifactsMixin:
         """
         self._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.MEMLOG,
+            artifact_type=models.DockerRunArtifactType.MEMLOG,
             output_path=output_path,
             timeout=timeout,
         )
 
     def download_compute_worker_run_corruptness_check_information(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_path: str,
         timeout: int = 60,
     ) -> None:
@@ -302,14 +298,14 @@ class _ArtifactsMixin:
         """
         self._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.CORRUPTNESS_CHECK_INFORMATION,
+            artifact_type=models.DockerRunArtifactType.CORRUPTNESS_CHECK_INFORMATION,
             output_path=output_path,
             timeout=timeout,
         )
 
     def download_compute_worker_run_sequence_information(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         output_path: str,
         timeout: int = 60,
     ) -> None:
@@ -343,14 +339,14 @@ class _ArtifactsMixin:
         """
         self._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.SEQUENCE_INFORMATION,
+            artifact_type=models.DockerRunArtifactType.SEQUENCE_INFORMATION,
             output_path=output_path,
             timeout=timeout,
         )
 
     def _download_compute_worker_run_artifact_by_type(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
         artifact_type: str,
         output_path: str,
         timeout: int,
@@ -364,8 +360,8 @@ class _ArtifactsMixin:
         )
 
     def _get_artifact_by_type(
-        self, artifact_type: str, run: DockerRunData
-    ) -> DockerRunArtifactData:
+        self, artifact_type: str, run: models.DockerRunData
+    ) -> models.DockerRunArtifactData:
         if run.artifacts is None:
             raise ArtifactNotExist(f"Run has no artifacts.")
         try:
@@ -395,7 +391,7 @@ class _ArtifactsMixin:
 
     def get_compute_worker_run_checkpoint_url(
         self,
-        run: DockerRunData,
+        run: models.DockerRunData,
     ) -> str:
         """Gets the download url of the last training checkpoint from a run.
 
@@ -428,7 +424,7 @@ class _ArtifactsMixin:
 
         """
         artifact = self._get_artifact_by_type(
-            artifact_type=DockerRunArtifactType.CHECKPOINT, run=run
+            artifact_type=models.DockerRunArtifactType.CHECKPOINT, run=run
         )
         read_url = self._compute_worker_api.get_docker_run_artifact_read_url_by_id(
             run_id=run.id, artifact_id=artifact.id

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -1,10 +1,6 @@
 from typing import List
 
-from lightly.openapi_generated.swagger_client.models import (
-    SharedAccessConfigCreateRequest,
-    SharedAccessConfigData,
-    SharedAccessType,
-)
+from lightly.openapi_generated.swagger_client import models
 
 
 class _CollaborationMixin:
@@ -37,8 +33,10 @@ class _CollaborationMixin:
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
           >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=[])
         """
-        body = SharedAccessConfigCreateRequest(
-            access_type=SharedAccessType.WRITE, users=user_emails, creator=self._creator
+        body = models.SharedAccessConfigCreateRequest(
+            access_type=models.SharedAccessType.WRITE,
+            users=user_emails,
+            creator=self._creator,
         )
         self._collaboration_api.create_or_update_shared_access_config_by_dataset_id(
             shared_access_config_create_request=body, dataset_id=dataset_id
@@ -61,7 +59,7 @@ class _CollaborationMixin:
         """
 
         access_configs: List[
-            SharedAccessConfigData
+            models.SharedAccessConfigData
         ] = self._collaboration_api.get_shared_access_configs_by_dataset_id(
             dataset_id=dataset_id
         )
@@ -71,7 +69,7 @@ class _CollaborationMixin:
         # we use the same hard rule in the frontend to communicate with the API
         # as we currently only support WRITE access
         for access_config in access_configs:
-            if access_config.access_type == SharedAccessType.WRITE:
+            if access_config.access_type == models.SharedAccessType.WRITE:
                 user_emails.extend(access_config.users)
                 break
 

--- a/tests/api_workflow/test_api_workflow_artifacts.py
+++ b/tests/api_workflow/test_api_workflow_artifacts.py
@@ -1,45 +1,42 @@
 import pytest
-from pytest_mock import MockerFixture
+import pytest_mock
 
-from lightly.api import ApiWorkflowClient, ArtifactNotExist
-from lightly.openapi_generated.swagger_client.api import DockerApi
-from lightly.openapi_generated.swagger_client.models import (
-    DockerRunArtifactData,
-    DockerRunArtifactType,
-    DockerRunData,
-    DockerRunState,
-)
-from tests.api_workflow.utils import generate_id
+from lightly import api as lightly_api
+from lightly.openapi_generated.swagger_client import api as swagger_api
+from lightly.openapi_generated.swagger_client import models
+from tests.api_workflow import utils
 
 
-def test_download_compute_worker_run_artifacts(mocker: MockerFixture) -> None:
-    client = ApiWorkflowClient(token="123")
+def test_download_compute_worker_run_artifacts(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    client = lightly_api.ApiWorkflowClient(token="123")
     mock_download_compute_worker_run_artifact = mocker.MagicMock(
         spec_set=client._download_compute_worker_run_artifact
     )
     client._download_compute_worker_run_artifact = (
         mock_download_compute_worker_run_artifact
     )
-    run_id = generate_id()
-    artifact_ids = [generate_id(), generate_id()]
-    run = DockerRunData(
+    run_id = utils.generate_id()
+    artifact_ids = [utils.generate_id(), utils.generate_id()]
+    run = models.DockerRunData(
         id=run_id,
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
-        state=DockerRunState.COMPUTING_METADATA,
+        state=models.DockerRunState.COMPUTING_METADATA,
         created_at=0,
         last_modified_at=0,
         artifacts=[
-            DockerRunArtifactData(
+            models.DockerRunArtifactData(
                 id=artifact_ids[0],
                 file_name="report.pdf",
-                type=DockerRunArtifactType.REPORT_PDF,
+                type=models.DockerRunArtifactType.REPORT_PDF,
             ),
-            DockerRunArtifactData(
+            models.DockerRunArtifactData(
                 id=artifact_ids[1],
                 file_name="checkpoint.ckpt",
-                type=DockerRunArtifactType.CHECKPOINT,
+                type=models.DockerRunArtifactType.CHECKPOINT,
             ),
         ],
     )
@@ -63,41 +60,41 @@ def test_download_compute_worker_run_artifacts(mocker: MockerFixture) -> None:
 
 
 def test__download_compute_worker_run_artifact_by_type(
-    mocker: MockerFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
-    client = ApiWorkflowClient(token="123")
+    client = lightly_api.ApiWorkflowClient(token="123")
     mock_download_compute_worker_run_artifact = mocker.MagicMock(
         spec_set=client._download_compute_worker_run_artifact
     )
     client._download_compute_worker_run_artifact = (
         mock_download_compute_worker_run_artifact
     )
-    run_id = generate_id()
-    artifact_ids = [generate_id(), generate_id()]
-    run = DockerRunData(
+    run_id = utils.generate_id()
+    artifact_ids = [utils.generate_id(), utils.generate_id()]
+    run = models.DockerRunData(
         id=run_id,
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
-        state=DockerRunState.COMPUTING_METADATA,
+        state=models.DockerRunState.COMPUTING_METADATA,
         created_at=0,
         last_modified_at=0,
         artifacts=[
-            DockerRunArtifactData(
+            models.DockerRunArtifactData(
                 id=artifact_ids[0],
                 file_name="report.pdf",
-                type=DockerRunArtifactType.REPORT_PDF,
+                type=models.DockerRunArtifactType.REPORT_PDF,
             ),
-            DockerRunArtifactData(
+            models.DockerRunArtifactData(
                 id=artifact_ids[1],
                 file_name="checkpoint.ckpt",
-                type=DockerRunArtifactType.CHECKPOINT,
+                type=models.DockerRunArtifactType.CHECKPOINT,
             ),
         ],
     )
     client._download_compute_worker_run_artifact_by_type(
         run=run,
-        artifact_type=DockerRunArtifactType.CHECKPOINT,
+        artifact_type=models.DockerRunArtifactType.CHECKPOINT,
         output_path="output_dir/checkpoint.ckpt",
         timeout=0,
     )
@@ -110,101 +107,101 @@ def test__download_compute_worker_run_artifact_by_type(
 
 
 def test__download_compute_worker_run_artifact_by_type__no_artifacts(
-    mocker: MockerFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
-    client = ApiWorkflowClient(token="123")
+    client = lightly_api.ApiWorkflowClient(token="123")
     mock_download_compute_worker_run_artifact = mocker.MagicMock(
         spec_set=client._download_compute_worker_run_artifact
     )
     client._download_compute_worker_run_artifact = (
         mock_download_compute_worker_run_artifact
     )
-    run = DockerRunData(
-        id=generate_id(),
+    run = models.DockerRunData(
+        id=utils.generate_id(),
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
-        state=DockerRunState.COMPUTING_METADATA,
+        state=models.DockerRunState.COMPUTING_METADATA,
         created_at=0,
         last_modified_at=0,
         artifacts=None,
     )
-    with pytest.raises(ArtifactNotExist, match="Run has no artifacts."):
+    with pytest.raises(lightly_api.ArtifactNotExist, match="Run has no artifacts."):
         client._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.CHECKPOINT,
+            artifact_type=models.DockerRunArtifactType.CHECKPOINT,
             output_path="output_dir/checkpoint.ckpt",
             timeout=0,
         )
 
 
 def test__download_compute_worker_run_artifact_by_type__no_artifact_with_type(
-    mocker: MockerFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
-    client = ApiWorkflowClient(token="123")
+    client = lightly_api.ApiWorkflowClient(token="123")
     mock_download_compute_worker_run_artifact = mocker.MagicMock(
         spec_set=client._download_compute_worker_run_artifact
     )
     client._download_compute_worker_run_artifact = (
         mock_download_compute_worker_run_artifact
     )
-    run = DockerRunData(
-        id=generate_id(),
+    run = models.DockerRunData(
+        id=utils.generate_id(),
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
-        state=DockerRunState.COMPUTING_METADATA,
+        state=models.DockerRunState.COMPUTING_METADATA,
         created_at=0,
         last_modified_at=0,
         artifacts=[
-            DockerRunArtifactData(
-                id=generate_id(),
+            models.DockerRunArtifactData(
+                id=utils.generate_id(),
                 file_name="report.pdf",
-                type=DockerRunArtifactType.REPORT_PDF,
+                type=models.DockerRunArtifactType.REPORT_PDF,
             ),
         ],
     )
-    with pytest.raises(ArtifactNotExist, match="No artifact with type"):
+    with pytest.raises(lightly_api.ArtifactNotExist, match="No artifact with type"):
         client._download_compute_worker_run_artifact_by_type(
             run=run,
-            artifact_type=DockerRunArtifactType.CHECKPOINT,
+            artifact_type=models.DockerRunArtifactType.CHECKPOINT,
             output_path="output_dir/checkpoint.ckpt",
             timeout=0,
         )
 
 
 def test__get_compute_worker_run_checkpoint_url(
-    mocker: MockerFixture,
+    mocker: pytest_mock.MockerFixture,
 ) -> None:
-    mocked_client = mocker.MagicMock(spec=ApiWorkflowClient)
-    mocked_artifact = DockerRunArtifactData(
-        id=generate_id(),
+    mocked_client = mocker.MagicMock(spec=lightly_api.ApiWorkflowClient)
+    mocked_artifact = models.DockerRunArtifactData(
+        id=utils.generate_id(),
         file_name="report.pdf",
-        type=DockerRunArtifactType.REPORT_PDF,
+        type=models.DockerRunArtifactType.REPORT_PDF,
     )
     mocked_client._get_artifact_by_type.return_value = mocked_artifact
-    mocked_client._compute_worker_api = mocker.MagicMock(spec_set=DockerApi)
+    mocked_client._compute_worker_api = mocker.MagicMock(spec_set=swagger_api.DockerApi)
     mocked_client._compute_worker_api.get_docker_run_artifact_read_url_by_id.return_value = (
         "some_read_url"
     )
 
-    run = DockerRunData(
-        id=generate_id(),
+    run = models.DockerRunData(
+        id=utils.generate_id(),
         user_id="user-id",
-        dataset_id=generate_id(),
+        dataset_id=utils.generate_id(),
         docker_version="",
-        state=DockerRunState.COMPUTING_METADATA,
+        state=models.DockerRunState.COMPUTING_METADATA,
         created_at=0,
         last_modified_at=0,
         artifacts=[mocked_artifact],
     )
-    read_url = ApiWorkflowClient.get_compute_worker_run_checkpoint_url(
+    read_url = lightly_api.ApiWorkflowClient.get_compute_worker_run_checkpoint_url(
         self=mocked_client, run=run
     )
 
     assert read_url == "some_read_url"
     mocked_client._get_artifact_by_type.assert_called_with(
-        artifact_type=DockerRunArtifactType.CHECKPOINT, run=run
+        artifact_type=models.DockerRunArtifactType.CHECKPOINT, run=run
     )
     mocked_client._compute_worker_api.get_docker_run_artifact_read_url_by_id.assert_called_with(
         run_id=run.id, artifact_id=mocked_artifact.id

--- a/tests/api_workflow/test_api_workflow_collaboration.py
+++ b/tests/api_workflow/test_api_workflow_collaboration.py
@@ -1,26 +1,24 @@
-from tests.api_workflow.mocked_api_workflow_client import (
-    MockedApiWorkflowClient,
-    MockedApiWorkflowSetup,
-)
-from tests.api_workflow.utils import generate_id
+from tests.api_workflow import mocked_api_workflow_client, utils
 
 
-class TestApiWorkflowDatasets(MockedApiWorkflowSetup):
+class TestApiWorkflowDatasets(mocked_api_workflow_client.MockedApiWorkflowSetup):
     def setUp(self) -> None:
-        self.api_workflow_client = MockedApiWorkflowClient(token="token_xyz")
+        self.api_workflow_client = mocked_api_workflow_client.MockedApiWorkflowClient(
+            token="token_xyz"
+        )
 
     def test_share_empty_dataset(self):
         self.api_workflow_client.share_dataset_only_with(
-            dataset_id=generate_id(), user_emails=[]
+            dataset_id=utils.generate_id(), user_emails=[]
         )
 
     def test_share_dataset(self):
         self.api_workflow_client.share_dataset_only_with(
-            dataset_id=generate_id(), user_emails=["someone@something.com"]
+            dataset_id=utils.generate_id(), user_emails=["someone@something.com"]
         )
 
     def test_get_shared_users(self):
         user_emails = self.api_workflow_client.get_shared_users(
-            dataset_id=generate_id()
+            dataset_id=utils.generate_id()
         )
         assert user_emails == ["user1@gmail.com", "user2@something.com"]


### PR DESCRIPTION
Changing the import style to importing modules and packages only. This PR focuses on module `lightly/api/api_workflow_compute_worker.py`.