### PR TITLE
paginate mapping endpoints

### DIFF
--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -221,8 +221,13 @@ class ApiWorkflowClient(
 
         :meta private:  # Skip docstring generation
         """
-        filenames_on_server = self._mappings_api.get_sample_mappings_by_dataset_id(
-            dataset_id=self.dataset_id, field="fileName"
+        filenames_on_server = list(
+            utils.paginate_endpoint(
+                self._mappings_api.get_sample_mappings_by_dataset_id,
+                page_size=25000,
+                dataset_id=self.dataset_id,
+                field="fileName"
+            )
         )
         return filenames_on_server
 

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -226,7 +226,7 @@ class ApiWorkflowClient(
                 self._mappings_api.get_sample_mappings_by_dataset_id,
                 page_size=25000,
                 dataset_id=self.dataset_id,
-                field="fileName"
+                field="fileName",
             )
         )
         return filenames_on_server

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -98,7 +98,7 @@ class _DownloadDatasetMixin:
                 self._mappings_api.get_sample_mappings_by_dataset_id,
                 page_size=25000,
                 dataset_id=self.dataset_id,
-                field="_id"
+                field="_id",
             )
         )
 

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -93,8 +93,13 @@ class _DownloadDatasetMixin:
             )
 
         # get sample ids
-        sample_ids = self._mappings_api.get_sample_mappings_by_dataset_id(
-            self.dataset_id, field="_id"
+        sample_ids = list(
+            utils.paginate_endpoint(
+                self._mappings_api.get_sample_mappings_by_dataset_id,
+                page_size=25000,
+                dataset_id=self.dataset_id,
+                field="_id"
+            )
         )
 
         indices = BitMask.from_hex(tag.bit_mask_data).to_indices()


### PR DESCRIPTION
closes lig-4613
- paginate mapping endpoint to allow >400k samples without overloading the API