### PR TITLE
Add codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto  # This sets the target to your last upload (useful for incremental changes)
+        threshold: 0.5%  # This allows for a decrease of up to 0.5% in coverage


### PR DESCRIPTION
## Changes

* Added a codecov.yml config file to make codecov pass even if the coverage slightly goes down by 0.5% as recommended. This will allow us to enforce again that all tests have to pass in order to merge a PR (we disabled this as codecov got annoying)