### PR TITLE
Allow empty file upload

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -228,7 +228,7 @@ class ApiWorkflowClient(
 
     def upload_file_with_signed_url(
         self,
-        file: IOBase,
+        file: Union[IOBase, None],
         signed_write_url: str,
         headers: Optional[Dict] = None,
         session: Optional[requests.Session] = None,
@@ -237,7 +237,7 @@ class ApiWorkflowClient(
 
         Args:
             file:
-                The file to upload.
+                The file to upload. If None, an empty file is uploaded.
             signed_write_url:
                 The url to upload the file to. As no authorization is used,
                 the url must be a signed write url.

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -235,6 +235,9 @@ class ApiWorkflowClient(
     ) -> Response:
         """Uploads a file to a url via a put request.
 
+        This method cannot upload 0 bytes files due to a limitation of the requests
+        library. Set file to None to upload an empty file.
+
         Args:
             file:
                 The file to upload. If None, an empty file is uploaded.


### PR DESCRIPTION
## Changes

* Allow empty files to be uploaded with the ApiWorkflowClient

Requests expects the file in `requests.put(data=file)` to not be empty. To upload an empty file we have to set `data=None`. As the file is an `IOBase` object we cannot infer the size from it. We therefore have to rely on the calling code to set the file to `None` if it is empty.

## How was it tested?

Tested it manually. Writing a test for it is difficult as it would require mocking something deep in the requests library.