### PR TITLE
disable caching in lightly-serve

### DIFF
--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -39,6 +39,11 @@ def get_server(
             self.send_header("Access-Control-Allow-Origin", "*")
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
             self.end_headers()
+        
+        def send_response_only(self, code, message=None):
+            super().send_response_only(code, message)
+            self.send_header('Cache-Control', 'no-store, must-revalidate, no-cache, max-age=-1')
+            self.send_header('Expires', '0')
 
     return HTTPServer((host, port), _LocalDatasourceRequestHandler)
 

--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -39,11 +39,13 @@ def get_server(
             self.send_header("Access-Control-Allow-Origin", "*")
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
             self.end_headers()
-        
+
         def send_response_only(self, code, message=None):
             super().send_response_only(code, message)
-            self.send_header('Cache-Control', 'no-store, must-revalidate, no-cache, max-age=-1')
-            self.send_header('Expires', '0')
+            self.send_header(
+                "Cache-Control", "no-store, must-revalidate, no-cache, max-age=-1"
+            )
+            self.send_header("Expires", "0")
 
     return HTTPServer((host, port), _LocalDatasourceRequestHandler)
 

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -40,8 +40,12 @@ def lightly_serve(cfg):
         host=cfg.host,
         port=cfg.port,
     )
-    print(f"Starting server, listening at '{bcolors.OKBLUE}{httpd.server_name}:{httpd.server_port}{bcolors.ENDC}'")
-    print(f"Serving files in '{bcolors.OKBLUE}{cfg.input_mount}{bcolors.ENDC}' and '{bcolors.OKBLUE}{cfg.lightly_mount}{bcolors.ENDC}'")
+    print(
+        f"Starting server, listening at '{bcolors.OKBLUE}{httpd.server_name}:{httpd.server_port}{bcolors.ENDC}'"
+    )
+    print(
+        f"Serving files in '{bcolors.OKBLUE}{cfg.input_mount}{bcolors.ENDC}' and '{bcolors.OKBLUE}{cfg.lightly_mount}{bcolors.ENDC}'"
+    )
     print(
         f"Please follow our docs if you are facing any issues: https://docs.lightly.ai/docs/local-storage#optional-after-run-view-local-data-in-lightly-platform"
     )

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -41,7 +41,9 @@ def lightly_serve(cfg):
     )
     print(f"Starting server, listening at '{httpd.server_name}:{httpd.server_port}'")
     print(f"Serving files in '{cfg.input_mount}' and '{cfg.lightly_mount}'")
-    print(f"Please follow our docs if you are facing any issues: https://docs.lightly.ai/docs/local-storage#optional-after-run-view-local-data-in-lightly-platform")
+    print(
+        f"Please follow our docs if you are facing any issues: https://docs.lightly.ai/docs/local-storage#optional-after-run-view-local-data-in-lightly-platform"
+    )
     httpd.serve_forever()
 
 

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -41,6 +41,7 @@ def lightly_serve(cfg):
     )
     print(f"Starting server, listening at '{httpd.server_name}:{httpd.server_port}'")
     print(f"Serving files in '{cfg.input_mount}' and '{cfg.lightly_mount}'")
+    print(f"Please follow our docs if you are facing any issues: https://docs.lightly.ai/docs/local-storage#optional-after-run-view-local-data-in-lightly-platform")
     httpd.serve_forever()
 
 

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -5,6 +5,7 @@ import hydra
 
 from lightly.api import serve
 from lightly.cli._helpers import fix_hydra_arguments
+from lightly.utils.hipify import bcolors
 
 
 @hydra.main(**fix_hydra_arguments(config_path="config", config_name="lightly-serve"))
@@ -39,8 +40,8 @@ def lightly_serve(cfg):
         host=cfg.host,
         port=cfg.port,
     )
-    print(f"Starting server, listening at '{httpd.server_name}:{httpd.server_port}'")
-    print(f"Serving files in '{cfg.input_mount}' and '{cfg.lightly_mount}'")
+    print(f"Starting server, listening at '{bcolors.OKBLUE}{httpd.server_name}:{httpd.server_port}{bcolors.ENDC}'")
+    print(f"Serving files in '{bcolors.OKBLUE}{cfg.input_mount}{bcolors.ENDC}' and '{bcolors.OKBLUE}{cfg.lightly_mount}{bcolors.ENDC}'")
     print(
         f"Please follow our docs if you are facing any issues: https://docs.lightly.ai/docs/local-storage#optional-after-run-view-local-data-in-lightly-platform"
     )


### PR DESCRIPTION
closes lig-4625
- disables caching for lightly-serve. This mitigates issues where the browser gets a 404 from lightly-serve due to wrong setup/configuration and caches the result even though the lightly-serve got fixed.
- also added link to the docs and added some colors (see screenshot)

![Screenshot 2024-02-20 at 15 42 42](https://github.com/lightly-ai/lightly/assets/1092216/6f3696a8-f0a2-4ae4-bc94-6602c6f0fb98)
