### PR TITLE
Add lightly-serve script

### DIFF
--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -23,7 +23,7 @@ def get_server(
         >>> from lightly.api import serve
         >>> from pathlib import Path
         >>> serve(
-        >>>    paths=[Path("/input_dir), Path("/lightly_dir)],
+        >>>    paths=[Path("/input_mount), Path("/lightly_mount)],
         >>>    host="localhost",
         >>>    port=1234,
         >>> )

--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -23,8 +23,7 @@ def get_server(
         >>> from lightly.api import serve
         >>> from pathlib import Path
         >>> serve(
-        >>>    input_dir=Path("/input_dir),
-        >>>    lightly_dir=Path("/lightly_dir),
+        >>>    paths=[Path("/input_dir), Path("/lightly_dir)],
         >>>    host="localhost",
         >>>    port=1234,
         >>> )

--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -1,0 +1,72 @@
+import re
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+
+
+def serve(
+    root_dir: Path,
+    input_path: str,
+    lightly_path: str,
+    host: str,
+    port: int,
+):
+    """Serve the local datasource.
+
+    Args:
+        root_dir:
+            Root directory of the local datasource.
+        input_path:
+            Path to the input directory, relative to the root directory.
+        lightly_path:
+            Path to the Lightly directory, relative to the root directory.
+        host:
+            Host to serve the datasource on.
+        port:
+            Port to serve the datasource on.
+
+    Examples:
+        >>> from lightly.api import serve
+        >>> from pathlib import Path
+        >>> serve(
+        >>>    input_dir=Path("/input_dir),
+        >>>    lightly_dir=Path("/lightly_dir),
+        >>>    host="localhost",
+        >>>    port=1234,
+        >>> )
+
+    """
+
+    directories = [root_dir / input_path, root_dir / lightly_path]
+
+    class _LocalDatasourceRequestHandler(SimpleHTTPRequestHandler):
+        """Request handler for the local datasource.
+
+        Tries to resolve the relative path to a file in the local input directory
+        and serves it if it exists. Otherwise, it tries to resolve the relative
+        path to a file in the lightly directory and serves it if it exists.
+
+        """
+
+        def translate_path(self, path: str) -> str:
+            path = _strip_leading_slashes(path)
+            for directory in directories:
+                if (directory / path).is_file():
+                    return str(directory / path)
+            return ""  # Not found.
+
+    httpd = HTTPServer((host, port), _LocalDatasourceRequestHandler)
+    httpd.serve_forever()
+
+
+def _strip_leading_slashes(path: str) -> str:
+    """Strip leading slashes from a path.
+
+    Args:
+        path:
+            Path to strip leading slashes from.
+
+    Returns:
+        Path without leading slashes.
+
+    """
+    return re.sub(r"^/+", "", path)

--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -25,7 +25,7 @@ def get_server(
         >>> serve(
         >>>    paths=[Path("/input_mount), Path("/lightly_mount)],
         >>>    host="localhost",
-        >>>    port=1234,
+        >>>    port=3456,
         >>> )
 
     """

--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -40,9 +40,9 @@ def get_server(
 def _translate_path(path: str, directories: Sequence[Path]) -> str:
     """Translates a relative path to a file in the local datasource.
 
-    Tries to resolve the relative path to a file in the local input directory
+    Tries to resolve the relative path to a file in the first directory
     and serves it if it exists. Otherwise, it tries to resolve the relative
-    path to a file in the lightly directory and serves it if it exists.
+    path to a file in the second directory and serves it if it exists, etc.
 
     Args:
         path:
@@ -56,22 +56,8 @@ def _translate_path(path: str, directories: Sequence[Path]) -> str:
         if the file doesn't exist.
 
     """
-    path = _strip_leading_slashes(path)
+    stripped_path = path.lstrip("/")
     for directory in directories:
-        if (directory / path).exists():
-            return str(directory / path)
+        if (directory / stripped_path).exists():
+            return str(directory / stripped_path)
     return ""  # Not found.
-
-
-def _strip_leading_slashes(path: str) -> str:
-    """Strip leading slashes from a path.
-
-    Args:
-        path:
-            Path to strip leading slashes from.
-
-    Returns:
-        Path without leading slashes.
-
-    """
-    return re.sub(r"^/+", "", path)

--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -1,25 +1,19 @@
 import re
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
-from typing import Sequence, Type
+from typing import Sequence
 
 
 def get_server(
-    root_dir: Path,
-    input_path: str,
-    lightly_path: str,
+    paths: Sequence[str],
     host: str,
     port: int,
 ):
     """Returns an HTTP server that serves a local datasource.
 
     Args:
-        root_dir:
-            Root directory of the local datasource.
-        input_path:
-            Path to the input directory, relative to the root directory.
-        lightly_path:
-            Path to the Lightly directory, relative to the root directory.
+        paths:
+            List of paths to serve.
         host:
             Host to serve the datasource on.
         port:
@@ -36,11 +30,10 @@ def get_server(
         >>> )
 
     """
-    directories = [root_dir / input_path, root_dir / lightly_path]
 
     class _LocalDatasourceRequestHandler(SimpleHTTPRequestHandler):
         def translate_path(self, path: str) -> str:
-            return _translate_path(path=path, directories=directories)
+            return _translate_path(path=path, directories=paths)
 
     return HTTPServer((host, port), _LocalDatasourceRequestHandler)
 

--- a/lightly/cli/config/lightly-serve.yaml
+++ b/lightly/cli/config/lightly-serve.yaml
@@ -2,9 +2,15 @@
 input_dir: ''     # Path to the input directory.
 lightly_dir: ''   # Path to the lightly directory.
 host: 'localhost' # Hostname for serving the data.
-port:             # Port for serving the data.
+port: 3456        # Port for serving the data.
 
 
-hydra:
-  run:
-    dir: lightly_outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+defaults:  
+  - _self_  
+  - override hydra/hydra_logging: disabled  
+  - override hydra/job_logging: disabled  
+  
+hydra:  
+  output_subdir: null  
+  run:  
+    dir: .

--- a/lightly/cli/config/lightly-serve.yaml
+++ b/lightly/cli/config/lightly-serve.yaml
@@ -1,0 +1,10 @@
+
+input_dir: ''     # Path to the input directory.
+lightly_dir: ''   # Path to the lightly directory.
+host: 'localhost' # Hostname for serving the data.
+port:             # Port for serving the data.
+
+
+hydra:
+  run:
+    dir: lightly_outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/lightly/cli/config/lightly-serve.yaml
+++ b/lightly/cli/config/lightly-serve.yaml
@@ -1,10 +1,10 @@
+input_mount: ''     # Path to the input directory.
+lightly_mount: ''   # Path to the lightly directory.
+host: 'localhost'   # Hostname for serving the data.
+port: 3456          # Port for serving the data.
 
-input_dir: ''     # Path to the input directory.
-lightly_dir: ''   # Path to the lightly directory.
-host: 'localhost' # Hostname for serving the data.
-port: 3456        # Port for serving the data.
 
-
+# Disable Hydra log directories.
 defaults:  
   - _self_  
   - override hydra/hydra_logging: disabled  

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -12,39 +12,39 @@ def lightly_serve(cfg):
     """Use lightly-serve to serve your data for interactive exploration.
 
     Command-Line Args:
-        input_dir:
+        input_mount:
             Path to the input directory.
-        lightly_dir:
+        lightly_mount:
             Path to the Lightly directory.
         host:
             Hostname for serving the data (defaults to localhost).
         port:
-            Port for serving the data.
+            Port for serving the data (defaults to 3456).
 
     Examples:
-        >>> lightly-serve input_dir=data/ lightly_dir=lightly/ port=8080
+        >>> lightly-serve input_mount=data/ lightly_mount=lightly/ port=8080
 
 
     """
-    if not cfg.input_dir:
+    if not cfg.input_mount:
         print(
-            "Please provide a valid input directory. Use --help for more information."
+            "Please provide a valid input mount. Use --help for more information."
         )
         sys.exit(1)
 
-    if not cfg.lightly_dir:
+    if not cfg.lightly_mount:
         print(
-            "Please provide a valid Lightly directory. Use --help for more information."
+            "Please provide a valid Lightly mount. Use --help for more information."
         )
         sys.exit(1)
 
     httpd = serve.get_server(
-        paths=[Path(cfg.input_dir), Path(cfg.lightly_dir)],
+        paths=[Path(cfg.input_mount), Path(cfg.lightly_mount)],
         host=cfg.host,
         port=cfg.port,
     )
     print(f"Starting server, listening at '{httpd.server_name}:{httpd.server_port}'")
-    print(f"Listing files in '{cfg.input_dir}' and '{cfg.lightly_dir}'")
+    print(f"Listing files in '{cfg.input_mount}' and '{cfg.lightly_mount}'")
     httpd.serve_forever()
 
 

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -1,0 +1,54 @@
+import sys
+from pathlib import Path
+
+import hydra
+
+from lightly.api import serve
+from lightly.cli._helpers import fix_hydra_arguments
+
+
+@hydra.main(**fix_hydra_arguments(config_path="config", config_name="lightly-serve"))
+def lightly_serve(cfg):
+    """Use lightly-serve to serve your data for interactive exploration.
+
+    Command-Line Args:
+        input_dir:
+            Path to the input directory.
+        lightly_dir:
+            Path to the Lightly directory.
+        host:
+            Hostname for serving the data (defaults to localhost).
+        port:
+            Port for serving the data.
+
+    Examples:
+        >>> lightly-serve input_dir=data/ lightly_dir=lightly/ port=8080
+
+
+    """
+    if not cfg.input_dir:
+        print(
+            "Please provide a valid input directory. Use --help for more information."
+        )
+        sys.exit(1)
+
+    if not cfg.lightly_dir:
+        print(
+            "Please provide a valid Lightly directory. Use --help for more information."
+        )
+        sys.exit(1)
+
+    if cfg.port is None:
+        print("Please provide a valid port. Use --help for more information.")
+        sys.exit(1)
+
+    httpd = serve.get_server(
+        paths=[Path(cfg.input_dir), Path(cfg.lightly_dir)],
+        host=cfg.host,
+        port=cfg.port,
+    )
+    httpd.serve_forever()
+
+
+def entry() -> None:
+    lightly_serve()

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -27,15 +27,11 @@ def lightly_serve(cfg):
 
     """
     if not cfg.input_mount:
-        print(
-            "Please provide a valid input mount. Use --help for more information."
-        )
+        print("Please provide a valid input mount. Use --help for more information.")
         sys.exit(1)
 
     if not cfg.lightly_mount:
-        print(
-            "Please provide a valid Lightly mount. Use --help for more information."
-        )
+        print("Please provide a valid Lightly mount. Use --help for more information.")
         sys.exit(1)
 
     httpd = serve.get_server(

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -38,15 +38,13 @@ def lightly_serve(cfg):
         )
         sys.exit(1)
 
-    if cfg.port is None:
-        print("Please provide a valid port. Use --help for more information.")
-        sys.exit(1)
-
     httpd = serve.get_server(
         paths=[Path(cfg.input_dir), Path(cfg.lightly_dir)],
         host=cfg.host,
         port=cfg.port,
     )
+    print(f"Starting server, listening at '{httpd.server_name}:{httpd.server_port}'")
+    print(f"Listing files in '{cfg.input_dir}' and '{cfg.lightly_dir}'")
     httpd.serve_forever()
 
 

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -22,7 +22,7 @@ def lightly_serve(cfg):
             Port for serving the data (defaults to 3456).
 
     Examples:
-        >>> lightly-serve input_mount=data/ lightly_mount=lightly/ port=8080
+        >>> lightly-serve input_mount=data/ lightly_mount=lightly/ port=3456
 
 
     """
@@ -40,7 +40,7 @@ def lightly_serve(cfg):
         port=cfg.port,
     )
     print(f"Starting server, listening at '{httpd.server_name}:{httpd.server_port}'")
-    print(f"Listing files in '{cfg.input_mount}' and '{cfg.lightly_mount}'")
+    print(f"Serving files in '{cfg.input_mount}' and '{cfg.lightly_mount}'")
     httpd.serve_forever()
 
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if __name__ == "__main__":
             "lightly-magic = lightly.cli.lightly_cli:entry",
             "lightly-download = lightly.cli.download_cli:entry",
             "lightly-version = lightly.cli.version_cli:entry",
+            "lightly-serve = lightly.cli.serve_cli:entry",
         ]
     }
 

--- a/tests/api/test_serve.py
+++ b/tests/api/test_serve.py
@@ -12,11 +12,7 @@ def test__translate_path(tmp_path: Path) -> None:
     assert serve._translate_path(
         path="/hello/world.txt", directories=[tmp_path]
     ) == str(tmp_file)
-
-
-def test__strip_leading_slashes() -> None:
-    assert serve._strip_leading_slashes("/") == ""
-    assert serve._strip_leading_slashes("//") == ""
-    assert serve._strip_leading_slashes("/hello") == "hello"
-    assert serve._strip_leading_slashes("/hello/world") == "hello/world"
-    assert serve._strip_leading_slashes("//hello/world/") == "hello/world/"
+    assert serve._translate_path(
+        path="/world.txt",
+        directories=[tmp_path / "hi", tmp_path / "hello"],
+    ) == str(tmp_file)

--- a/tests/api/test_serve.py
+++ b/tests/api/test_serve.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from lightly.api import serve
+
+
+def test__translate_path(tmp_path: Path) -> None:
+    tmp_file = tmp_path / "hello/world.txt"
+    assert serve._translate_path(path="/hello/world.txt", directories=[]) == ""
+    assert serve._translate_path(path="/hello/world.txt", directories=[tmp_path]) == ""
+    tmp_file.mkdir(parents=True, exist_ok=True)
+    tmp_file.touch()
+    assert serve._translate_path(
+        path="/hello/world.txt", directories=[tmp_path]
+    ) == str(tmp_file)
+
+
+def test__strip_leading_slashes() -> None:
+    assert serve._strip_leading_slashes("/") == ""
+    assert serve._strip_leading_slashes("//") == ""
+    assert serve._strip_leading_slashes("/hello") == "hello"
+    assert serve._strip_leading_slashes("/hello/world") == "hello/world"
+    assert serve._strip_leading_slashes("//hello/world/") == "hello/world/"


### PR DESCRIPTION
# Add lightly-serve script

Adds a script to serve data from two local directories on localhost:
```
lightly-serve input_mount=data/ lightly_mount=lightly/ port=8080
```

* The `HTTPServer` can also be created using `lightly.api.serve.get_server`.
* I added tests for the helper functions and tested the script manually.