### PR TITLE
Update scheduler.py

### DIFF
--- a/lightly/utils/scheduler.py
+++ b/lightly/utils/scheduler.py
@@ -48,7 +48,7 @@ def cosine_schedule(
             * (np.cos(np.pi * step / (max_steps - 1)) + 1)
             / 2
         )
-    return decay / start_value 
+    return decay / start_value
 
 
 class CosineWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):
@@ -106,7 +106,7 @@ class CosineWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):
 
         """
         if epoch < self.warmup_epochs:
-            return (epoch + 1) / self.warmup_epochs
+            return self.start_value * (epoch + 1) / self.warmup_epochs
         else:
             return cosine_schedule(
                 step=epoch - self.warmup_epochs,

--- a/lightly/utils/scheduler.py
+++ b/lightly/utils/scheduler.py
@@ -48,7 +48,7 @@ def cosine_schedule(
             * (np.cos(np.pi * step / (max_steps - 1)) + 1)
             / 2
         )
-    return decay
+    return decay / start_value 
 
 
 class CosineWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):

--- a/lightly/utils/scheduler.py
+++ b/lightly/utils/scheduler.py
@@ -48,7 +48,7 @@ def cosine_schedule(
             * (np.cos(np.pi * step / (max_steps - 1)) + 1)
             / 2
         )
-    return decay / start_value
+    return decay
 
 
 class CosineWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):

--- a/tests/utils/test_scheduler.py
+++ b/tests/utils/test_scheduler.py
@@ -62,3 +62,22 @@ class TestScheduler(unittest.TestCase):
             RuntimeWarning, msg="Current step number 7 exceeds max_steps 6."
         ):
             scheduler.step()
+
+    def test_CosineWarmupScheduler__warmup(self):
+        model = nn.Linear(10, 1)
+        optimizer = torch.optim.SGD(
+            model.parameters(), lr=1.0, momentum=0.0, weight_decay=0.0
+        )
+        scheduler = CosineWarmupScheduler(
+            optimizer,
+            warmup_epochs=3,
+            max_epochs=6,
+            start_value=2.0,
+            end_value=0.0,
+        )
+        # Linear warmup
+        self.assertAlmostEqual(scheduler.scale_lr(epoch=0), 2.0 * 1 / 3)
+        self.assertAlmostEqual(scheduler.scale_lr(epoch=1), 2.0 * 2 / 3)
+        self.assertAlmostEqual(scheduler.scale_lr(epoch=2), 2.0 * 3 / 3)
+        # Cosine decay
+        self.assertLess(scheduler.scale_lr(epoch=3), 2.0)

--- a/tests/utils/test_scheduler.py
+++ b/tests/utils/test_scheduler.py
@@ -80,4 +80,5 @@ class TestScheduler(unittest.TestCase):
         self.assertAlmostEqual(scheduler.scale_lr(epoch=1), 2.0 * 2 / 3)
         self.assertAlmostEqual(scheduler.scale_lr(epoch=2), 2.0 * 3 / 3)
         # Cosine decay
-        self.assertLess(scheduler.scale_lr(epoch=3), 2.0)
+        self.assertAlmostEqual(scheduler.scale_lr(epoch=3), 2.0 * 3 / 3)
+        self.assertLess(scheduler.scale_lr(epoch=4), 2.0)


### PR DESCRIPTION
Here is a quick test to verify the **fixed scheduler**:

```
### Test
# Parameters for the scheduler and training
import matplotlib.pyplot as plt
import torch
from lightly.utils.scheduler import CosineWarmupScheduler
warmup_epochs = 10
max_epochs = 1000
start_value = 2.0
end_value = 0.0001

# Create a dummy optimizer (no need to attach it to a model)
dummy_optimizer = torch.optim.SGD([torch.tensor(0.0)], lr=start_value)

# Create the scheduler instance
scheduler = CosineWarmupScheduler(
    optimizer=dummy_optimizer,
    warmup_epochs=warmup_epochs,
    max_epochs=max_epochs,
    start_value=start_value,
    end_value=end_value,
    verbose=False
)

# List to store learning rates
learning_rates = []

# Simulate epoch progression and track learning rates
for epoch in range(max_epochs):
    current_lr = scheduler.get_last_lr()[0]
    learning_rates.append(current_lr)
    scheduler.step()

# Plotting the learning rate schedule
# Find the lowest learning rate and its index
lowest_lr = min(learning_rates)
lowest_lr_index = learning_rates.index(lowest_lr)
highest_lr = max(learning_rates)
highest_lr_index = learning_rates.index(highest_lr)

plt.figure(figsize=(10, 6))
plt.plot(range(max_epochs), learning_rates, linestyle='-', color='b')
plt.scatter(lowest_lr_index, lowest_lr, color='r', label=f'Lowest LR: {lowest_lr:.5f}')
plt.scatter(highest_lr_index, highest_lr, color='r', label=f'Highest LR: {highest_lr:.5f}')
plt.xlabel('Epoch', fontsize=14)
plt.ylabel('Learning Rate', fontsize=14)
plt.title('Learning Rate Schedule', fontsize=16)
plt.xticks(fontsize=12)
plt.yticks(fontsize=12)
plt.grid(True)
plt.legend()
plt.tight_layout()
```
![lightly_lrs](https://github.com/lightly-ai/lightly/assets/5554065/beaced0f-b90d-4113-ac5a-96747a2c12c3)


To see the old scheduler issue:
Run the same **test with the existing version** of the scheduler. It should produce the following plot:
![lightly_lrs_old](https://github.com/lightly-ai/lightly/assets/5554065/83effbd9-2d5c-4b85-b491-8d94324c0b24)

Hope this helps. 
 
