### PR TITLE
upgrade requirements/base.txt minimum numpy version to 1.20 for typing

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 certifi>=14.05.14
 hydra-core>=1.0.0
 lightly_utils~=0.0.0
-numpy>=1.18.1
+numpy>=1.20.0
 python_dateutil>=2.5.3
 requests>=2.23.0
 six>=1.10


### PR DESCRIPTION
We are using the `numpy.typing` subpackage, which is only available in numpy >= 1.20: https://numpy.org/devdocs/reference/typing.html#module-numpy.typing

Thus we need to update the minimum requirement.