### PR TITLE
Add discord release notification

### DIFF
--- a/.github/workflows/discord_release_notification.yml
+++ b/.github/workflows/discord_release_notification.yml
@@ -1,0 +1,37 @@
+name: Discord Release Notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send Notification to Discord
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      # We truncate the description at the models section (starting with ### Models)
+      # to keep the message short.
+      # We have also have to format the release description for it to be valid JSON.
+      # This is done by piping the description to jq.
+      run: |
+          DESCRIPTION=$(echo '${{ github.event.release.body }}' | awk '/### Models/{exit}1' | jq -aRs .)
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d @- \
+               "${DISCORD_WEBHOOK}" << EOF
+          {
+            "username": "Lightly",
+            "avatar_url": "https://avatars.githubusercontent.com/u/50146475",
+            "content": "Lightly ${{ github.event.release.tag_name }} has been released!",
+            "embeds": [
+              {
+                "title": "${{ github.event.release.name }}",
+                "url": "${{ github.event.release.html_url }}",
+                "color": 5814783,
+                "description": $DESCRIPTION
+              }
+            ]
+          }
+          EOF


### PR DESCRIPTION
### Changes

* Automatically send message to discord for new releases

The message will look like this and be sent to the general channel:
![Screen Shot 2023-11-15 at 10 12 23](https://github.com/lightly-ai/lightly/assets/43336610/7fe3a5e7-7960-4341-aa54-6e130950d9ec)

I tried to keep the action simple and did not add any fancy checks. In some weird scenarios we might get additional or no messages:
* If a release is first released as a pre-release and only later changed to a latest release no notification will be sent
* If a release is released but not marked as the latest release a notification will still be sent

Note that no message will be sent for draft releases, edits, deleted releases, etc.


### How was it tested?

Tested it in a test repo and test discord channel.
