### PR TITLE
Guarin lig 3871 lightly serve unsupported method options

### DIFF
--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -34,9 +34,10 @@ def get_server(
             return _translate_path(path=path, directories=paths)
 
         def do_OPTIONS(self) -> None:
+            self.send_response(204)
             self.send_header("Access-Control-Allow-Origin", "*")
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_response(204)
+            self.end_headers()
 
     return HTTPServer((host, port), _LocalDatasourceRequestHandler)
 


### PR DESCRIPTION
## Changes
* Handle `OPTIONS` requests

## How was it tested?
* Tested it manually on a local dataset, the server now successfully sends responses:

```
127.0.0.1 - - [21/Sep/2023 08:01:30] "OPTIONS /bdd_tiny/.lightly/thumbnails/00a2e3ca-5c856cde-0-mp4_thumb.png HTTP/1.1" 200 -
127.0.0.1 - - [21/Sep/2023 08:01:32] "OPTIONS /bdd_tiny/.lightly/thumbnails/00a2e3ca-5c856cde-3-mp4_thumb.png HTTP/1.1" 200 -
127.0.0.1 - - [21/Sep/2023 08:01:33] "GET /bdd_tiny/.lightly/frames/00a2e3ca-5c856cde-3-mp4.png HTTP/1.1" 200 -
127.0.0.1 - - [21/Sep/2023 08:01:33] "OPTIONS /bdd_tiny/.lightly/frames/00a2e3ca-5c856cde-3-mp4.png HTTP/1.1" 200 -
127.0.0.1 - - [21/Sep/2023 08:01:39] "OPTIONS /bdd_tiny/.lightly/thumbnails/00a0f008-3c67908e-3-mp4_thumb.png HTTP/1.1" 200 -
127.0.0.1 - - [21/Sep/2023 08:01:40] "GET /bdd_tiny/.lightly/frames/00a0f008-3c67908e-3-mp4.png HTTP/1.1" 200 -
```
