### PR TITLE
Igor lig 3904 fix imagenet benchmark memory usage

### DIFF
--- a/benchmarks/imagenet/resnet50/finetune_eval.py
+++ b/benchmarks/imagenet/resnet50/finetune_eval.py
@@ -82,7 +82,7 @@ def finetune_eval(
         shuffle=True,
         num_workers=num_workers,
         drop_last=True,
-        persistent_workers=True,
+        persistent_workers=False,
     )
 
     # Setup validation data.
@@ -100,7 +100,7 @@ def finetune_eval(
         batch_size=batch_size_per_device,
         shuffle=False,
         num_workers=num_workers,
-        persistent_workers=True,
+        persistent_workers=False,
     )
 
     # Train linear classifier.
@@ -117,6 +117,7 @@ def finetune_eval(
         logger=TensorBoardLogger(save_dir=str(log_dir), name="finetune_eval"),
         precision=precision,
         strategy="ddp_find_unused_parameters_true",
+        num_sanity_val_steps=0,
     )
     classifier = FinetuneLinearClassifier(
         model=model,

--- a/benchmarks/imagenet/resnet50/knn_eval.py
+++ b/benchmarks/imagenet/resnet50/knn_eval.py
@@ -82,6 +82,7 @@ def knn_eval(
             metric_callback,
         ],
         strategy="ddp_find_unused_parameters_true",
+        num_sanity_val_steps=0,
     )
     trainer.fit(
         model=classifier,

--- a/benchmarks/imagenet/resnet50/linear_eval.py
+++ b/benchmarks/imagenet/resnet50/linear_eval.py
@@ -59,7 +59,7 @@ def linear_eval(
         shuffle=True,
         num_workers=num_workers,
         drop_last=True,
-        persistent_workers=True,
+        persistent_workers=False,
     )
 
     # Setup validation data.
@@ -77,7 +77,7 @@ def linear_eval(
         batch_size=batch_size_per_device,
         shuffle=False,
         num_workers=num_workers,
-        persistent_workers=True,
+        persistent_workers=False,
     )
 
     # Train linear classifier.
@@ -94,6 +94,7 @@ def linear_eval(
         logger=TensorBoardLogger(save_dir=str(log_dir), name="linear_eval"),
         precision=precision,
         strategy="ddp_find_unused_parameters_true",
+        num_sanity_val_steps=0,
     )
     classifier = LinearClassifier(
         model=model,

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -183,7 +183,7 @@ def pretrain(
         shuffle=True,
         num_workers=num_workers,
         drop_last=True,
-        persistent_workers=True,
+        persistent_workers=False,
     )
 
     # Setup validation data.
@@ -201,7 +201,7 @@ def pretrain(
         batch_size=batch_size_per_device,
         shuffle=False,
         num_workers=num_workers,
-        persistent_workers=True,
+        persistent_workers=False,
     )
 
     # Train model.
@@ -221,6 +221,7 @@ def pretrain(
         precision=precision,
         strategy="ddp_find_unused_parameters_true",
         sync_batchnorm=True,
+        num_sanity_val_steps=0,
     )
     trainer.fit(
         model=model,


### PR DESCRIPTION
## Changes

We noticed quite a high memory consumption during the ImageNet benchmarks. In some cases this could also lead to crashes on our cluster. This PR addresses several issues we found:

- We stop using persistent workers in the PyTorch dataloader as we noticed that this leads to a high number of processes staying alive in the background. (running benchmarks using `num_workers` set to `12` on a machine with two GPUs can lead to over 100 new processes started. 
- We disabled `num_sanity_val_steps` in the PyTorchLightning Trainer. We noticed that using these sanity steps cause the validation dataloader to stay alive throughout the training process which leads to an increase in shared memory usage. In our tests we were able to reduce shared memory usage from 6GB to 3GB during kNN evaluation and linearEvaluation steps

### Some Numbers of the tests

**Before this PR:**
- used memory can jump up to 50GB and consume up to 20GB of swap memory
- over 16GB of shared memory was used during processing
- number of processes spawned during the benchmark are around 100

**With this PR:**
- used memory can jump up to 40GB and consume up to 16GB of swap memory
- shared memory stays below 12GB
- number of processes spawned during the benchmark are around 60
- processing speed seems to slightly go up after disabling persistent_workers. But this needs more investigation.

This has been tested using the SimCLR benchmark!