### PR TITLE
Parse lightly-serve paths correctly

### DIFF
--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -1,6 +1,7 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from typing import Sequence
+from urllib import parse
 
 
 def get_server(
@@ -61,6 +62,7 @@ def _translate_path(path: str, directories: Sequence[Path]) -> str:
         if the file doesn't exist.
 
     """
+    path = parse.unquote(path)
     stripped_path = path.lstrip("/")
     for directory in directories:
         if (directory / stripped_path).exists():

--- a/tests/api/test_serve.py
+++ b/tests/api/test_serve.py
@@ -16,3 +16,15 @@ def test__translate_path(tmp_path: Path) -> None:
         path="/world.txt",
         directories=[tmp_path / "hi", tmp_path / "hello"],
     ) == str(tmp_file)
+
+
+def test__translate_path__special_chars(tmp_path: Path) -> None:
+    (tmp_path / "white space.txt").touch()
+    assert serve._translate_path(
+        path="/white%20space.txt", directories=[tmp_path]
+    ) == str(tmp_path / "white space.txt")
+
+    (tmp_path / "parens(1).txt").touch()
+    assert serve._translate_path(
+        path="/parens%281%29.txt", directories=[tmp_path]
+    ) == str(tmp_path / "parens(1).txt")


### PR DESCRIPTION
### Changes

* Parse lightly-serve paths correctly

This fixes a bug where paths with whitespaces or special characters were not correctly resolved.

### How was it tested

* Added unit tests
* Tested it manually with lightly-serve