### PR TITLE
Fix TiCoLoss

### DIFF
--- a/lightly/loss/tico_loss.py
+++ b/lightly/loss/tico_loss.py
@@ -101,7 +101,7 @@ class TiCoLoss(torch.nn.Module):
         z_b = torch.nn.functional.normalize(z_b, dim=1)
 
         # compute auxiliary matrix B
-        B = torch.mm(z_a.T, z_a) / z_a.shape[0]
+        B = torch.mm(z_a.T, z_a).detach() / z_a.shape[0]
 
         # init covariance matrix
         if self.C is None:


### PR DESCRIPTION
## Changes

* Detach auxiliary matrix B in loss computation

The figure in the paper suggests that no gradients are back-propagated through the batch covariance matrix B:

![Screen Shot 2024-01-23 at 15 54 28](https://github.com/lightly-ai/lightly/assets/43336610/f814e954-acbd-4869-a22f-ff37232d5721)
