### PR TITLE
Update list_datasource_permissions docstring

### DIFF
--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -769,22 +769,24 @@ class _DatasourcesMixin:
         """Lists granted access permissions for the datasource set up with a dataset.
 
         Returns a string dictionary, with each permission mapped to a boolean value,
-        see the example below. Additionally, there is the ``errors`` key. Permission
-        errors are stored in a dictionary where permission names are keys and error
-        messages are values. If there is no error, the value is ``None``.
+        see the example below. An additional ``errors`` key is present if any permission
+        errors have been encountered. Permission errors are stored in a dictionary where
+        permission names are keys and error messages are values.
 
         >>> from lightly.api import ApiWorkflowClient
         >>> client = ApiWorkflowClient(
         ...    token="MY_LIGHTLY_TOKEN", dataset_id="MY_DATASET_ID"
         ... )
         >>> client.list_datasource_permissions()
-        {'can_list': True,
-         'can_overwrite': True,
-         'can_read': True,
-         'can_write': True,
-         'errors': None}
+        {
+            'can_read': True,
+            'can_write': True,
+            'can_list': False,
+            'can_overwrite': True,
+            'errors': {'can_list': 'error message'}
+        }
 
         """
         return self._datasources_api.verify_datasource_by_dataset_id(
             dataset_id=self.dataset_id,
-        )
+        ).to_dict()

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -10,6 +10,12 @@ from lightly.openapi_generated.swagger_client.models import (
     DatasourceConfigS3DelegatedAccess,
     DatasourceRawSamplesDataRow,
 )
+from lightly.openapi_generated.swagger_client.models.datasource_config_verify_data import (
+    DatasourceConfigVerifyData,
+)
+from lightly.openapi_generated.swagger_client.models.datasource_config_verify_data_errors import (
+    DatasourceConfigVerifyDataErrors,
+)
 
 
 def test__download_raw_files(mocker: MockerFixture) -> None:
@@ -289,3 +295,48 @@ def test_update_processed_until_timestamp(mocker: MockerFixture) -> None:
         kwargs["datasource_processed_until_timestamp_request"].processed_until_timestamp
         == 10
     )
+
+
+def test_list_datasource_permissions(mocker: MockerFixture) -> None:
+    client = ApiWorkflowClient()
+    client._dataset_id = "dataset-id"
+    client._datasources_api.verify_datasource_by_dataset_id = mocker.MagicMock(
+        return_value=DatasourceConfigVerifyData(
+            canRead=True,
+            canWrite=True,
+            canList=False,
+            canOverwrite=True,
+            errors=None,
+        ),
+    )
+    assert client.list_datasource_permissions() == {
+        "can_read": True,
+        "can_write": True,
+        "can_list": False,
+        "can_overwrite": True,
+    }
+
+
+def test_list_datasource_permissions__error(mocker: MockerFixture) -> None:
+    client = ApiWorkflowClient()
+    client._dataset_id = "dataset-id"
+    client._datasources_api.verify_datasource_by_dataset_id = mocker.MagicMock(
+        return_value=DatasourceConfigVerifyData(
+            canRead=True,
+            canWrite=True,
+            canList=False,
+            canOverwrite=True,
+            errors=DatasourceConfigVerifyDataErrors(
+                canRead=None, canWrite=None, canList="error message", canOverwrite=None
+            ),
+        ),
+    )
+    assert client.list_datasource_permissions() == {
+        "can_read": True,
+        "can_write": True,
+        "can_list": False,
+        "can_overwrite": True,
+        "errors": {
+            "can_list": "error message",
+        },
+    }


### PR DESCRIPTION
## Changes

* Update docstring
* Convert `DatasourceConfigVerifyData` to dict before returning. Required for backwards compatibility.

## How was it tested
* Added unit test