### PR TITLE
draft of PrettyPrintApiException

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -250,24 +250,8 @@ class _ComputeWorkerMixin:
                 "creator": self._creator,
             }
         )
-        try:
-            response = self._compute_worker_api.create_docker_worker_config_vx(request)
-            return response.id
-        except ApiException as e:
-            if e.body is None:
-                raise e
-            eb = json.loads(e.body)
-            eb_code = eb.get("code")
-            eb_error = eb.get("error")
-            if str(e.status)[0] == "4" and eb_code is not None and eb_error is not None:
-                raise ValueError(
-                    f"Trying to schedule your job resulted in\n"
-                    f">> {eb_code}\n>> {json.dumps(eb_error, indent=4)}\n"
-                    f">> Please fix the issue mentioned above and see our docs "
-                    f"https://docs.lightly.ai/docs/all-configuration-options for more help."
-                ) from e
-            else:
-                raise e
+        response = self._compute_worker_api.create_docker_worker_config_vx(request)
+        return response.id
 
     def schedule_compute_worker_run(
         self,

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -18,7 +18,7 @@ class PrettyPrintApiException(ApiException):
         error_message += f"Error Reason: {self.reason}\n"
         error_body_dict = json.loads(self.body)
         if "error" in error_body_dict:
-            error_message += f"Error Message: {error_body_dict['error']}\n"
+            error_message += f"Error Message: \033[1m\033[31m{error_body_dict['error']}\033[0m\n"
 
         return error_message
 

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -1,12 +1,9 @@
 import json
+from json import JSONDecodeError
 from typing import Any, Dict, Optional, Tuple, Union
 
 from lightly.openapi_generated.swagger_client.api_client import Configuration
-from lightly.openapi_generated.swagger_client.exceptions import (
-    ApiException,
-    UnauthorizedException,
-)
-from lightly.openapi_generated.swagger_client.models.api_error_code import ApiErrorCode
+from lightly.openapi_generated.swagger_client.exceptions import ApiException
 from lightly.openapi_generated.swagger_client.rest import RESTClientObject
 
 
@@ -19,18 +16,24 @@ class PrettyPrintApiException(ApiException):
 
     def __str__(self):
         error_message = "\n"
-        error_message += "#" * 30
-        error_message += f"\nError Code: {self.status}\n"
-        error_message += f"Error Reason: {self.reason}\n"
-        if self.body is not None:
-            try:
-                error_body_dict = json.loads(self.body)
-            except JSONDecodeError:
-                pass
-            else:
-                if "error" in error_body_dict:
-                    error_message += f"Error Message: {error_body_dict['error']}\n"
-        error_message += "#" * 30 + "\n"
+        error_message += "#" * 100
+        error_message += "\n"
+        error_message += f"Error Code: {self.status}"
+        error_message += "\n"
+        error_message += f"Error Reason: {self.reason}"
+        error_message += "\n"
+        error_message += "\n"
+        try:
+            error_body_dict = json.loads(self.body)
+        except JSONDecodeError:
+            pass
+        else:
+            if "error" in error_body_dict:
+                error_message += f"Error Message: {error_body_dict['error']}"
+
+        error_message += "\n"
+
+        error_message += "#" * 100
 
         # make the error message red
         error_message = f"\033[91m{error_message}\033[0m"
@@ -107,14 +110,7 @@ class PatchRESTClientObjectMixin:
                 _request_timeout=_request_timeout,
             )
         except ApiException as e:
-            if e.reason in [
-                ApiErrorCode.BAD_REQUEST,
-                ApiErrorCode.CONFLICT,
-                ApiErrorCode.MALFORMED_RESPONSE,
-                ApiErrorCode.MALFORMED_REQUEST,
-            ]:
-                raise e
-            raise PrettyPrintApiException(e).with_traceback(None) from None
+            raise PrettyPrintApiException(e) from None
 
     def __getstate__(self) -> Dict[str, Any]:
         """__getstate__ method for pickling."""

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -1,7 +1,26 @@
+import json
 from typing import Any, Dict, Optional, Tuple, Union
 
 from lightly.openapi_generated.swagger_client.api_client import Configuration
+from lightly.openapi_generated.swagger_client.exceptions import ApiException, UnauthorizedException
+from lightly.openapi_generated.swagger_client.models.api_error_code import ApiErrorCode
 from lightly.openapi_generated.swagger_client.rest import RESTClientObject
+
+class PrettyPrintApiException(ApiException):
+
+    def __init__(self, current_exception: ApiException):
+        super().__init__(current_exception.status, current_exception.reason)
+        self.body = current_exception.body
+        self.headers = current_exception.headers
+
+    def __str__(self):
+        error_message = f"\nError Code: {self.status}\n"
+        error_message += f"Error Reason: {self.reason}\n"
+        error_body_dict = json.loads(self.body)
+        if "error" in error_body_dict:
+            error_message += f"Error Message: {error_body_dict['error']}\n"
+
+        return error_message
 
 
 class PatchRESTClientObjectMixin:
@@ -61,16 +80,22 @@ class PatchRESTClientObjectMixin:
             _request_timeout = self.timeout
 
         # Call RESTClientObject.request
-        return super().request(
-            method=method,
-            url=url,
-            query_params=query_params,
-            headers=headers,
-            body=body,
-            post_params=post_params,
-            _preload_content=_preload_content,
-            _request_timeout=_request_timeout,
-        )
+        try:
+            return super().request(
+                method=method,
+                url=url,
+                query_params=query_params,
+                headers=headers,
+                body=body,
+                post_params=post_params,
+                _preload_content=_preload_content,
+                _request_timeout=_request_timeout,
+            )
+        except ApiException as e:
+            if e.reason in [ApiErrorCode.BAD_REQUEST, ApiErrorCode.CONFLICT, ApiErrorCode.MALFORMED_RESPONSE, ApiErrorCode.MALFORMED_REQUEST]:
+                raise e
+            raise PrettyPrintApiException(e).with_traceback(None) from None
+
 
     def __getstate__(self) -> Dict[str, Any]:
         """__getstate__ method for pickling."""
@@ -116,3 +141,4 @@ class LightlySwaggerRESTClientObject(PatchRESTClientObjectMixin, RESTClientObjec
     """
 
     pass
+

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -25,10 +25,11 @@ class PrettyPrintApiException(ApiException):
         if self.body is not None:
             try:
                 error_body_dict = json.loads(self.body)
+            except JSONDecodeError:
+                pass
+            else:
                 if "error" in error_body_dict:
                     error_message += f"Error Message: {error_body_dict['error']}\n"
-            except json.JSONDecodeError:
-                pass
         error_message += "#" * 30 + "\n"
 
         # make the error message red

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -8,7 +8,6 @@ from lightly.openapi_generated.swagger_client.rest import RESTClientObject
 
 
 class PrettyPrintApiException(ApiException):
-
     def __init__(self, current_exception: ApiException):
         super().__init__(current_exception.status, current_exception.reason)
         self.body = current_exception.body

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -14,14 +14,23 @@ class PrettyPrintApiException(ApiException):
         self.headers = current_exception.headers
 
     def __str__(self):
-        error_message = f"\nError Code: {self.status}\n"
+        error_message = "\n"
+        error_message += "#"*30
+        error_message += f"\nError Code: {self.status}\n"
         error_message += f"Error Reason: {self.reason}\n"
-        error_body_dict = json.loads(self.body)
-        if "error" in error_body_dict:
-            error_message += f"Error Message: \033[1m\033[31m{error_body_dict['error']}\033[0m\n"
+        if self.body is not None:
+            try:
+                error_body_dict = json.loads(self.body)
+                if "error" in error_body_dict:
+                    error_message += f"Error Message: {error_body_dict['error']}\n"
+            except json.JSONDecodeError:
+                pass
+        error_message += "#"*30+"\n"
+
+        # make the error message red
+        error_message = f"\033[91m{error_message}\033[0m"
 
         return error_message
-
 
 class PatchRESTClientObjectMixin:
     """Mixin that adds patches to a RESTClientObject.

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -2,9 +2,13 @@ import json
 from typing import Any, Dict, Optional, Tuple, Union
 
 from lightly.openapi_generated.swagger_client.api_client import Configuration
-from lightly.openapi_generated.swagger_client.exceptions import ApiException, UnauthorizedException
+from lightly.openapi_generated.swagger_client.exceptions import (
+    ApiException,
+    UnauthorizedException,
+)
 from lightly.openapi_generated.swagger_client.models.api_error_code import ApiErrorCode
 from lightly.openapi_generated.swagger_client.rest import RESTClientObject
+
 
 class PrettyPrintApiException(ApiException):
 
@@ -15,7 +19,7 @@ class PrettyPrintApiException(ApiException):
 
     def __str__(self):
         error_message = "\n"
-        error_message += "#"*30
+        error_message += "#" * 30
         error_message += f"\nError Code: {self.status}\n"
         error_message += f"Error Reason: {self.reason}\n"
         if self.body is not None:
@@ -25,12 +29,13 @@ class PrettyPrintApiException(ApiException):
                     error_message += f"Error Message: {error_body_dict['error']}\n"
             except json.JSONDecodeError:
                 pass
-        error_message += "#"*30+"\n"
+        error_message += "#" * 30 + "\n"
 
         # make the error message red
         error_message = f"\033[91m{error_message}\033[0m"
 
         return error_message
+
 
 class PatchRESTClientObjectMixin:
     """Mixin that adds patches to a RESTClientObject.
@@ -101,10 +106,14 @@ class PatchRESTClientObjectMixin:
                 _request_timeout=_request_timeout,
             )
         except ApiException as e:
-            if e.reason in [ApiErrorCode.BAD_REQUEST, ApiErrorCode.CONFLICT, ApiErrorCode.MALFORMED_RESPONSE, ApiErrorCode.MALFORMED_REQUEST]:
+            if e.reason in [
+                ApiErrorCode.BAD_REQUEST,
+                ApiErrorCode.CONFLICT,
+                ApiErrorCode.MALFORMED_RESPONSE,
+                ApiErrorCode.MALFORMED_REQUEST,
+            ]:
                 raise e
             raise PrettyPrintApiException(e).with_traceback(None) from None
-
 
     def __getstate__(self) -> Dict[str, Any]:
         """__getstate__ method for pickling."""
@@ -150,4 +159,3 @@ class LightlySwaggerRESTClientObject(PatchRESTClientObjectMixin, RESTClientObjec
     """
 
     pass
-

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -15,6 +15,8 @@ from typing import Iterator, List, Optional
 # PIL misidentifies certain jpeg images as MPOs
 from PIL import JpegImagePlugin
 
+from lightly.api.swagger_rest_client import PrettyPrintApiException
+
 JpegImagePlugin._getmp = lambda: None
 
 from lightly.openapi_generated.swagger_client.configuration import Configuration
@@ -55,6 +57,8 @@ def retry(func, *args, **kwargs):  # type: ignore
             # return on success
             return func(*args, **kwargs)
         except Exception as e:
+            if isinstance(e, (PrettyPrintApiException, KeyboardInterrupt)):
+                raise e
             # sleep on failure
             time.sleep(backoff)
             backoff = 2 * backoff if backoff < max_backoff else backoff

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -55,8 +55,6 @@ def retry(func, *args, **kwargs):  # type: ignore
             # return on success
             return func(*args, **kwargs)
         except Exception as e:
-            if isinstance(e, KeyboardInterrupt):
-                raise e
             # sleep on failure
             time.sleep(backoff)
             backoff = 2 * backoff if backoff < max_backoff else backoff

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -15,8 +15,6 @@ from typing import Iterator, List, Optional
 # PIL misidentifies certain jpeg images as MPOs
 from PIL import JpegImagePlugin
 
-from lightly.api.swagger_rest_client import PrettyPrintApiException
-
 JpegImagePlugin._getmp = lambda: None
 
 from lightly.openapi_generated.swagger_client.configuration import Configuration
@@ -57,7 +55,7 @@ def retry(func, *args, **kwargs):  # type: ignore
             # return on success
             return func(*args, **kwargs)
         except Exception as e:
-            if isinstance(e, (PrettyPrintApiException, KeyboardInterrupt)):
+            if isinstance(e, KeyboardInterrupt):
                 raise e
             # sleep on failure
             time.sleep(backoff)

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -480,8 +480,8 @@ def test_create_docker_worker_config_vx_api_error() -> None:
     client._dataset_id = utils.generate_id()
     client._compute_worker_api.create_docker_worker_config_vx = mocked_raise_exception
     with pytest.raises(
-        ValueError,
-        match=r'Trying to schedule your job resulted in\n>> ACCOUNT_SUBSCRIPTION_INSUFFICIENT\n>> "Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."\n>> Please fix the issue mentioned above and see our docs https://docs.lightly.ai/docs/all-configuration-options for more help.',
+        ApiException,
+        match=r'"Your current plan allows for 1000000 samples but you tried to use 2000000 samples, please contact sales at sales@lightly.ai to upgrade your account."',
     ):
         r = client.create_compute_worker_config(
             selection_config={


### PR DESCRIPTION
## Description (version 2):

Change `ApiException` to`PrettyPrintApiException(ApiException)`, which prints it much more nicely (formatting, print relevant part in bold and red). I kept it inheriting from `ApiException` to ensure that the calling code can still catch it if needed.

## Effects
1) Shortens the stacktrace a bit 
2) Prints the ApiException more nicely.

## Stacktrace still there

We will not overwrite the `sys.excepthook`, see discussion with Guarin [here](https://lightly-ai.slack.com/archives/C01KSD8EE65/p1712741150247569?thread_ts=1712242200.360349&cid=C01KSD8EE65), as it is too hacky and might cause problems among users of the library.

## Screenshots
![image](https://github.com/lightly-ai/lightly/assets/20324507/52410f64-fb6d-46d6-a808-970e46ef244f)
![image](https://github.com/lightly-ai/lightly/assets/20324507/e2a019ec-aad0-4cfc-a631-524c09e55704)
![image](https://github.com/lightly-ai/lightly/assets/20324507/1f87db62-f7a7-4cc0-96de-8bff7f0071d5)

