### PR TITLE
Update README to Reflect Correct Import Usage for `LightlyDataset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ transform = transforms.SimCLRTransform(input_size=32, cj_prob=0.5)
 
 
 # Create a dataset from your image folder.
-dataset = data.LightlyDataset(input_dir="./my/cute/cats/dataset/", transform=transform)
+dataset = LightlyDataset(input_dir="./my/cute/cats/dataset/", transform=transform)
 
 # Build a PyTorch dataloader.
 dataloader = torch.utils.data.DataLoader(


### PR DESCRIPTION
I've noticed an inconsistency in the README file regarding the usage of `LightlyDataset`. The current documentation does not align with the actual import statement provided.

In the README, the import statement for `LightlyDataset` is:
```python
from lightly.data import LightlyDataset
```
But the usage is 
```python
dataset = data.LightlyDataset(input_dir="./my/cute/cats/dataset/", transform=transform)
```

This PR makes a fix so that the usage is consistent with the imports. Eg

```python
dataset = LightlyDataset(input_dir="./my/cute/cats/dataset/", transform=transform)
```