### PR TITLE
Igor lig 3058 add barlowtwins imagenet benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ tuned for maximum accuracy. For detailed results and more info about the benchma
 
 ### Imagenet
 
+The following experiments have been conducted on a system with 2x4090 GPUs. 
+Training a model takes around 4 days for 100 epochs (35 min per epoch), including kNN, linear probing, and fine-tuning evaluation.
+
 > **Note**: Evaluation settings are based on these papers:
 > * Linear: [SimCLR](https://arxiv.org/abs/2002.05709)
 > * Finetune: [SimCLR](https://arxiv.org/abs/2002.05709)
@@ -289,6 +292,7 @@ tuned for maximum accuracy. For detailed results and more info about the benchma
 
 | Model          | Backbone | Batch Size | Epochs | Linear Top1 | Finetune Top1 | KNN Top1 | Tensorboard | Checkpoint |
 |----------------|----------|------------|--------|-------------|---------------|----------|-------------|------------|
+| BarlowTwins    | Res50    |        256 |    100 |        62.9 |          72.6 |     45.6 |      [link](https://tensorboard.dev/experiment/NxyNRiQsQjWZ82I9b0PvKg/) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_barlowtwins_2023-08-18_00-11-03/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |
 | BYOL           | Res50    |        256 |    100 |        62.4 |          74.0 |     45.6 |      [link](https://tensorboard.dev/experiment/Z0iG2JLaTJe5nuBD7DK1bg) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_byol_2023-07-10_10-37-32/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |
 | DINO           | Res50    |        128 |    100 |        68.2 |          72.5 |     49.9 |      [link](https://tensorboard.dev/experiment/DvKHX9sNSWWqDrRksllPLA) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dino_2023-06-06_13-59-48/pretrain/version_0/checkpoints/epoch%3D99-step%3D1000900.ckpt) |
 | SimCLR*        | Res50    |        256 |    100 |        63.2 |          73.9 |     44.8 |      [link](https://tensorboard.dev/experiment/Ugol97adQdezgcVibDYMMA) |       [link](https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-06-22_09-11-13/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt) |

--- a/benchmarks/imagenet/resnet50/barlowtwins.py
+++ b/benchmarks/imagenet/resnet50/barlowtwins.py
@@ -10,7 +10,7 @@ from torchvision.models import resnet50
 from lightly.loss import BarlowTwinsLoss
 from lightly.models.modules import BarlowTwinsProjectionHead
 from lightly.models.utils import get_weight_decay_parameters, update_momentum
-from lightly.transforms import SimCLRTransform
+from lightly.transforms import BYOLTransform
 from lightly.utils.benchmarking import OnlineLinearClassifier
 from lightly.utils.lars import LARS
 from lightly.utils.scheduler import CosineWarmupScheduler, cosine_schedule
@@ -25,64 +25,31 @@ class BarlowTwins(LightningModule):
         resnet = resnet50()
         resnet.fc = Identity()  # Ignore classification head
         self.backbone = resnet
-        self.projection_head = BYOLProjectionHead()
-        self.student_backbone = copy.deepcopy(self.backbone)
-        self.student_projection_head = BYOLProjectionHead()
-        self.student_prediction_head = BYOLPredictionHead()
-        self.criterion = NegativeCosineSimilarity()
+        self.projection_head = BarlowTwinsProjectionHead()
+        self.criterion = BarlowTwinsLoss(lambda_param=5e-3, gather_distributed=True)
 
         self.online_classifier = OnlineLinearClassifier(num_classes=num_classes)
 
     def forward(self, x: Tensor) -> Tensor:
         return self.backbone(x)
 
-    @torch.no_grad()
-    def forward_teacher(self, x: Tensor) -> Tuple[Tensor, Tensor]:
-        features = self(x).flatten(start_dim=1)
-        projections = self.projection_head(features)
-        return features, projections
-
-    def forward_student(self, x: Tensor) -> Tensor:
-        features = self.student_backbone(x).flatten(start_dim=1)
-        projections = self.student_projection_head(features)
-        predictions = self.student_prediction_head(projections)
-        return predictions
-
     def training_step(
         self, batch: Tuple[List[Tensor], Tensor, List[str]], batch_idx: int
     ) -> Tensor:
-        # Momentum update teacher.
-        # Settings follow original code for 100 epochs which are slightly different
-        # from the paper, see:
-        # https://github.com/deepmind/deepmind-research/blob/f5de0ede8430809180254ee957abf36ed62579ef/byol/configs/byol.py#L21-L23
-        momentum = cosine_schedule(
-            step=self.trainer.global_step,
-            max_steps=self.trainer.estimated_stepping_batches,
-            start_value=0.99,
-            end_value=1.0,
-        )
-        update_momentum(self.student_backbone, self.backbone, m=momentum)
-        update_momentum(self.student_projection_head, self.projection_head, m=momentum)
-
         # Forward pass and loss calculation.
         views, targets = batch[0], batch[1]
-        teacher_features_0, teacher_projections_0 = self.forward_teacher(views[0])
-        _, teacher_projections_1 = self.forward_teacher(views[1])
-        student_predictions_0 = self.forward_student(views[0])
-        student_predictions_1 = self.forward_student(views[1])
-        # NOTE: Factor 2 because: L2(norm(x), norm(y)) = 2 - 2 * cossim(x, y)
-        loss_0 = 2 * self.criterion(teacher_projections_0, student_predictions_1)
-        loss_1 = 2 * self.criterion(teacher_projections_1, student_predictions_0)
-        # NOTE: No mean because original code only takes mean over batch dimension, not
-        # views.
-        loss = loss_0 + loss_1
+        features = self.forward(torch.cat(views)).flatten(start_dim=1)
+        z = self.projection_head(features)
+        z0, z1 = z.chunk(len(views))
+        loss = self.criterion(z0, z1)
+
         self.log(
             "train_loss", loss, prog_bar=True, sync_dist=True, batch_size=len(targets)
         )
 
         # Online linear evaluation.
         cls_loss, cls_log = self.online_classifier.training_step(
-            (teacher_features_0.detach(), targets), batch_idx
+            (features.detach(), targets.repeat(len(views))), batch_idx
         )
         self.log_dict(cls_log, sync_dist=True, batch_size=len(targets))
         return loss + cls_loss
@@ -99,22 +66,21 @@ class BarlowTwins(LightningModule):
         return cls_loss
 
     def configure_optimizers(self):
+        lr_factor = self.batch_size_per_device * self.trainer.world_size / 256
+
         # Don't use weight decay for batch norm, bias parameters, and classification
         # head to improve performance.
         params, params_no_weight_decay = get_weight_decay_parameters(
-            [
-                self.student_backbone,
-                self.student_projection_head,
-                self.student_prediction_head,
-            ]
+            [self.backbone, self.projection_head]
         )
         optimizer = LARS(
             [
-                {"name": "byol", "params": params},
+                {"name": "barlowtwins", "params": params},
                 {
-                    "name": "byol_no_weight_decay",
+                    "name": "barlowtwins_no_weight_decay",
                     "params": params_no_weight_decay,
                     "weight_decay": 0.0,
+                    "lr": 0.0048 * lr_factor,
                 },
                 {
                     "name": "online_classifier",
@@ -122,13 +88,11 @@ class BarlowTwins(LightningModule):
                     "weight_decay": 0.0,
                 },
             ],
-            # Settings follow original code for 100 epochs which are slightly different
-            # from the paper, see:
-            # https://github.com/deepmind/deepmind-research/blob/f5de0ede8430809180254ee957abf36ed62579ef/byol/configs/byol.py#L21-L23
-            lr=0.45 * self.batch_size_per_device * self.trainer.world_size / 256,
+            lr=0.2 * lr_factor,
             momentum=0.9,
-            weight_decay=1e-6,
+            weight_decay=1.5e-6,
         )
+
         scheduler = {
             "scheduler": CosineWarmupScheduler(
                 optimizer=optimizer,
@@ -144,5 +108,5 @@ class BarlowTwins(LightningModule):
         return [optimizer], [scheduler]
 
 
-# BYOL uses same transform as SimCLR.
-transform = SimCLRTransform()
+# BarlowTwins uses same transform as BYOL.
+transform = BYOLTransform()

--- a/benchmarks/imagenet/resnet50/barlowtwins.py
+++ b/benchmarks/imagenet/resnet50/barlowtwins.py
@@ -9,11 +9,11 @@ from torchvision.models import resnet50
 
 from lightly.loss import BarlowTwinsLoss
 from lightly.models.modules import BarlowTwinsProjectionHead
-from lightly.models.utils import get_weight_decay_parameters, update_momentum
+from lightly.models.utils import get_weight_decay_parameters
 from lightly.transforms import BYOLTransform
 from lightly.utils.benchmarking import OnlineLinearClassifier
 from lightly.utils.lars import LARS
-from lightly.utils.scheduler import CosineWarmupScheduler, cosine_schedule
+from lightly.utils.scheduler import CosineWarmupScheduler
 
 
 class BarlowTwins(LightningModule):

--- a/benchmarks/imagenet/resnet50/barlowtwins.py
+++ b/benchmarks/imagenet/resnet50/barlowtwins.py
@@ -1,0 +1,148 @@
+import copy
+from typing import List, Tuple
+
+import torch
+from pytorch_lightning import LightningModule
+from torch import Tensor
+from torch.nn import Identity
+from torchvision.models import resnet50
+
+from lightly.loss import BarlowTwinsLoss
+from lightly.models.modules import BarlowTwinsProjectionHead
+from lightly.models.utils import get_weight_decay_parameters, update_momentum
+from lightly.transforms import SimCLRTransform
+from lightly.utils.benchmarking import OnlineLinearClassifier
+from lightly.utils.lars import LARS
+from lightly.utils.scheduler import CosineWarmupScheduler, cosine_schedule
+
+
+class BarlowTwins(LightningModule):
+    def __init__(self, batch_size_per_device: int, num_classes: int) -> None:
+        super().__init__()
+        self.save_hyperparameters()
+        self.batch_size_per_device = batch_size_per_device
+
+        resnet = resnet50()
+        resnet.fc = Identity()  # Ignore classification head
+        self.backbone = resnet
+        self.projection_head = BYOLProjectionHead()
+        self.student_backbone = copy.deepcopy(self.backbone)
+        self.student_projection_head = BYOLProjectionHead()
+        self.student_prediction_head = BYOLPredictionHead()
+        self.criterion = NegativeCosineSimilarity()
+
+        self.online_classifier = OnlineLinearClassifier(num_classes=num_classes)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.backbone(x)
+
+    @torch.no_grad()
+    def forward_teacher(self, x: Tensor) -> Tuple[Tensor, Tensor]:
+        features = self(x).flatten(start_dim=1)
+        projections = self.projection_head(features)
+        return features, projections
+
+    def forward_student(self, x: Tensor) -> Tensor:
+        features = self.student_backbone(x).flatten(start_dim=1)
+        projections = self.student_projection_head(features)
+        predictions = self.student_prediction_head(projections)
+        return predictions
+
+    def training_step(
+        self, batch: Tuple[List[Tensor], Tensor, List[str]], batch_idx: int
+    ) -> Tensor:
+        # Momentum update teacher.
+        # Settings follow original code for 100 epochs which are slightly different
+        # from the paper, see:
+        # https://github.com/deepmind/deepmind-research/blob/f5de0ede8430809180254ee957abf36ed62579ef/byol/configs/byol.py#L21-L23
+        momentum = cosine_schedule(
+            step=self.trainer.global_step,
+            max_steps=self.trainer.estimated_stepping_batches,
+            start_value=0.99,
+            end_value=1.0,
+        )
+        update_momentum(self.student_backbone, self.backbone, m=momentum)
+        update_momentum(self.student_projection_head, self.projection_head, m=momentum)
+
+        # Forward pass and loss calculation.
+        views, targets = batch[0], batch[1]
+        teacher_features_0, teacher_projections_0 = self.forward_teacher(views[0])
+        _, teacher_projections_1 = self.forward_teacher(views[1])
+        student_predictions_0 = self.forward_student(views[0])
+        student_predictions_1 = self.forward_student(views[1])
+        # NOTE: Factor 2 because: L2(norm(x), norm(y)) = 2 - 2 * cossim(x, y)
+        loss_0 = 2 * self.criterion(teacher_projections_0, student_predictions_1)
+        loss_1 = 2 * self.criterion(teacher_projections_1, student_predictions_0)
+        # NOTE: No mean because original code only takes mean over batch dimension, not
+        # views.
+        loss = loss_0 + loss_1
+        self.log(
+            "train_loss", loss, prog_bar=True, sync_dist=True, batch_size=len(targets)
+        )
+
+        # Online linear evaluation.
+        cls_loss, cls_log = self.online_classifier.training_step(
+            (teacher_features_0.detach(), targets), batch_idx
+        )
+        self.log_dict(cls_log, sync_dist=True, batch_size=len(targets))
+        return loss + cls_loss
+
+    def validation_step(
+        self, batch: Tuple[Tensor, Tensor, List[str]], batch_idx: int
+    ) -> Tensor:
+        images, targets = batch[0], batch[1]
+        features = self.forward(images).flatten(start_dim=1)
+        cls_loss, cls_log = self.online_classifier.validation_step(
+            (features.detach(), targets), batch_idx
+        )
+        self.log_dict(cls_log, prog_bar=True, sync_dist=True, batch_size=len(targets))
+        return cls_loss
+
+    def configure_optimizers(self):
+        # Don't use weight decay for batch norm, bias parameters, and classification
+        # head to improve performance.
+        params, params_no_weight_decay = get_weight_decay_parameters(
+            [
+                self.student_backbone,
+                self.student_projection_head,
+                self.student_prediction_head,
+            ]
+        )
+        optimizer = LARS(
+            [
+                {"name": "byol", "params": params},
+                {
+                    "name": "byol_no_weight_decay",
+                    "params": params_no_weight_decay,
+                    "weight_decay": 0.0,
+                },
+                {
+                    "name": "online_classifier",
+                    "params": self.online_classifier.parameters(),
+                    "weight_decay": 0.0,
+                },
+            ],
+            # Settings follow original code for 100 epochs which are slightly different
+            # from the paper, see:
+            # https://github.com/deepmind/deepmind-research/blob/f5de0ede8430809180254ee957abf36ed62579ef/byol/configs/byol.py#L21-L23
+            lr=0.45 * self.batch_size_per_device * self.trainer.world_size / 256,
+            momentum=0.9,
+            weight_decay=1e-6,
+        )
+        scheduler = {
+            "scheduler": CosineWarmupScheduler(
+                optimizer=optimizer,
+                warmup_epochs=(
+                    self.trainer.estimated_stepping_batches
+                    / self.trainer.max_epochs
+                    * 10
+                ),
+                max_epochs=self.trainer.estimated_stepping_batches,
+            ),
+            "interval": "step",
+        }
+        return [optimizer], [scheduler]
+
+
+# BYOL uses same transform as SimCLR.
+transform = SimCLRTransform()

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Sequence, Union
 
+import barlowtwins
 import byol
 import dcl
 import dclw
@@ -46,6 +47,10 @@ parser.add_argument("--skip-linear-eval", action="store_true")
 parser.add_argument("--skip-finetune-eval", action="store_true")
 
 METHODS = {
+    "barlowtwins": {
+        "model": barlowtwins.BarlowTwins,
+        "transform": barlowtwins.transform,
+    },
     "byol": {"model": byol.BYOL, "transform": byol.transform},
     "dcl": {"model": dcl.DCL, "transform": dcl.transform},
     "dclw": {"model": dclw.DCLW, "transform": dclw.transform},

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -17,7 +17,7 @@ ImageNet
 We use the ImageNet1k ILSVRC2012 split provided here: https://image-net.org/download.php.
 
 Self-supervised training of a SimCLR model for 100 epochs with total batch size 256
-takes about two days on two GeForce RTX 4090 GPUs. You can reproduce the results with
+takes about four days including evaluation on two GeForce RTX 4090 GPUs. You can reproduce the results with
 the code at `benchmarks/imagenet/resnet50 <https://github.com/lightly-ai/lightly/tree/master/benchmarks/imagenet/resnet50>`_.
 
 Evaluation settings are based on these papers:
@@ -33,6 +33,7 @@ See the `benchmarking scripts <https://github.com/lightly-ai/lightly/tree/master
   :header: "Model", "Backbone", "Batch Size", "Epochs", "Linear Top1", "Linear Top5", "Finetune Top1", "Finetune Top5", "KNN Top1", "KNN Top5", "Tensorboard", "Checkpoint"
   :widths: 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20
 
+  "BarlowTwins", "Res50", "256", "100", "62.9", "84.3", "72.6", "90.9", "45.6", "73.9", "`link <https://tensorboard.dev/experiment/NxyNRiQsQjWZ82I9b0PvKg/>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_barlowtwins_2023-08-18_00-11-03/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
   "BYOL", "Res50", "256", "100", "62.4", "84.7", "74.0", "91.9", "45.6", "74.8", "`link <https://tensorboard.dev/experiment/Z0iG2JLaTJe5nuBD7DK1bg>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_byol_2023-07-10_10-37-32/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
   "DINO", "Res50", "128", "100", "68.2", "87.9", "72.5", "90.8", "49.9", "78.7", "`link <https://tensorboard.dev/experiment/DvKHX9sNSWWqDrRksllPLA>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dino_2023-06-06_13-59-48/pretrain/version_0/checkpoints/epoch%3D99-step%3D1000900.ckpt>`_"
   "SimCLR*", "Res50", "256", "100", "63.2", "85.2", "73.9", "91.9", "44.8", "73.9", "`link <https://tensorboard.dev/experiment/Ugol97adQdezgcVibDYMMA>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-06-22_09-11-13/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"

--- a/lightly/loss/barlow_twins_loss.py
+++ b/lightly/loss/barlow_twins_loss.py
@@ -64,6 +64,7 @@ class BarlowTwinsLoss(torch.nn.Module):
         if self.gather_distributed and dist.is_initialized():
             world_size = dist.get_world_size()
             if world_size > 1:
+                c = c / world_size
                 dist.all_reduce(c)
 
         invariance_loss = torch.diagonal(c).add_(-1).pow_(2).sum()

--- a/lightly/loss/barlow_twins_loss.py
+++ b/lightly/loss/barlow_twins_loss.py
@@ -51,11 +51,7 @@ class BarlowTwinsLoss(torch.nn.Module):
             )
 
     def forward(self, z_a: torch.Tensor, z_b: torch.Tensor) -> torch.Tensor:
-        device = z_a.device
-
         # normalize repr. along the batch dimension
-        # z_a_norm = (z_a - z_a.mean(0)) / z_a.std(0)  # NxD
-        # z_b_norm = (z_b - z_b.mean(0)) / z_b.std(0)  # NxD
         z_a_norm, z_b_norm = _normalize(z_a, z_b)
 
         N = z_a.size(0)
@@ -71,7 +67,7 @@ class BarlowTwinsLoss(torch.nn.Module):
                 c = c / world_size
                 dist.all_reduce(c)
 
-        invariance_loss = (torch.trace(c) - D) ** 2
+        invariance_loss = torch.diagonal(c).add_(-1).pow_(2).sum()
         redundancy_reduction_loss = _off_diagonal(c).pow_(2).sum()
         loss = invariance_loss + self.lambda_param * redundancy_reduction_loss
 

--- a/lightly/loss/barlow_twins_loss.py
+++ b/lightly/loss/barlow_twins_loss.py
@@ -55,16 +55,15 @@ class BarlowTwinsLoss(torch.nn.Module):
         z_a_norm, z_b_norm = _normalize(z_a, z_b)
 
         N = z_a.size(0)
-        D = z_a.size(1)
 
         # cross-correlation matrix
-        c = torch.mm(z_a_norm.T, z_b_norm) / N  # DxD
+        c = z_a_norm.T @ z_b_norm
+        c.div_(N)
 
         # sum cross-correlation matrix between multiple gpus
         if self.gather_distributed and dist.is_initialized():
             world_size = dist.get_world_size()
             if world_size > 1:
-                c = c / world_size
                 dist.all_reduce(c)
 
         invariance_loss = torch.diagonal(c).add_(-1).pow_(2).sum()

--- a/lightly/loss/barlow_twins_loss.py
+++ b/lightly/loss/barlow_twins_loss.py
@@ -67,9 +67,15 @@ class BarlowTwinsLoss(torch.nn.Module):
                 c = c / world_size
                 dist.all_reduce(c)
 
-        on_diag = torch.diagonal(c).add_(-1).pow_(2).sum()
-        n, m = c.shape
-        off_diag = c.flatten()[:-1].view(n - 1, n + 1)[:, 1:].flatten().pow_(2).sum()
-        loss = on_diag + self.lambda_param * off_diag
+        invariance_loss = torch.diagonal(c).add_(-1).pow_(2).sum()
+        redundancy_reduction_loss = off_diagonal(c).pow_(2).sum()
+        loss = invariance_loss + self.lambda_param * redundancy_reduction_loss
 
         return loss
+
+
+def off_diagonal(x):
+    # return a flattened view of the off-diagonal elements of a square matrix
+    n, m = x.shape
+    assert n == m
+    return x.flatten()[:-1].view(n - 1, n + 1)[:, 1:].flatten()

--- a/tests/loss/test_barlow_twins_loss.py
+++ b/tests/loss/test_barlow_twins_loss.py
@@ -1,8 +1,49 @@
 import pytest
+import torch
+import torch.nn as nn
 from pytest_mock import MockerFixture
 from torch import distributed as dist
 
 from lightly.loss.barlow_twins_loss import BarlowTwinsLoss
+
+
+class BarlowTwinsLossReference(torch.nn.Module):
+    def __init__(
+        self,
+        projector_dim: int = 8196,
+        lambda_param: float = 5e-3,
+        gather_distributed: bool = False,
+    ):
+        super(BarlowTwinsLossReference, self).__init__()
+        # normalization layer for the representations z1 and z2
+        self.bn = nn.BatchNorm1d(projector_dim, affine=False)
+        self.lambda_param = lambda_param
+        self.gather_distributed = gather_distributed
+
+    def forward(self, z_a: torch.Tensor, z_b: torch.Tensor) -> torch.Tensor:
+        # code from https://github.com/facebookresearch/barlowtwins/blob/main/main.py
+
+        N = z_a.size(0)
+
+        # empirical cross-correlation matrix
+        c = self.bn(z_a).T @ self.bn(z_b)
+
+        # sum the cross-correlation matrix between all gpus
+        c.div_(N)
+        if self.gather_distributed:
+            torch.distributed.all_reduce(c)
+
+        on_diag = torch.diagonal(c).add_(-1).pow_(2).sum()
+        off_diag = off_diagonal(c).pow_(2).sum()
+        loss = on_diag + self.lambda_param * off_diag
+        return loss
+
+
+def off_diagonal(x):
+    # return a flattened view of the off-diagonal elements of a square matrix
+    n, m = x.shape
+    assert n == m
+    return x.flatten()[:-1].view(n - 1, n + 1)[:, 1:].flatten()
 
 
 class TestBarlowTwinsLoss:
@@ -20,3 +61,25 @@ class TestBarlowTwinsLoss:
         with pytest.raises(ValueError):
             BarlowTwinsLoss(gather_distributed=True)
         mock_is_available.assert_called_once()
+
+    def test__loss_matches_reference_loss(self) -> None:
+        batch_size = 32
+        projector_dim = 8196
+        lambda_param = 5e-3
+        gather_distributed = False
+        loss = BarlowTwinsLoss(
+            lambda_param=lambda_param, gather_distributed=gather_distributed
+        )
+        loss_ref = BarlowTwinsLossReference(
+            projector_dim=projector_dim,
+            lambda_param=lambda_param,
+            gather_distributed=gather_distributed,
+        )
+
+        z_a = torch.randn(batch_size, projector_dim)
+        z_b = torch.randn(batch_size, projector_dim)
+
+        loss_out = loss(z_a, z_b)
+        loss_ref_out = loss_ref(z_a, z_b)
+
+        assert torch.allclose(loss_out, loss_ref_out, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## Changes

Closes #1323 

Quick update (10.8.2023). I started the training run again and we're at 56 epochs:
```
Epoch 56:  49%|████▉     | 2470/5004 [1:28:24<1:30:42,  2.15s/it, v_num=0, train_loss=1.79e+3, val_online_cls_loss=1.950, val_online_cls_top1=0.564, val_online_cls_top5=0.801]
...
Epoch 88:  14%|█▍        | 701/5004 [25:03<2:33:49,  2.14s/it, v_num=0, train_loss=1.72e+3, val_online_cls_loss=1.610, val_online_cls_top1=0.624, val_online_cls_top5=0.841] 
```
The results look pretty promising. I noticed that the projection head of the model is gigantic (Barlow Twins has huge linear layers). 
```
  | Name              | Type                      | Params
----------------------------------------------------------------
0 | backbone          | ResNet                    | 23.5 M
1 | projection_head   | BarlowTwinsProjectionHead | 151 M 
2 | criterion         | BarlowTwinsLoss           | 0     
3 | online_classifier | OnlineLinearClassifier    | 2.0 M 
----------------------------------------------------------------
```
And I think the ImageNet benchmark code is not optimised well. GPU and CPU usage are rather low and it takes quite some time for processing. The job is running since 7 days and we're at 56 epochs...