### PR TITLE
Reduce expected error tolerance to make test pass

### DIFF
--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -58,6 +58,14 @@ class TestLightlyDataset(unittest.TestCase):
         )
 
         manual_seed(43)
+        dataloader_1_worker_2 = DataLoader(
+            dataset, shuffle=True, num_workers=0, batch_size=4
+        )
+        embeddings_1_worker_2, *_ = encoder.embed(
+            dataloader_1_worker_2,
+            device=device,
+        )
+
         dataloader_4_worker = DataLoader(
             dataset, shuffle=True, num_workers=4, batch_size=4
         )
@@ -66,7 +74,10 @@ class TestLightlyDataset(unittest.TestCase):
             device=device,
         )
 
-        np.testing.assert_allclose(embeddings_1_worker, embeddings_4_worker, rtol=5e-5)
+        np.testing.assert_allclose(
+            embeddings_1_worker, embeddings_1_worker_2, rtol=1e-1
+        )
+        np.testing.assert_allclose(embeddings_1_worker, embeddings_4_worker, rtol=1e-1)
         np.testing.assert_allclose(labels_1_worker, labels_4_worker, rtol=1e-5)
 
         self.assertListEqual(filenames_1_worker, filenames_4_worker)

--- a/tests/embedding/test_embedding.py
+++ b/tests/embedding/test_embedding.py
@@ -58,14 +58,6 @@ class TestLightlyDataset(unittest.TestCase):
         )
 
         manual_seed(43)
-        dataloader_1_worker_2 = DataLoader(
-            dataset, shuffle=True, num_workers=0, batch_size=4
-        )
-        embeddings_1_worker_2, *_ = encoder.embed(
-            dataloader_1_worker_2,
-            device=device,
-        )
-
         dataloader_4_worker = DataLoader(
             dataset, shuffle=True, num_workers=4, batch_size=4
         )
@@ -74,11 +66,8 @@ class TestLightlyDataset(unittest.TestCase):
             device=device,
         )
 
-        np.testing.assert_allclose(
-            embeddings_1_worker, embeddings_1_worker_2, rtol=1e-1
-        )
-        np.testing.assert_allclose(embeddings_1_worker, embeddings_4_worker, rtol=1e-1)
-        np.testing.assert_allclose(labels_1_worker, labels_4_worker, rtol=1e-5)
+        np.testing.assert_allclose(embeddings_1_worker, embeddings_4_worker, atol=5e-4)
+        np.testing.assert_allclose(labels_1_worker, labels_4_worker, atol=1e-5)
 
         self.assertListEqual(filenames_1_worker, filenames_4_worker)
         self.assertListEqual(filenames_1_worker, dataset.get_filenames())


### PR DESCRIPTION
## Changes
Closes #1328 

I tried out different tricks to keep the tolerance but nothing worked:
- `torch.backends.cudnn.deterministic = True`
- `torch.backends.cuda.matmul.allow_tf32 = False`
- `torch.set_float32_matmul_precision("highest")`

This PR switches the test to use absolute tolerance instead of relative tolerance when comparing the embeddings. This makes sense as values close to `0.0` can have a very high relative tolerance between each other.