### PR TITLE
Fix PMSNLoss

### DIFF
--- a/lightly/loss/pmsn_loss.py
+++ b/lightly/loss/pmsn_loss.py
@@ -68,7 +68,9 @@ class PMSNLoss(MSNLoss):
             exponent=self.power_law_exponent,
             device=mean_anchor_probs.device,
         )
-        loss = F.kl_div(input=mean_anchor_probs, target=power_dist, reduction="sum")
+        loss = F.kl_div(
+            input=mean_anchor_probs.log(), target=power_dist, reduction="sum"
+        )
         return loss
 
 
@@ -139,7 +141,9 @@ class PMSNCustomLoss(MSNLoss):
         target_dist = self.target_distribution(mean_anchor_probs).to(
             mean_anchor_probs.device
         )
-        loss = F.kl_div(input=mean_anchor_probs, target=target_dist, reduction="sum")
+        loss = F.kl_div(
+            input=mean_anchor_probs.log(), target=target_dist, reduction="sum"
+        )
         return loss
 
 

--- a/tests/loss/test_PMSNLoss.py
+++ b/tests/loss/test_PMSNLoss.py
@@ -12,7 +12,7 @@ from lightly.loss.pmsn_loss import PMSNCustomLoss, PMSNLoss
 class TestPMSNLoss:
     def test_regularization_loss(self) -> None:
         criterion = PMSNLoss()
-        mean_anchor_probs = torch.Tensor([0.1, 0.3, 0.6]).log()
+        mean_anchor_probs = torch.Tensor([0.1, 0.3, 0.6])
         loss = criterion.regularization_loss(mean_anchor_probs=mean_anchor_probs)
         norm = 1 / (1**0.25) + 1 / (2**0.25) + 1 / (3**0.25)
         t0 = 1 / (1**0.25) / norm
@@ -45,7 +45,7 @@ class TestPMSNLoss:
 class TestPMSNCustomLoss:
     def test_regularization_loss(self) -> None:
         criterion = PMSNCustomLoss(target_distribution=_uniform_distribution)
-        mean_anchor_probs = torch.Tensor([0.1, 0.3, 0.6]).log()
+        mean_anchor_probs = torch.Tensor([0.1, 0.3, 0.6])
         loss = criterion.regularization_loss(mean_anchor_probs=mean_anchor_probs)
         expected_loss = (
             1


### PR DESCRIPTION
Closes #1340 

## Changes

* Convert probabilities to log-space before KL div

The pytorch KL div loss expects the input distribution to be in log-space, see https://pytorch.org/docs/stable/generated/torch.nn.functional.kl_div.html