### PR TITLE
Jeremy lig 4470 proxy

### DIFF
--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -228,6 +228,7 @@ def get_api_client_configuration(
 ) -> Configuration:
     host = get_lightly_server_location_from_env()
     ssl_ca_cert = getenv("LIGHTLY_CA_CERTS", None)
+    proxy = getenv("ALL_PROXY", getenv("HTTPS_PROXY", getenv("HTTP_PROXY", None)))
 
     if token is None:
         token = getenv("LIGHTLY_TOKEN", None)
@@ -239,6 +240,7 @@ def get_api_client_configuration(
     configuration = Configuration()
     configuration.api_key = {"ApiKeyAuth": token}
     configuration.ssl_ca_cert = ssl_ca_cert
+    configuration.proxy = proxy
     configuration.host = host
 
     return configuration


### PR DESCRIPTION
closes lig-4470
closes https://github.com/lightly-ai/lightly/issues/1492

**Changes**
- if `ALL_PROXY`, `HTTPS_PROXY` or `HTTP_PROXY` environment vars are set, pass that information to swagger which triggers the usage `urllib3.ProxyManager`. According to [Olivier Benz](https://github.com/lightly-ai/lightly/issues/1492) this should resolve the issue of using lightly behind a corporate mitm proxy.

**Tests**
- no manual tests have been done. Needs to be tested once it landed in the worker and tested behind a proxy in the future. However these changes should not have any impact on existing users.
