### PR TITLE
Clean up lightly.api docs

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -218,6 +218,8 @@ class ApiWorkflowClient(
 
         Returns:
             Names of files in the current dataset.
+
+        :meta private:  # Skip docstring generation
         """
         filenames_on_server = self._mappings_api.get_sample_mappings_by_dataset_id(
             dataset_id=self.dataset_id, field="fileName"
@@ -247,6 +249,7 @@ class ApiWorkflowClient(
         Returns:
             The response of the put request.
 
+        :meta private:  # Skip docstring generation
         """
 
         # check to see if server side encryption for S3 is desired

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -207,6 +207,8 @@ class _ComputeWorkerMixin:
             >>> config_id = client.create_compute_worker_config(
             ...     selection_config=selection_config,
             ... )
+
+        :meta private:  # Skip docstring generation
         """
         if isinstance(selection_config, dict):
             selection = selection_config_from_dict(cfg=selection_config)

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -130,6 +130,8 @@ class _DatasourcesMixin:
             >>> client.set_dataset_id_by_name("my-dataset")
             >>> client.download_raw_samples()
             [('image-1.png', 'https://......'), ('image-2.png', 'https://......')]
+
+        :meta private:  # Skip docstring generation
         """
         samples = self._download_raw_files(
             download_function=self._datasources_api.get_list_of_raw_samples_from_datasource_by_dataset_id,
@@ -198,6 +200,8 @@ class _DatasourcesMixin:
             >>> client.download_raw_predictions(task_name=task_name)
             [('.lightly/predictions/object-detection/image-1.json', 'https://......'),
              ('.lightly/predictions/object-detection/image-2.json', 'https://......')]
+
+        :meta private:  # Skip docstring generation
         """
         if run_id is not None and relevant_filenames_artifact_id is None:
             raise ValueError(
@@ -281,6 +285,8 @@ class _DatasourcesMixin:
             >>> client.download_raw_metadata()
             [('.lightly/metadata/object-detection/image-1.json', 'https://......'),
              ('.lightly/metadata/object-detection/image-2.json', 'https://......')]
+
+        :meta private:  # Skip docstring generation
         """
         if run_id is not None and relevant_filenames_artifact_id is None:
             raise ValueError(
@@ -370,6 +376,8 @@ class _DatasourcesMixin:
             >>> client.set_dataset_id_by_name("my-dataset")
             >>> client.get_processed_until_timestamp()
             1684750513
+
+        :meta private:  # Skip docstring generation
         """
         response: DatasourceProcessedUntilTimestampResponse = self._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id(
             dataset_id=self.dataset_id
@@ -721,6 +729,7 @@ class _DatasourcesMixin:
             A read-url to the file. Note that a URL will be returned even if the file does not
             exist.
 
+        :meta private:  # Skip docstring generation
         """
         return self._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id(
             dataset_id=self.dataset_id,
@@ -741,6 +750,7 @@ class _DatasourcesMixin:
             A read-url to the file. Note that a URL will be returned even if the file does not
             exist.
 
+        :meta private:  # Skip docstring generation
         """
         return self._datasources_api.get_metadata_file_read_url_from_datasource_by_dataset_id(
             dataset_id=self.dataset_id,
@@ -761,6 +771,7 @@ class _DatasourcesMixin:
             A read-url to the file. Note that a URL will be returned even if the file does not
             exist.
 
+        :meta private:  # Skip docstring generation
         """
         return self._datasources_api.get_custom_embedding_file_read_url_from_datasource_by_dataset_id(
             dataset_id=self.dataset_id,

--- a/lightly/api/api_workflow_predictions.py
+++ b/lightly/api/api_workflow_predictions.py
@@ -44,7 +44,7 @@ class _PredictionsMixin:
           >>> )
           >>> client.create_or_update_prediction_task_schema(schema=schema)
 
-
+        :meta private:  # Skip docstring generation
         """
         self._predictions_api.create_or_update_prediction_task_schema_by_dataset_id(
             prediction_task_schema=schema,
@@ -71,6 +71,8 @@ class _PredictionsMixin:
 
             prediction_singletons:
                 Predictions to be uploaded for the designated sample.
+
+        :meta private:  # Skip docstring generation
         """
         self._predictions_api.create_or_update_prediction_by_sample_id(
             prediction_singleton=prediction_singletons,

--- a/lightly/api/api_workflow_selection.py
+++ b/lightly/api/api_workflow_selection.py
@@ -39,6 +39,8 @@ class _SelectionMixin:
                 and score arrays. The length of each score array must match samples
                 in the designated tag.
             query_tag_id: ID of the desired tag.
+
+        :meta private:  # Skip docstring generation
         """
         # iterate over all available score types and upload them
         for score_type, score_values in al_scores.items():
@@ -79,6 +81,7 @@ class _SelectionMixin:
                 When `initial-tag` does not exist in the dataset.
                 When the selection task fails.
 
+        :meta private:  # Skip docstring generation
         """
 
         warnings.warn(

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -124,6 +124,8 @@ class _TagsMixin:
             >>> tag = client.get_tag_by_name("cool-tag")
             >>> client.get_filenames_in_tag(tag_data=tag)
             ['image-1.png', 'image-2.png']
+
+        :meta private:  # Skip docstring generation
         """
 
         if exclude_parent_tag:

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -31,7 +31,10 @@ class _UploadEmbeddingsMixin:
         return reader
 
     def set_embedding_id_to_latest(self) -> None:
-        """Sets the embedding ID in the API client to the latest embedding ID in the current dataset."""
+        """Sets the embedding ID in the API client to the latest embedding ID in the current dataset.
+
+        :meta private:  # Skip docstring generation
+        """
         embeddings_on_server: List[
             DatasetEmbeddingData
         ] = self._embeddings_api.get_embeddings_by_dataset_id(
@@ -104,6 +107,7 @@ class _UploadEmbeddingsMixin:
                 The name of the embedding. If an embedding with such a name already exists on the server,
                 the upload is aborted.
 
+        :meta private:  # Skip docstring generation
         """
         io_utils.check_embeddings(
             path_to_embeddings_csv, remove_additional_columns=True
@@ -185,6 +189,7 @@ class _UploadEmbeddingsMixin:
                 If the number of columns in the local embeddings file and that of the remote
                 embeddings file mismatch.
 
+        :meta private:  # Skip docstring generation
         """
 
         # read embedding from API

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -67,6 +67,7 @@ class _UploadCustomMetadataMixin:
             If there are no annotations for a filename, the custom metadata
             is None instead.
 
+        :meta private:  # Skip docstring generation
         """
 
         # The mapping is filename -> image_id -> custom_metadata
@@ -141,6 +142,7 @@ class _UploadCustomMetadataMixin:
             max_workers:
                 Maximum number of concurrent threads during upload.
 
+        :meta private:  # Skip docstring generation
         """
 
         self.verify_custom_metadata_format(custom_metadata)
@@ -241,7 +243,7 @@ class _UploadCustomMetadataMixin:
             >>>     [entry],
             >>> )
 
-
+        :meta private:  # Skip docstring generation
         """
         config_set_request = ConfigurationSetRequest(name=name, configs=configs)
         resp = self._metadata_configurations_api.create_meta_data_configuration(

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -262,7 +262,10 @@ def load_embeddings_as_dict(
 
 
 class COCO_ANNOTATION_KEYS:
-    """Enum of coco annotation keys complemented with a key for custom metadata."""
+    """Enum of coco annotation keys complemented with a key for custom metadata.
+
+    :meta private:  # Skip docstring generation
+    """
 
     # image keys
     images: str = "images"
@@ -298,6 +301,7 @@ def format_custom_metadata(
         >>> >   'metadata': [{'image_id': 0, 'number_of_people': 1}, {'image_id': 1, 'number_of_people': 3}]
         >>> > }
 
+    :meta private:  # Skip docstring generation
     """
     formatted: Dict[str, List[Any]] = {
         COCO_ANNOTATION_KEYS.images: [],
@@ -330,6 +334,7 @@ def save_custom_metadata(path: str, custom_metadata: List[Tuple[str, Any]]) -> N
         custom_metadata:
             List of tuples (filename, metadata) where metadata is a dictionary.
 
+    :meta private:  # Skip docstring generation
     """
     formatted = format_custom_metadata(custom_metadata)
     with open(path, "w") as f:


### PR DESCRIPTION
## What has changed and why?

Removed deprecated and internal api functions from the generated docs.

Closes #1375.

## How has it been tested?

* Locally built the docs. Checked that entries are missing.
* Checksum: There are 24 entries to remove and 24x added a line with `:meta private:`