### PR TITLE
Fix MoCov2 Transform Parameters

### DIFF
--- a/lightly/transforms/moco_transform.py
+++ b/lightly/transforms/moco_transform.py
@@ -83,7 +83,7 @@ class MoCoV1Transform(SimCLRTransform):
         hf_prob: float = 0.5,
         rr_prob: float = 0.0,
         rr_degrees: Union[None, float, Tuple[float, float]] = None,
-        normalize: Dict[str, List[float]] = IMAGENET_NORMALIZE,
+        normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
         super().__init__(
             input_size=input_size,
@@ -109,7 +109,8 @@ class MoCoV1Transform(SimCLRTransform):
 class MoCoV2Transform(SimCLRTransform):
     """Implements the transformations for MoCo v2 [0].
 
-    Identical to SimCLRTransform.
+    Similar to SimCLRTransform, but with different values for color jittering and
+    minimum scale of the random resized crop.
 
     Input to this transform:
         PIL Image or Tensor.
@@ -172,3 +173,43 @@ class MoCoV2Transform(SimCLRTransform):
             Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
 
     """
+
+    def __init__(
+        self,
+        input_size: int = 224,
+        cj_prob: float = 0.8,
+        cj_strength: float = 1.0,
+        cj_bright: float = 0.4,
+        cj_contrast: float = 0.4,
+        cj_sat: float = 0.4,
+        cj_hue: float = 0.1,
+        min_scale: float = 0.2,
+        random_gray_scale: float = 0.2,
+        gaussian_blur: float = 0.5,
+        kernel_size: Optional[float] = None,
+        sigmas: Tuple[float, float] = (0.1, 2),
+        vf_prob: float = 0.0,
+        hf_prob: float = 0.5,
+        rr_prob: float = 0.0,
+        rr_degrees: Union[None, float, Tuple[float, float]] = None,
+        normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
+    ):
+        super().__init__(
+            input_size=input_size,
+            cj_prob=cj_prob,
+            cj_strength=cj_strength,
+            cj_bright=cj_bright,
+            cj_contrast=cj_contrast,
+            cj_sat=cj_sat,
+            cj_hue=cj_hue,
+            min_scale=min_scale,
+            random_gray_scale=random_gray_scale,
+            gaussian_blur=gaussian_blur,
+            kernel_size=kernel_size,
+            sigmas=sigmas,
+            vf_prob=vf_prob,
+            hf_prob=hf_prob,
+            rr_prob=rr_prob,
+            rr_degrees=rr_degrees,
+            normalize=normalize,
+        )


### PR DESCRIPTION
## Changes

* Increase min_scale from 0.08 to 0.2
* Decrease color jitter strengths

Modifies the default parameters for the MoCov2 transform to match the parameters from the original implementation: https://github.com/facebookresearch/moco/blob/5a429c00bb6d4efdf511bf31b6f01e064bf929ab/main_moco.py#L328-L337
