### PR TITLE
Fix typo in tutorial_simclr_clothing.py

### DIFF
--- a/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
+++ b/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
@@ -84,7 +84,7 @@ path_to_data = "/datasets/clothing-dataset/images"
 # such as vertical flip or random rotation (90 degrees).
 # By adding these augmentations we learn our model invariance regarding the
 # orientation of the clothing piece. E.g. we don't care if a shirt is upside down
-# but more about the strcture which make it a shirt.
+# but more about the structure which make it a shirt.
 #
 # You can learn more about the different augmentations and learned invariances
 # here: :ref:`lightly-advanced`.


### PR DESCRIPTION
# Fix typo in tutorial_simclr_clothing.py

Closes #1534. Change "strcture" to "structure".