### PR TITLE
Fix unittest warning handling with pytest 8.0

### DIFF
--- a/tests/cli/test_cli_download.py
+++ b/tests/cli/test_cli_download.py
@@ -1,11 +1,11 @@
 import os
 import sys
 import tempfile
+import warnings
 
 import pytest
 import torchvision
 from hydra.experimental import compose, initialize
-import warnings
 
 import lightly
 from tests.api_workflow.mocked_api_workflow_client import (

--- a/tests/cli/test_cli_download.py
+++ b/tests/cli/test_cli_download.py
@@ -5,6 +5,7 @@ import tempfile
 import pytest
 import torchvision
 from hydra.experimental import compose, initialize
+import warnings
 
 import lightly
 from tests.api_workflow.mocked_api_workflow_client import (
@@ -114,7 +115,7 @@ class TestCLIDownload(MockedApiWorkflowSetup):
             f"lightly-download token='123' dataset_id='{_DATASET_ID}' tag_name=1000"
         )
         self.parse_cli_string(cli_string)
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as record:
             lightly.cli.download_cli(self.cfg)
         # check if the warning "Tag with name 1000 does not exist" is raised
         # if so, the cli string was not parsed correctly


### PR DESCRIPTION
## Changes

* Use `warnings.catch_warning` instead of `pytest.warns(None)` as the latter was deprecated in pytest 8.0

This fixes a bug where our unit tests recently started failing due to the deprecation.
Example of failing test: https://github.com/lightly-ai/lightly/actions/runs/7708499394/job/21007710296