### PR TITLE
generate SelectionConfigEntryStrategy.strength with borders reduced to 1e9

### DIFF
--- a/lightly/openapi_generated/swagger_client/models/selection_config_entry_strategy.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_entry_strategy.py
@@ -30,7 +30,7 @@ class SelectionConfigEntryStrategy(BaseModel):
     SelectionConfigEntryStrategy
     """
     type: SelectionStrategyType = Field(...)
-    strength: Optional[Union[confloat(le=10000000000, ge=-10000000000, strict=True), conint(le=2147483647, ge=-2147483648, strict=True)]] = Field(None, description="The relative strength of this strategy compared to other strategies. The default value is 1.0, which is set in the worker for backwards compatibility. The minimum and maximum values of +-10^10 are used to prevent numerical issues. ")
+    strength: Optional[Union[confloat(le=1000000000, ge=-1000000000, strict=True), conint(le=1000000000, ge=-1000000000, strict=True)]] = Field(None, description="The relative strength of this strategy compared to other strategies. The default value is 1.0, which is set in the worker for backwards compatibility. The minimum and maximum values of +-10^9 are used to prevent numerical issues. ")
     stopping_condition_minimum_distance: Optional[Union[StrictFloat, StrictInt]] = None
     threshold: Optional[Union[StrictFloat, StrictInt]] = None
     operation: Optional[SelectionStrategyThresholdOperation] = None


### PR DESCRIPTION
This is necessary because of https://github.com/OpenAPITools/openapi-generator/issues/16135