### PR TITLE
Add methods to iteratively list predictions and metadata files

### DIFF
--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -83,52 +83,9 @@ class _DatasourcesMixin:
         use_redirected_read_url: bool = False,
         progress_bar: Optional[tqdm.tqdm] = None,
     ) -> List[Tuple[str, str]]:
-        """Downloads prediction filenames and read urls from the datasource.
+        """Downloads all prediction filenames and read urls from the datasource.
 
-        Only samples with timestamp between `from_` (inclusive) and `to` (inclusive)
-        will be downloaded.
-
-        Args:
-            task_name:
-                Name of the prediction task.
-            from_:
-                Unix timestamp from which on samples are downloaded. Defaults to the
-                very beginning (timestamp 0).
-            to:
-                Unix timestamp up to and including which samples are downloaded.
-                Defaults to the current timestamp.
-            relevant_filenames_file_name:
-                Path to the relevant filenames text file in the cloud bucket.
-                The path is relative to the datasource root. Optional.
-            run_id:
-                Run ID. Optional. Should be given along with
-                `relevant_filenames_artifact_id` to download relevant files only.
-            relevant_filenames_artifact_id:
-                ID of the relevant filename artifact. Optional. Should be given along
-                with `run_id` to download relevant files only. Note that this is
-                different from `relevant_filenames_file_name`.
-            use_redirected_read_url:
-                Flag for redirected read urls. When this flag is true,
-                RedirectedReadUrls are returned instead of ReadUrls, meaning that the
-                returned URLs have unlimited access to the file.
-                Defaults to False. When S3DelegatedAccess is configured, this flag has
-                no effect because RedirectedReadUrls are always returned.
-            progress_bar:
-                Tqdm progress bar to show how many prediction files have already been
-                retrieved.
-
-        Returns:
-            A list of (filename, url) tuples where each tuple represents a sample.
-
-        Examples:
-            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>>
-            >>> # Already created some Lightly Worker runs with this dataset
-            >>> task_name = "object-detection"
-            >>> client.set_dataset_id_by_name("my-dataset")
-            >>> client.download_raw_predictions(task_name=task_name)
-            [('.lightly/predictions/object-detection/image-1.json', 'https://......'),
-             ('.lightly/predictions/object-detection/image-2.json', 'https://......')]
+        See `download_raw_predictions_iter` for details.
 
         :meta private:  # Skip docstring generation
         """
@@ -245,47 +202,7 @@ class _DatasourcesMixin:
     ) -> List[Tuple[str, str]]:
         """Downloads all metadata filenames and read urls from the datasource.
 
-        Only samples with timestamp between `from_` (inclusive) and `to` (inclusive)
-        will be downloaded.
-
-        Args:
-            from_:
-                Unix timestamp from which on samples are downloaded. Defaults to the
-                very beginning (timestamp 0).
-            to:
-                Unix timestamp up to and including which samples are downloaded.
-                Defaults to the current timestamp.
-            relevant_filenames_file_name:
-                Path to the relevant filenames text file in the cloud bucket.
-                The path is relative to the datasource root. Optional.
-            run_id:
-                Run ID. Optional. Should be given along with
-                `relevant_filenames_artifact_id` to download relevant files only.
-            relevant_filenames_artifact_id:
-                ID of the relevant filename artifact. Optional. Should be given along
-                with `run_id` to download relevant files only. Note that this is
-                different from `relevant_filenames_file_name`.
-            use_redirected_read_url:
-                Flag for redirected read urls. When this flag is true,
-                RedirectedReadUrls are returned instead of ReadUrls, meaning that the
-                returned URLs have unlimited access to the file.
-                Defaults to False. When S3DelegatedAccess is configured, this flag has
-                no effect because RedirectedReadUrls are always returned.
-            progress_bar:
-                Tqdm progress bar to show how many metadata files have already been
-                retrieved.
-
-        Returns:
-            A list of (filename, url) tuples where each tuple represents a sample.
-
-        Examples:
-            >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>>
-            >>> # Already created some Lightly Worker runs with this dataset
-            >>> client.set_dataset_id_by_name("my-dataset")
-            >>> client.download_raw_metadata()
-            [('.lightly/metadata/object-detection/image-1.json', 'https://......'),
-             ('.lightly/metadata/object-detection/image-2.json', 'https://......')]
+        See `download_raw_metadata_iter` for details.
 
         :meta private:  # Skip docstring generation
         """

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -880,12 +880,10 @@ def _sample_unseen_and_valid(
     relevant_filenames_file_name: Optional[str],
     listed_filenames: Set[str],
 ) -> bool:
-    # Note: These checks are not in the API because of two reasons. 1) Checking if all
-    # entries in the relevant filenames file are valid is too expensive. We would have
-    # to iterate over all entries in the file when scheduling a new run. As the file
-    # can be arbitrarily large, this is not feasible. 2) Checking for duplicate entries
-    # in the API is also too expensive as the API would have to maintain a list of all
-    # seen filenames in memory.
+    # Note: We want to remove these checks eventually. Absolute paths and relative paths
+    # with dot notation should be handled either in the API or the Worker. Duplicate
+    # filenames should be handled in the Worker as handling it in the API would require
+    # too much memory.
     if sample.file_name.startswith("/"):
         warnings.warn(
             UserWarning(

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -880,6 +880,12 @@ def _sample_unseen_and_valid(
     relevant_filenames_file_name: Optional[str],
     listed_filenames: Set[str],
 ) -> bool:
+    # Note: These checks are not in the API because of two reasons. 1) Checking if all
+    # entries in the relevant filenames file are valid is too expensive. We would have
+    # to iterate over all entries in the file when scheduling a new run. As the file
+    # can be arbitrarily large, this is not feasible. 2) Checking for duplicate entries
+    # in the API is also too expensive as the API would have to maintain a list of all
+    # seen filenames in memory.
     if sample.file_name.startswith("/"):
         warnings.warn(
             UserWarning(

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -281,13 +281,13 @@ class TestDatasourcesMixin:
         self, mocker: MockerFixture
     ) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client.get_processed_until_timestamp = mocker.MagicMock(return_value=0)
+        client.get_processed_until_timestamp = mocker.MagicMock(return_value=2)
         mocker.patch("time.time", return_value=5)
         client.download_raw_samples = mocker.MagicMock()
         client.update_processed_until_timestamp = mocker.MagicMock()
         client.download_new_raw_samples()
         client.download_raw_samples.assert_called_once_with(
-            from_=0,
+            from_=3,
             to=5,
             relevant_filenames_file_name=None,
             use_redirected_read_url=False,

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -1,7 +1,8 @@
 import pytest
+import tqdm
 from pytest_mock import MockerFixture
 
-from lightly.api import ApiWorkflowClient
+from lightly.api import ApiWorkflowClient, api_workflow_datasources
 from lightly.openapi_generated.swagger_client.models import (
     DatasourceConfigAzure,
     DatasourceConfigGCS,
@@ -17,351 +18,591 @@ from lightly.openapi_generated.swagger_client.models.datasource_config_verify_da
 from lightly.openapi_generated.swagger_client.models.datasource_config_verify_data_errors import (
     DatasourceConfigVerifyDataErrors,
 )
+from lightly.openapi_generated.swagger_client.models.datasource_processed_until_timestamp_response import (
+    DatasourceProcessedUntilTimestampResponse,
+)
+from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data import (
+    DatasourceRawSamplesData,
+)
 
 
-def test__download_raw_files(mocker: MockerFixture) -> None:
-    mock_response_1 = mocker.MagicMock()
-    mock_response_1.has_more = True
-    mock_response_1.data = [
-        DatasourceRawSamplesDataRow(file_name="/file1", read_url="url1"),
-        DatasourceRawSamplesDataRow(file_name="file2", read_url="url2"),
-    ]
+class TestDatasourcesMixin:
+    def test_download_raw_samples(self, mocker: MockerFixture) -> None:
+        response = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_list_of_raw_samples_from_datasource_by_dataset_id = mocker.MagicMock(
+            side_effect=[response]
+        )
+        assert client.download_raw_samples() == [("file1", "url1"), ("file2", "url2")]
 
-    mock_response_2 = mocker.MagicMock()
-    mock_response_2.has_more = False
-    mock_response_2.data = [
-        DatasourceRawSamplesDataRow(file_name="./file3", read_url="url3"),
-        DatasourceRawSamplesDataRow(file_name="file2", read_url="url2"),
-    ]
+    def test_download_raw_predictions(self, mocker: MockerFixture) -> None:
+        response = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id = mocker.MagicMock(
+            side_effect=[response]
+        )
+        assert client.download_raw_predictions(task_name="task") == [
+            ("file1", "url1"),
+            ("file2", "url2"),
+        ]
 
-    mocked_method = mocker.MagicMock(side_effect=[mock_response_1, mock_response_2])
-    mocked_pbar = mocker.MagicMock()
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_warning = mocker.patch("warnings.warn")
-    client = ApiWorkflowClient()
-    client._dataset_id = "dataset-id"
-    result = client._download_raw_files(
-        download_function=mocked_method,
-        progress_bar=mocked_pbar,
-    )
-    kwargs = mocked_method.call_args[1]
-    assert "relevant_filenames_file_name" not in kwargs
-    assert mocked_pbar.update.call_count == 2
-    assert mocked_warning.call_count == 3
-    warning_text = [str(call_args[0][0]) for call_args in mocked_warning.call_args_list]
-    assert warning_text == [
-        (
-            "Absolute file paths like /file1 are not supported"
-            " in relevant filenames file None due to blob storage"
-        ),
-        (
-            "Using dot notation ('./', '../') like in ./file3 is not supported"
-            " in relevant filenames file None due to blob storage"
-        ),
-        ("Duplicate filename file2 in relevant filenames file None"),
-    ]
-    assert len(result) == 1
-    assert result[0][0] == "file2"
-
-
-def test_get_prediction_read_url(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._dataset_id = "dataset-id"
-    client._datasources_api = mocked_api
-    client.get_prediction_read_url("test.json")
-    mocked_method = (
-        mocked_api.get_prediction_file_read_url_from_datasource_by_dataset_id
-    )
-    mocked_method.assert_called_once_with(
-        dataset_id="dataset-id", file_name="test.json"
-    )
-
-
-def test_download_new_raw_samples(mocker: MockerFixture) -> None:
-    from_timestamp = 2
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocker.patch.object(
-        ApiWorkflowClient, "get_processed_until_timestamp", return_value=from_timestamp
-    )
-    current_time = 5
-    mocker.patch("time.time", return_value=current_time)
-    mocked_download = mocker.patch.object(ApiWorkflowClient, "download_raw_samples")
-    mocked_update_timestamp = mocker.patch.object(
-        ApiWorkflowClient, "update_processed_until_timestamp"
-    )
-    client = ApiWorkflowClient()
-    client.download_new_raw_samples()
-    mocked_download.assert_called_once_with(
-        from_=from_timestamp + 1,
-        to=current_time,
-        relevant_filenames_file_name=None,
-        use_redirected_read_url=False,
-    )
-    mocked_update_timestamp.assert_called_once_with(timestamp=current_time)
-
-
-def test_download_new_raw_samples__from_beginning(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocker.patch.object(
-        ApiWorkflowClient, "get_processed_until_timestamp", return_value=0
-    )
-    current_time = 5
-    mocker.patch("time.time", return_value=current_time)
-    mocked_download = mocker.patch.object(ApiWorkflowClient, "download_raw_samples")
-    mocked_update_timestamp = mocker.patch.object(
-        ApiWorkflowClient, "update_processed_until_timestamp"
-    )
-    client = ApiWorkflowClient()
-    client.download_new_raw_samples()
-    mocked_download.assert_called_once_with(
-        from_=0,
-        to=current_time,
-        relevant_filenames_file_name=None,
-        use_redirected_read_url=False,
-    )
-    mocked_update_timestamp.assert_called_once_with(timestamp=current_time)
-
-
-def test_download_raw_samples_predictions__relevant_filenames_artifact_id(
-    mocker: MockerFixture,
-) -> None:
-    mock_response = mocker.MagicMock()
-    mock_response.has_more = False
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_api = mocker.MagicMock()
-    mocked_method = mocker.MagicMock(return_value=mock_response)
-    mocked_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id = (
-        mocked_method
-    )
-    client = ApiWorkflowClient()
-    client._dataset_id = "dataset-id"
-    client._datasources_api = mocked_api
-    client.download_raw_predictions(
-        task_name="task", run_id="foo", relevant_filenames_artifact_id="bar"
-    )
-    kwargs = mocked_method.call_args[1]
-    assert kwargs.get("relevant_filenames_run_id") == "foo"
-    assert kwargs.get("relevant_filenames_artifact_id") == "bar"
-
-    # should raise ValueError when only run_id is given
-    with pytest.raises(ValueError):
-        client.download_raw_predictions(task_name="foobar", run_id="foo")
-    # should raise ValueError when only relevant_filenames_artifact_id is given
-    with pytest.raises(ValueError):
-        client.download_raw_predictions(
-            task_name="foobar", relevant_filenames_artifact_id="bar"
+    def test_download_raw_predictions_iter(self, mocker: MockerFixture) -> None:
+        response_1 = DatasourceRawSamplesData(
+            hasMore=True,
+            cursor="cursor1",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        response_2 = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="cursor2",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file3", readUrl="url3"),
+                DatasourceRawSamplesDataRow(fileName="file4", readUrl="url4"),
+            ],
+        )
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id = mocker.MagicMock(
+            side_effect=[response_1, response_2]
+        )
+        assert list(client.download_raw_predictions_iter(task_name="task")) == [
+            ("file1", "url1"),
+            ("file2", "url2"),
+            ("file3", "url3"),
+            ("file4", "url4"),
+        ]
+        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id.assert_has_calls(
+            [
+                mocker.call(
+                    dataset_id="dataset-id",
+                    task_name="task",
+                    var_from=0,
+                    to=mocker.ANY,
+                    use_redirected_read_url=False,
+                ),
+                mocker.call(
+                    dataset_id="dataset-id",
+                    task_name="task",
+                    cursor="cursor1",
+                    use_redirected_read_url=False,
+                ),
+            ]
         )
 
+    def test_download_raw_predictions_iter__relevant_filenames_artifact_id(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        response = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id = mocker.MagicMock(
+            side_effect=[response]
+        )
+        assert list(
+            client.download_raw_predictions_iter(
+                task_name="task",
+                run_id="run-id",
+                relevant_filenames_artifact_id="relevant-filenames",
+            )
+        ) == [
+            ("file1", "url1"),
+            ("file2", "url2"),
+        ]
+        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id.assert_called_once_with(
+            dataset_id="dataset-id",
+            task_name="task",
+            var_from=0,
+            to=mocker.ANY,
+            relevant_filenames_run_id="run-id",
+            relevant_filenames_artifact_id="relevant-filenames",
+            use_redirected_read_url=False,
+        )
 
-def test_download_raw_samples_metadata__relevant_filenames_artifact_id(
-    mocker: MockerFixture,
-) -> None:
-    mock_response = mocker.MagicMock()
-    mock_response.has_more = False
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_api = mocker.MagicMock()
-    mocked_method = mocker.MagicMock(return_value=mock_response)
-    mocked_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id = (
-        mocked_method
-    )
-    client = ApiWorkflowClient()
-    client._dataset_id = "dataset-id"
-    client._datasources_api = mocked_api
-    client.download_raw_metadata(run_id="foo", relevant_filenames_artifact_id="bar")
-    kwargs = mocked_method.call_args[1]
-    assert kwargs.get("relevant_filenames_run_id") == "foo"
-    assert kwargs.get("relevant_filenames_artifact_id") == "bar"
+        # should raise ValueError when only run_id is given
+        with pytest.raises(ValueError):
+            next(
+                client.download_raw_predictions_iter(task_name="task", run_id="run-id")
+            )
 
-    # should raise ValueError when only run_id is given
-    with pytest.raises(ValueError):
-        client.download_raw_metadata(run_id="foo")
-    # should raise ValueError when only relevant_filenames_artifact_id is given
-    with pytest.raises(ValueError):
-        client.download_raw_metadata(relevant_filenames_artifact_id="bar")
+        # should raise ValueError when only relevant_filenames_artifact_id is given
+        with pytest.raises(ValueError):
+            next(
+                client.download_raw_predictions_iter(
+                    task_name="task",
+                    relevant_filenames_artifact_id="relevant-filenames",
+                )
+            )
 
+    def test_download_raw_metadata(self, mocker: MockerFixture) -> None:
+        response = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id = mocker.MagicMock(
+            side_effect=[response]
+        )
+        assert client.download_raw_metadata() == [
+            ("file1", "url1"),
+            ("file2", "url2"),
+        ]
 
-def test_get_processed_until_timestamp(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_datasources_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._dataset_id = "dataset-id"
-    client._datasources_api = mocked_datasources_api
-    client.get_processed_until_timestamp()
-    mocked_method = (
-        mocked_datasources_api.get_datasource_processed_until_timestamp_by_dataset_id
-    )
-    mocked_method.assert_called_once_with(dataset_id="dataset-id")
+    def test_download_raw_metadata_iter(self, mocker: MockerFixture) -> None:
+        response_1 = DatasourceRawSamplesData(
+            hasMore=True,
+            cursor="cursor1",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        response_2 = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="cursor2",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file3", readUrl="url3"),
+                DatasourceRawSamplesDataRow(fileName="file4", readUrl="url4"),
+            ],
+        )
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id = mocker.MagicMock(
+            side_effect=[response_1, response_2]
+        )
+        assert list(client.download_raw_metadata_iter()) == [
+            ("file1", "url1"),
+            ("file2", "url2"),
+            ("file3", "url3"),
+            ("file4", "url4"),
+        ]
+        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id.assert_has_calls(
+            [
+                mocker.call(
+                    dataset_id="dataset-id",
+                    var_from=0,
+                    to=mocker.ANY,
+                    use_redirected_read_url=False,
+                ),
+                mocker.call(
+                    dataset_id="dataset-id",
+                    cursor="cursor1",
+                    use_redirected_read_url=False,
+                ),
+            ]
+        )
 
+    def test_download_raw_metadata_iter__relevant_filenames_artifact_id(
+        self, mocker: MockerFixture
+    ) -> None:
+        response = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id = mocker.MagicMock(
+            side_effect=[response]
+        )
+        assert list(
+            client.download_raw_metadata_iter(
+                run_id="run-id",
+                relevant_filenames_artifact_id="relevant-filenames",
+            )
+        ) == [
+            ("file1", "url1"),
+            ("file2", "url2"),
+        ]
+        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id.assert_called_once_with(
+            dataset_id="dataset-id",
+            var_from=0,
+            to=mocker.ANY,
+            relevant_filenames_run_id="run-id",
+            relevant_filenames_artifact_id="relevant-filenames",
+            use_redirected_read_url=False,
+        )
 
-def test_set_azure_config(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_datasources_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._datasources_api = mocked_datasources_api
-    client._dataset_id = "dataset-id"
-    client.set_azure_config(
-        container_name="my-container/name",
-        account_name="my-account-name",
-        sas_token="my-sas-token",
-        thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
-    )
-    kwargs = mocked_datasources_api.update_datasource_by_dataset_id.call_args[1]
-    assert isinstance(
-        kwargs["datasource_config"].actual_instance, DatasourceConfigAzure
-    )
+        # should raise ValueError when only run_id is given
+        with pytest.raises(ValueError):
+            next(client.download_raw_metadata_iter(run_id="run-id"))
 
+        # should raise ValueError when only relevant_filenames_artifact_id is given
+        with pytest.raises(ValueError):
+            next(
+                client.download_raw_metadata_iter(
+                    relevant_filenames_artifact_id="relevant-filenames",
+                )
+            )
 
-def test_set_gcs_config(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_datasources_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._datasources_api = mocked_datasources_api
-    client._dataset_id = "dataset-id"
-    client.set_gcs_config(
-        resource_path="gs://my-bucket/my-dataset",
-        project_id="my-project-id",
-        credentials="my-credentials",
-        thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
-    )
-    kwargs = mocked_datasources_api.update_datasource_by_dataset_id.call_args[1]
-    assert isinstance(kwargs["datasource_config"].actual_instance, DatasourceConfigGCS)
+    def test_download_new_raw_samples(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client.get_processed_until_timestamp = mocker.MagicMock(return_value=2)
+        mocker.patch("time.time", return_value=5)
+        client.download_raw_samples = mocker.MagicMock()
+        client.update_processed_until_timestamp = mocker.MagicMock()
+        client.download_new_raw_samples()
+        client.download_raw_samples.assert_called_once_with(
+            from_=2 + 1,
+            to=5,
+            relevant_filenames_file_name=None,
+            use_redirected_read_url=False,
+        )
+        client.update_processed_until_timestamp.assert_called_once_with(timestamp=5)
 
+    def test_download_new_raw_samples__from_beginning(
+        self, mocker: MockerFixture
+    ) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client.get_processed_until_timestamp = mocker.MagicMock(return_value=0)
+        mocker.patch("time.time", return_value=5)
+        client.download_raw_samples = mocker.MagicMock()
+        client.update_processed_until_timestamp = mocker.MagicMock()
+        client.download_new_raw_samples()
+        client.download_raw_samples.assert_called_once_with(
+            from_=0,
+            to=5,
+            relevant_filenames_file_name=None,
+            use_redirected_read_url=False,
+        )
+        client.update_processed_until_timestamp.assert_called_once_with(timestamp=5)
 
-def test_set_local_config(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_datasources_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._datasources_api = mocked_datasources_api
-    client._dataset_id = "dataset-id"
+    def test_get_processed_until_timestamp(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id = mocker.MagicMock(
+            return_value=DatasourceProcessedUntilTimestampResponse(
+                processedUntilTimestamp=5
+            )
+        )
+        assert client.get_processed_until_timestamp() == 5
+        client._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id.assert_called_once_with(
+            dataset_id="dataset-id"
+        )
 
-    client.set_local_config(
-        web_server_location="http://localhost:1234",
-        relative_path="path/to/my/data",
-        thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
-        purpose=DatasourcePurpose.INPUT,
-    )
-    kwargs = mocked_datasources_api.update_datasource_by_dataset_id.call_args[1]
-    datasource_config = kwargs["datasource_config"].actual_instance
-    assert isinstance(datasource_config, DatasourceConfigLOCAL)
-    assert datasource_config.type == "LOCAL"
-    assert datasource_config.web_server_location == "http://localhost:1234"
-    assert datasource_config.full_path == "path/to/my/data"
-    assert (
-        datasource_config.thumb_suffix
-        == ".lightly/thumbnails/[filename]-thumb-[extension]"
-    )
-    assert datasource_config.purpose == DatasourcePurpose.INPUT
+    def test_update_processed_until_timestamp(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.update_datasource_processed_until_timestamp_by_dataset_id = (
+            mocker.MagicMock()
+        )
+        client.update_processed_until_timestamp(timestamp=10)
+        kwargs = client._datasources_api.update_datasource_processed_until_timestamp_by_dataset_id.call_args[
+            1
+        ]
+        assert kwargs["dataset_id"] == "dataset-id"
+        assert (
+            kwargs[
+                "datasource_processed_until_timestamp_request"
+            ].processed_until_timestamp
+            == 10
+        )
 
-    # Test defaults
-    client.set_local_config()
-    kwargs = mocked_datasources_api.update_datasource_by_dataset_id.call_args[1]
-    datasource_config = kwargs["datasource_config"].actual_instance
-    assert isinstance(datasource_config, DatasourceConfigLOCAL)
-    assert datasource_config.type == "LOCAL"
-    assert datasource_config.web_server_location == "http://localhost:3456"
-    assert datasource_config.full_path == ""
-    assert (
-        datasource_config.thumb_suffix
-        == ".lightly/thumbnails/[filename]_thumb.[extension]"
-    )
-    assert datasource_config.purpose == DatasourcePurpose.INPUT_OUTPUT
+    def test_set_azure_config(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        client.set_azure_config(
+            container_name="my-container/name",
+            account_name="my-account-name",
+            sas_token="my-sas-token",
+            thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
+        )
+        kwargs = client._datasources_api.update_datasource_by_dataset_id.call_args[1]
+        assert isinstance(
+            kwargs["datasource_config"].actual_instance, DatasourceConfigAzure
+        )
 
+    def test_set_gcs_config(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        client.set_gcs_config(
+            resource_path="gs://my-bucket/my-dataset",
+            project_id="my-project-id",
+            credentials="my-credentials",
+            thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
+        )
+        kwargs = client._datasources_api.update_datasource_by_dataset_id.call_args[1]
+        assert isinstance(
+            kwargs["datasource_config"].actual_instance, DatasourceConfigGCS
+        )
 
-def test_set_s3_config(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_datasources_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._datasources_api = mocked_datasources_api
-    client._dataset_id = "dataset-id"
-    client.set_s3_config(
-        resource_path="s3://my-bucket/my-dataset",
-        thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
-        region="eu-central-1",
-        access_key="my-access-key",
-        secret_access_key="my-secret-access-key",
-    )
-    kwargs = mocked_datasources_api.update_datasource_by_dataset_id.call_args[1]
-    assert isinstance(kwargs["datasource_config"].actual_instance, DatasourceConfigS3)
+    def test_set_local_config(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        client.set_local_config(
+            web_server_location="http://localhost:1234",
+            relative_path="path/to/my/data",
+            thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
+            purpose=DatasourcePurpose.INPUT,
+        )
+        kwargs = client._datasources_api.update_datasource_by_dataset_id.call_args[1]
+        datasource_config = kwargs["datasource_config"].actual_instance
+        assert isinstance(datasource_config, DatasourceConfigLOCAL)
+        assert datasource_config.type == "LOCAL"
+        assert datasource_config.web_server_location == "http://localhost:1234"
+        assert datasource_config.full_path == "path/to/my/data"
+        assert (
+            datasource_config.thumb_suffix
+            == ".lightly/thumbnails/[filename]-thumb-[extension]"
+        )
+        assert datasource_config.purpose == DatasourcePurpose.INPUT
 
+        # Test defaults
+        client.set_local_config()
+        kwargs = client._datasources_api.update_datasource_by_dataset_id.call_args[1]
+        datasource_config = kwargs["datasource_config"].actual_instance
+        assert isinstance(datasource_config, DatasourceConfigLOCAL)
+        assert datasource_config.type == "LOCAL"
+        assert datasource_config.web_server_location == "http://localhost:3456"
+        assert datasource_config.full_path == ""
+        assert (
+            datasource_config.thumb_suffix
+            == ".lightly/thumbnails/[filename]_thumb.[extension]"
+        )
+        assert datasource_config.purpose == DatasourcePurpose.INPUT_OUTPUT
 
-def test_set_s3_delegated_access_config(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_datasources_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._datasources_api = mocked_datasources_api
-    client._dataset_id = "dataset-id"
-    client.set_s3_delegated_access_config(
-        resource_path="s3://my-bucket/my-dataset",
-        thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
-        region="eu-central-1",
-        role_arn="arn:aws:iam::000000000000:role.test",
-        external_id="my-external-id",
-    )
-    kwargs = mocked_datasources_api.update_datasource_by_dataset_id.call_args[1]
-    assert isinstance(
-        kwargs["datasource_config"].actual_instance, DatasourceConfigS3DelegatedAccess
-    )
+    def test_set_s3_config(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        client.set_s3_config(
+            resource_path="s3://my-bucket/my-dataset",
+            thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
+            region="eu-central-1",
+            access_key="my-access-key",
+            secret_access_key="my-secret-access-key",
+        )
+        kwargs = client._datasources_api.update_datasource_by_dataset_id.call_args[1]
+        assert isinstance(
+            kwargs["datasource_config"].actual_instance, DatasourceConfigS3
+        )
 
+    def test_set_s3_delegated_access_config(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        client.set_s3_delegated_access_config(
+            resource_path="s3://my-bucket/my-dataset",
+            thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
+            region="eu-central-1",
+            role_arn="arn:aws:iam::000000000000:role.test",
+            external_id="my-external-id",
+        )
+        kwargs = client._datasources_api.update_datasource_by_dataset_id.call_args[1]
+        assert isinstance(
+            kwargs["datasource_config"].actual_instance,
+            DatasourceConfigS3DelegatedAccess,
+        )
 
-def test_update_processed_until_timestamp(mocker: MockerFixture) -> None:
-    mocker.patch.object(ApiWorkflowClient, "__init__", return_value=None)
-    mocked_datasources_api = mocker.MagicMock()
-    client = ApiWorkflowClient()
-    client._dataset_id = "dataset-id"
-    client._datasources_api = mocked_datasources_api
-    client.update_processed_until_timestamp(10)
-    kwargs = mocked_datasources_api.update_datasource_processed_until_timestamp_by_dataset_id.call_args[
-        1
-    ]
-    assert kwargs["dataset_id"] == "dataset-id"
-    assert (
-        kwargs["datasource_processed_until_timestamp_request"].processed_until_timestamp
-        == 10
-    )
+    def test_get_prediction_read_url(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id = mocker.MagicMock(
+            return_value="read-url"
+        )
+        assert client.get_prediction_read_url(filename="test.json") == "read-url"
+        client._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id.assert_called_once_with(
+            dataset_id="dataset-id", file_name="test.json"
+        )
 
+    def test_get_custom_embedding_read_url(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.get_custom_embedding_file_read_url_from_datasource_by_dataset_id = mocker.MagicMock(
+            return_value="read-url"
+        )
+        assert (
+            client.get_custom_embedding_read_url(filename="embeddings.csv")
+            == "read-url"
+        )
+        client._datasources_api.get_custom_embedding_file_read_url_from_datasource_by_dataset_id.assert_called_once_with(
+            dataset_id="dataset-id", file_name="embeddings.csv"
+        )
 
-def test_list_datasource_permissions(mocker: MockerFixture) -> None:
-    client = ApiWorkflowClient(token="abc")
-    client._dataset_id = "dataset-id"
-    client._datasources_api.verify_datasource_by_dataset_id = mocker.MagicMock(
-        return_value=DatasourceConfigVerifyData(
-            canRead=True,
-            canWrite=True,
-            canList=False,
-            canOverwrite=True,
-            errors=None,
-        ),
-    )
-    assert client.list_datasource_permissions() == {
-        "can_read": True,
-        "can_write": True,
-        "can_list": False,
-        "can_overwrite": True,
-    }
-
-
-def test_list_datasource_permissions__error(mocker: MockerFixture) -> None:
-    client = ApiWorkflowClient(token="abc")
-    client._dataset_id = "dataset-id"
-    client._datasources_api.verify_datasource_by_dataset_id = mocker.MagicMock(
-        return_value=DatasourceConfigVerifyData(
-            canRead=True,
-            canWrite=True,
-            canList=False,
-            canOverwrite=True,
-            errors=DatasourceConfigVerifyDataErrors(
-                canRead=None, canWrite=None, canList="error message", canOverwrite=None
+    def test_list_datasource_permissions(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.verify_datasource_by_dataset_id = mocker.MagicMock(
+            return_value=DatasourceConfigVerifyData(
+                canRead=True,
+                canWrite=True,
+                canList=False,
+                canOverwrite=True,
+                errors=None,
             ),
-        ),
+        )
+        assert client.list_datasource_permissions() == {
+            "can_read": True,
+            "can_write": True,
+            "can_list": False,
+            "can_overwrite": True,
+        }
+
+    def test_list_datasource_permissions__error(self, mocker: MockerFixture) -> None:
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        client._datasources_api.verify_datasource_by_dataset_id = mocker.MagicMock(
+            return_value=DatasourceConfigVerifyData(
+                canRead=True,
+                canWrite=True,
+                canList=False,
+                canOverwrite=True,
+                errors=DatasourceConfigVerifyDataErrors(
+                    canRead=None,
+                    canWrite=None,
+                    canList="error message",
+                    canOverwrite=None,
+                ),
+            ),
+        )
+        assert client.list_datasource_permissions() == {
+            "can_read": True,
+            "can_write": True,
+            "can_list": False,
+            "can_overwrite": True,
+            "errors": {
+                "can_list": "error message",
+            },
+        }
+
+    def test__download_raw_files(self, mocker: MockerFixture) -> None:
+        response = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        download_function = mocker.MagicMock(side_effect=[response])
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        assert client._download_raw_files(
+            download_function=download_function,
+        ) == [("file1", "url1"), ("file2", "url2")]
+
+    def test__download_raw_files_iter(self, mocker: MockerFixture) -> None:
+        response_1 = DatasourceRawSamplesData(
+            hasMore=True,
+            cursor="cursor1",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+                DatasourceRawSamplesDataRow(fileName="file2", readUrl="url2"),
+            ],
+        )
+        response_2 = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="cursor2",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="file3", readUrl="url3"),
+                DatasourceRawSamplesDataRow(fileName="file4", readUrl="url4"),
+            ],
+        )
+        download_function = mocker.MagicMock(side_effect=[response_1, response_2])
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        progress_bar = mocker.spy(tqdm, "tqdm")
+        assert list(
+            client._download_raw_files_iter(
+                download_function=download_function,
+                from_=0,
+                to=5,
+                relevant_filenames_file_name="relevant-filenames",
+                use_redirected_read_url=True,
+                progress_bar=progress_bar,
+                foo="bar",
+            )
+        ) == [
+            ("file1", "url1"),
+            ("file2", "url2"),
+            ("file3", "url3"),
+            ("file4", "url4"),
+        ]
+        download_function.assert_has_calls(
+            [
+                mocker.call(
+                    dataset_id="dataset-id",
+                    var_from=0,
+                    to=5,
+                    relevant_filenames_file_name="relevant-filenames",
+                    use_redirected_read_url=True,
+                    foo="bar",
+                ),
+                mocker.call(
+                    dataset_id="dataset-id",
+                    cursor="cursor1",
+                    relevant_filenames_file_name="relevant-filenames",
+                    use_redirected_read_url=True,
+                    foo="bar",
+                ),
+            ]
+        )
+        assert progress_bar.update.call_count == 4
+
+    def test__download_raw_files_iter__no_relevant_filenames(
+        self, mocker: MockerFixture
+    ) -> None:
+        response = DatasourceRawSamplesData(hasMore=False, cursor="", data=[])
+        download_function = mocker.MagicMock(side_effect=[response])
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        list(client._download_raw_files_iter(download_function=download_function))
+        assert "relevant_filenames_file_name" not in download_function.call_args[1]
+
+    def test__download_raw_files_iter__warning(self, mocker: MockerFixture) -> None:
+        response = DatasourceRawSamplesData(
+            hasMore=False,
+            cursor="",
+            data=[
+                DatasourceRawSamplesDataRow(fileName="/file1", readUrl="url1"),
+            ],
+        )
+        download_function = mocker.MagicMock(side_effect=[response])
+        client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
+        with pytest.warns(UserWarning, match="Absolute file paths like /file1"):
+            list(client._download_raw_files_iter(download_function=download_function))
+
+
+def test__sample_unseen_and_valid() -> None:
+    with pytest.warns(UserWarning, match="Absolute file paths like /file1"):
+        assert not api_workflow_datasources._sample_unseen_and_valid(
+            sample=DatasourceRawSamplesDataRow(fileName="/file1", readUrl="url1"),
+            relevant_filenames_file_name=None,
+            listed_filenames=set(),
+        )
+
+    with pytest.warns(UserWarning, match="Using dot notation"):
+        assert not api_workflow_datasources._sample_unseen_and_valid(
+            sample=DatasourceRawSamplesDataRow(fileName="./file1", readUrl="url1"),
+            relevant_filenames_file_name=None,
+            listed_filenames=set(),
+        )
+
+    with pytest.warns(UserWarning, match="Duplicate filename file1"):
+        assert not api_workflow_datasources._sample_unseen_and_valid(
+            sample=DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+            relevant_filenames_file_name=None,
+            listed_filenames={"file1"},
+        )
+
+    assert api_workflow_datasources._sample_unseen_and_valid(
+        sample=DatasourceRawSamplesDataRow(fileName="file1", readUrl="url1"),
+        relevant_filenames_file_name=None,
+        listed_filenames=set(),
     )
-    assert client.list_datasource_permissions() == {
-        "can_read": True,
-        "can_write": True,
-        "can_list": False,
-        "can_overwrite": True,
-        "errors": {
-            "can_list": "error message",
-        },
-    }

--- a/tests/api_workflow/test_api_workflow_datasources.py
+++ b/tests/api_workflow/test_api_workflow_datasources.py
@@ -37,8 +37,10 @@ class TestDatasourcesMixin:
             ],
         )
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_list_of_raw_samples_from_datasource_by_dataset_id = mocker.MagicMock(
-            side_effect=[response]
+        mocker.patch.object(
+            client._datasources_api,
+            "get_list_of_raw_samples_from_datasource_by_dataset_id",
+            side_effect=[response],
         )
         assert client.download_raw_samples() == [("file1", "url1"), ("file2", "url2")]
 
@@ -52,8 +54,10 @@ class TestDatasourcesMixin:
             ],
         )
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id = mocker.MagicMock(
-            side_effect=[response]
+        mocker.patch.object(
+            client._datasources_api,
+            "get_list_of_raw_samples_predictions_from_datasource_by_dataset_id",
+            side_effect=[response],
         )
         assert client.download_raw_predictions(task_name="task") == [
             ("file1", "url1"),
@@ -78,8 +82,10 @@ class TestDatasourcesMixin:
             ],
         )
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id = mocker.MagicMock(
-            side_effect=[response_1, response_2]
+        mocker.patch.object(
+            client._datasources_api,
+            "get_list_of_raw_samples_predictions_from_datasource_by_dataset_id",
+            side_effect=[response_1, response_2],
         )
         assert list(client.download_raw_predictions_iter(task_name="task")) == [
             ("file1", "url1"),
@@ -118,8 +124,10 @@ class TestDatasourcesMixin:
             ],
         )
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_list_of_raw_samples_predictions_from_datasource_by_dataset_id = mocker.MagicMock(
-            side_effect=[response]
+        mocker.patch.object(
+            client._datasources_api,
+            "get_list_of_raw_samples_predictions_from_datasource_by_dataset_id",
+            side_effect=[response],
         )
         assert list(
             client.download_raw_predictions_iter(
@@ -166,8 +174,10 @@ class TestDatasourcesMixin:
             ],
         )
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id = mocker.MagicMock(
-            side_effect=[response]
+        mocker.patch.object(
+            client._datasources_api,
+            "get_list_of_raw_samples_metadata_from_datasource_by_dataset_id",
+            side_effect=[response],
         )
         assert client.download_raw_metadata() == [
             ("file1", "url1"),
@@ -192,8 +202,10 @@ class TestDatasourcesMixin:
             ],
         )
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id = mocker.MagicMock(
-            side_effect=[response_1, response_2]
+        mocker.patch.object(
+            client._datasources_api,
+            "get_list_of_raw_samples_metadata_from_datasource_by_dataset_id",
+            side_effect=[response_1, response_2],
         )
         assert list(client.download_raw_metadata_iter()) == [
             ("file1", "url1"),
@@ -229,8 +241,10 @@ class TestDatasourcesMixin:
             ],
         )
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_list_of_raw_samples_metadata_from_datasource_by_dataset_id = mocker.MagicMock(
-            side_effect=[response]
+        mocker.patch.object(
+            client._datasources_api,
+            "get_list_of_raw_samples_metadata_from_datasource_by_dataset_id",
+            side_effect=[response],
         )
         assert list(
             client.download_raw_metadata_iter(
@@ -266,8 +280,8 @@ class TestDatasourcesMixin:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
         client.get_processed_until_timestamp = mocker.MagicMock(return_value=2)
         mocker.patch("time.time", return_value=5)
-        client.download_raw_samples = mocker.MagicMock()
-        client.update_processed_until_timestamp = mocker.MagicMock()
+        mocker.patch.object(client, "download_raw_samples")
+        mocker.patch.object(client, "update_processed_until_timestamp")
         client.download_new_raw_samples()
         client.download_raw_samples.assert_called_once_with(
             from_=2 + 1,
@@ -283,8 +297,8 @@ class TestDatasourcesMixin:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
         client.get_processed_until_timestamp = mocker.MagicMock(return_value=2)
         mocker.patch("time.time", return_value=5)
-        client.download_raw_samples = mocker.MagicMock()
-        client.update_processed_until_timestamp = mocker.MagicMock()
+        mocker.patch.object(client, "download_raw_samples")
+        mocker.patch.object(client, "update_processed_until_timestamp")
         client.download_new_raw_samples()
         client.download_raw_samples.assert_called_once_with(
             from_=3,
@@ -296,10 +310,12 @@ class TestDatasourcesMixin:
 
     def test_get_processed_until_timestamp(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id = mocker.MagicMock(
+        mocker.patch.object(
+            client._datasources_api,
+            "get_datasource_processed_until_timestamp_by_dataset_id",
             return_value=DatasourceProcessedUntilTimestampResponse(
                 processedUntilTimestamp=5
-            )
+            ),
         )
         assert client.get_processed_until_timestamp() == 5
         client._datasources_api.get_datasource_processed_until_timestamp_by_dataset_id.assert_called_once_with(
@@ -308,8 +324,9 @@ class TestDatasourcesMixin:
 
     def test_update_processed_until_timestamp(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.update_datasource_processed_until_timestamp_by_dataset_id = (
-            mocker.MagicMock()
+        mocker.patch.object(
+            client._datasources_api,
+            "update_datasource_processed_until_timestamp_by_dataset_id",
         )
         client.update_processed_until_timestamp(timestamp=10)
         kwargs = client._datasources_api.update_datasource_processed_until_timestamp_by_dataset_id.call_args[
@@ -325,7 +342,10 @@ class TestDatasourcesMixin:
 
     def test_set_azure_config(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        mocker.patch.object(
+            client._datasources_api,
+            "update_datasource_by_dataset_id",
+        )
         client.set_azure_config(
             container_name="my-container/name",
             account_name="my-account-name",
@@ -339,7 +359,10 @@ class TestDatasourcesMixin:
 
     def test_set_gcs_config(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        mocker.patch.object(
+            client._datasources_api,
+            "update_datasource_by_dataset_id",
+        )
         client.set_gcs_config(
             resource_path="gs://my-bucket/my-dataset",
             project_id="my-project-id",
@@ -353,7 +376,10 @@ class TestDatasourcesMixin:
 
     def test_set_local_config(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        mocker.patch.object(
+            client._datasources_api,
+            "update_datasource_by_dataset_id",
+        )
         client.set_local_config(
             web_server_location="http://localhost:1234",
             relative_path="path/to/my/data",
@@ -388,7 +414,10 @@ class TestDatasourcesMixin:
 
     def test_set_s3_config(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        mocker.patch.object(
+            client._datasources_api,
+            "update_datasource_by_dataset_id",
+        )
         client.set_s3_config(
             resource_path="s3://my-bucket/my-dataset",
             thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
@@ -403,7 +432,10 @@ class TestDatasourcesMixin:
 
     def test_set_s3_delegated_access_config(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.update_datasource_by_dataset_id = mocker.MagicMock()
+        mocker.patch.object(
+            client._datasources_api,
+            "update_datasource_by_dataset_id",
+        )
         client.set_s3_delegated_access_config(
             resource_path="s3://my-bucket/my-dataset",
             thumbnail_suffix=".lightly/thumbnails/[filename]-thumb-[extension]",
@@ -419,8 +451,10 @@ class TestDatasourcesMixin:
 
     def test_get_prediction_read_url(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id = mocker.MagicMock(
-            return_value="read-url"
+        mocker.patch.object(
+            client._datasources_api,
+            "get_prediction_file_read_url_from_datasource_by_dataset_id",
+            return_value="read-url",
         )
         assert client.get_prediction_read_url(filename="test.json") == "read-url"
         client._datasources_api.get_prediction_file_read_url_from_datasource_by_dataset_id.assert_called_once_with(
@@ -429,8 +463,10 @@ class TestDatasourcesMixin:
 
     def test_get_custom_embedding_read_url(self, mocker: MockerFixture) -> None:
         client = ApiWorkflowClient(token="abc", dataset_id="dataset-id")
-        client._datasources_api.get_custom_embedding_file_read_url_from_datasource_by_dataset_id = mocker.MagicMock(
-            return_value="read-url"
+        mocker.patch.object(
+            client._datasources_api,
+            "get_custom_embedding_file_read_url_from_datasource_by_dataset_id",
+            return_value="read-url",
         )
         assert (
             client.get_custom_embedding_read_url(filename="embeddings.csv")


### PR DESCRIPTION
### Changes

* Add download_raw_predictions_iter
* Add download_raw_metadata_iter
* Add _download_raw_files_iter
* Refactor files listing
* Refactor datasources tests

There are many changes in the test file but most of them are either new tests for the methods I added or refactoring of existing tests to make the mocking consistent.

### How was it tested?
* Add unit tests
