### PR TITLE
Malte lig 4952 add test for all components using gatherlayer

### DIFF
--- a/lightly/utils/benchmarking/benchmark_module.py
+++ b/lightly/utils/benchmarking/benchmark_module.py
@@ -142,10 +142,6 @@ class BenchmarkModule(LightningModule):
                 self.knn_t,
             )
 
-            print(f"_train_features: {self._train_features}")
-            print(f"_train_targets: {self._train_targets}")
-            print(f"predicted_labels: {predicted_labels}")
-            print(f"targets: {targets}")
             if dist.is_initialized() and dist.get_world_size() > 1:
                 # gather predictions and targets from all processes
 

--- a/lightly/utils/benchmarking/benchmark_module.py
+++ b/lightly/utils/benchmarking/benchmark_module.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from typing import List, Optional
+from typing import Any, List, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -12,6 +12,7 @@ from torch import Tensor
 from torch.utils.data import DataLoader
 
 from lightly.utils.benchmarking.knn import knn_predict
+from lightly.utils.dist import gather as lightly_gather
 
 
 class BenchmarkModule(LightningModule):
@@ -84,7 +85,7 @@ class BenchmarkModule(LightningModule):
 
     def __init__(
         self,
-        dataloader_kNN: DataLoader,
+        dataloader_kNN: DataLoader[Any],
         num_classes: int,
         knn_k: int = 200,
         knn_t: float = 0.1,
@@ -117,15 +118,16 @@ class BenchmarkModule(LightningModule):
                     and dist.is_initialized()
                     and dist.get_world_size() > 0
                 ):
-                    # gather features and targets from all processes
-                    feature = torch.cat(dist.gather(feature), 0)
-                    target = torch.cat(dist.gather(target), 0)
+                    feature = torch.cat(lightly_gather(feature), dim=0)
+                    target = torch.cat(lightly_gather(target), dim=0)
                 train_features.append(feature)
                 train_targets.append(target)
         self._train_features = torch.cat(train_features, dim=0).t().contiguous()
         self._train_targets = torch.cat(train_targets, dim=0).t().contiguous()
 
-    def validation_step(self, batch, batch_idx) -> None:
+    def validation_step(
+        self, batch: Tuple[List[torch.Tensor], Tensor, List[str]], batch_idx: int
+    ) -> None:
         # we can only do kNN predictions once we have a feature bank
         if self._train_features is not None and self._train_targets is not None:
             images, targets, _ = batch
@@ -139,10 +141,16 @@ class BenchmarkModule(LightningModule):
                 self.knn_k,
                 self.knn_t,
             )
-            if dist.is_initialized() and dist.get_world_size() > 0:
+
+            print(f"_train_features: {self._train_features}")
+            print(f"_train_targets: {self._train_targets}")
+            print(f"predicted_labels: {predicted_labels}")
+            print(f"targets: {targets}")
+            if dist.is_initialized() and dist.get_world_size() > 1:
                 # gather predictions and targets from all processes
-                predicted_labels = torch.cat(dist.gather(predicted_labels), 0)
-                targets = torch.cat(dist.gather(targets), 0)
+
+                predicted_labels = torch.cat(lightly_gather(predicted_labels), dim=0)
+                targets = torch.cat(lightly_gather(targets), dim=0)
 
             self._val_predicted_labels.append(predicted_labels.cpu())
             self._val_targets.append(targets.cpu())
@@ -154,8 +162,11 @@ class BenchmarkModule(LightningModule):
             top1 = (predicted_labels[:, 0] == targets).float().sum()
             acc = top1 / len(targets)
             if acc > self.max_accuracy:
-                self.max_accuracy = acc.item()
+                self.max_accuracy = float(acc.item())
             self.log("kNN_accuracy", acc * 100.0, prog_bar=True)
+            print(
+                f"This method should not be called - accuracy at rank {dist.get_rank()} is {self.max_accuracy}"
+            )
 
         self._val_predicted_labels.clear()
         self._val_targets.clear()

--- a/lightly/utils/benchmarking/benchmark_module.py
+++ b/lightly/utils/benchmarking/benchmark_module.py
@@ -135,7 +135,7 @@ class BenchmarkModule(LightningModule):
                 self.knn_t,
             )
 
-            if dist.is_initialized() and dist.get_world_size() > 1:
+            if dist.is_initialized() and dist.get_world_size() > 0:
                 # gather predictions and targets from all processes
 
                 predicted_labels = torch.cat(lightly_gather(predicted_labels), dim=0)

--- a/lightly/utils/benchmarking/benchmark_module.py
+++ b/lightly/utils/benchmarking/benchmark_module.py
@@ -119,7 +119,7 @@ class BenchmarkModule(LightningModule):
         self._train_targets = torch.cat(train_targets, dim=0).t().contiguous()
 
     def validation_step(
-        self, batch: Tuple[List[torch.Tensor], Tensor, List[str]], batch_idx: int
+        self, batch: Tuple[List[Tensor], Tensor, List[str]], batch_idx: int
     ) -> None:
         # we can only do kNN predictions once we have a feature bank
         if self._train_features is not None and self._train_targets is not None:

--- a/lightly/utils/benchmarking/benchmark_module.py
+++ b/lightly/utils/benchmarking/benchmark_module.py
@@ -113,13 +113,6 @@ class BenchmarkModule(LightningModule):
                 target = target.to(self.device)
                 feature = self.backbone(img).squeeze()
                 feature = F.normalize(feature, dim=1)
-                if (
-                    dist.is_available()
-                    and dist.is_initialized()
-                    and dist.get_world_size() > 0
-                ):
-                    feature = torch.cat(lightly_gather(feature), dim=0)
-                    target = torch.cat(lightly_gather(target), dim=0)
                 train_features.append(feature)
                 train_targets.append(target)
         self._train_features = torch.cat(train_features, dim=0).t().contiguous()
@@ -160,9 +153,6 @@ class BenchmarkModule(LightningModule):
             if acc > self.max_accuracy:
                 self.max_accuracy = float(acc.item())
             self.log("kNN_accuracy", acc * 100.0, prog_bar=True)
-            print(
-                f"This method should not be called - accuracy at rank {dist.get_rank()} is {self.max_accuracy}"
-            )
 
         self._val_predicted_labels.clear()
         self._val_targets.clear()

--- a/tests/utils/benchmarking/test_benchmark_module.py
+++ b/tests/utils/benchmarking/test_benchmark_module.py
@@ -84,7 +84,7 @@ class _DummyModel(BenchmarkModule):  # type: ignore[misc]
         self.criterion = CrossEntropyLoss()
 
     def training_step(
-        self, batch: Tuple[List[torch.Tensor], Tensor, List[str]], batch_idx: int
+        self, batch: Tuple[List[Tensor], Tensor, List[str]], batch_idx: int
     ) -> Tensor:
         images, targets, _ = batch
         predictions = self.backbone(images)

--- a/tests/utils/test_dist__gather__benchmark_module.py
+++ b/tests/utils/test_dist__gather__benchmark_module.py
@@ -35,7 +35,7 @@ def close_torch_distributed() -> Generator[None, None, None]:
     torch.distributed.destroy_process_group()
 
 
-class TestGatherLayer_BenchmarkModule:
+class TestGatherLayerBenchmarkModule:
     """
     Tests that the gather layer works as expected.
 
@@ -43,7 +43,7 @@ class TestGatherLayer_BenchmarkModule:
     times, running a proper test is difficult. The approach used here:
 
     1. This test was run once with n_devices=1 and gather=False.
-    The resulting knn accuracy of 0.953125 is hardcoded in the assertion
+    The resulting knn accuracy of 0.75 is hardcoded in the assertion
 
     2. This test is now run with n_devices=2 and gather=True. The resulting
     parameters are asserted to be the same ad with n_devices=1 and gather=False.

--- a/tests/utils/test_dist__gather__benchmark_module.py
+++ b/tests/utils/test_dist__gather__benchmark_module.py
@@ -1,0 +1,114 @@
+from typing import Any, Generator, Tuple
+
+import pytest
+import pytorch_lightning as pl
+import torch
+import torch.distributed
+from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning.strategies.ddp import DDPStrategy
+from torch import Tensor
+from torch.nn import Linear, Module
+from torch.optim import SGD
+from torch.utils.data import DataLoader, TensorDataset
+from torchvision.datasets import FakeData
+from torchvision.transforms import ToTensor
+
+from lightly.data import LightlyDataset
+from lightly.loss.dcl_loss import DCLLoss
+from lightly.loss.ntx_ent_loss import NTXentLoss
+from lightly.loss.tico_loss import TiCoLoss
+from lightly.loss.vicreg_loss import VICRegLoss
+from tests.utils.benchmarking.test_benchmark_module import (
+    _DummyModel as _BenchmarkDummyModel,
+)
+
+"""
+WARNING: 
+Using a DDPStrategy causes the file to be executed once per device.
+Thus this test needs to be in a separate file.
+"""
+
+@pytest.fixture
+def close_torch_distributed() -> Generator[None, None, None]:
+    yield None
+    torch.distributed.destroy_process_group()
+
+
+class TestGatherLayer_BenchmarkModule:
+    """
+    Tests that the gather layer works as expected.
+
+    Because using a DDPStrategy causes the whole script to be executed multiple
+    times, running a proper test is difficult. The approach used here:
+
+    1. This test was run once with n_devices=1 and gather=False.
+    The resulting knn accuracy of 0.953125 is hardcoded in the assertion
+
+    2. This test is now run with n_devices=2 and gather=True. The resulting
+    parameters are asserted to be the same ad with n_devices=1 and gather=False.
+
+    Note that the results would not be the same for n_devices=1 and n_devices=2 if
+    there was:
+    - Any randomness in the transform, as the order the samples are processed and
+    thus the random seed differ.
+    - Any batch normalization in the model, as the batch size is split between
+    the devices and there is no gather layer for the batch normalization.
+    """
+
+    def test__benchmark_module(self, close_torch_distributed: None) -> None:
+        n_devices = 2
+        n_samples = 128
+        num_classes = 3
+        batch_size = int(n_samples / n_devices)
+
+        pl.seed_everything(0, workers=True)
+
+        dataset_train = LightlyDataset.from_torch_dataset(
+            FakeData(
+                size=n_samples,
+                image_size=(3, 32, 32),
+                num_classes=num_classes,
+                transform=ToTensor(),
+            )
+        )
+        dataloader_train = DataLoader(
+            dataset_train,
+            batch_size=batch_size,
+            num_workers=0,
+            shuffle=False,
+            drop_last=False,
+        )
+        dataset_val = LightlyDataset.from_torch_dataset(
+            FakeData(
+                size=n_samples,
+                image_size=(3, 32, 32),
+                num_classes=num_classes,
+                transform=ToTensor(),
+                random_offset=10,
+            )
+        )
+        dataloader_val = DataLoader(
+            dataset_val,
+            batch_size=batch_size,
+            num_workers=0,
+            shuffle=False,
+            drop_last=False,
+        )
+
+        model = _BenchmarkDummyModel(
+            dataloader_kNN=dataloader_train, num_classes=num_classes
+        )
+
+        trainer = Trainer(
+            devices=n_devices,
+            accelerator="cpu",
+            strategy=DDPStrategy(find_unused_parameters=False),
+            max_epochs=10,
+        )
+        trainer.fit(
+            model,
+            train_dataloaders=dataloader_train,
+            val_dataloaders=dataloader_val,
+        )
+
+        assert model.max_accuracy == 0.953125

--- a/tests/utils/test_dist__gather__losses.py
+++ b/tests/utils/test_dist__gather__losses.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, Tuple
+from typing import Any, Generator, Tuple, Type
 
 import pytest
 import pytorch_lightning as pl
@@ -147,9 +147,10 @@ class TestGatherLayer_Losses:
         ys = torch.arange(n_samples * 2 * 2).reshape(n_samples, 2, 2).float()
         dataset = TensorDataset(xs, ys)
 
+        # type ignore because 'Unexpected keyword argument "gather_distributed" for "Module"'
         model = Model(
             gather=gather,
-            criterion=loss(gather_distributed=gather),
+            criterion=loss(gather_distributed=gather),  # type: ignore[call-arg]
             learning_rate=learning_rate,
         )
 

--- a/tests/utils/test_dist__gather__losses.py
+++ b/tests/utils/test_dist__gather__losses.py
@@ -85,7 +85,7 @@ class TestGatherLayer_Losses:
     def test_loss_ntxent(self, close_torch_distributed: None) -> None:
         self._test_ddp(
             NTXentLoss,
-            torch.Tensor(
+            torch.tensor(
                 [
                     [0.1675, 0.2676, 0.3678, 0.4679, 0.5680],
                     [0.5763, 0.6742, 0.7721, 0.8700, 0.9679],
@@ -132,7 +132,7 @@ class TestGatherLayer_Losses:
 
     def _test_ddp(
         self,
-        loss: Module,
+        loss: Type[Module],
         expected_params__10_epochs__no_gather: Tensor,
         learning_rate: float,
     ) -> None:
@@ -153,7 +153,7 @@ class TestGatherLayer_Losses:
             learning_rate=learning_rate,
         )
 
-        dataloader = torch.utils.data.DataLoader(
+        dataloader = DataLoader(
             dataset,
             batch_size=batch_size,
             shuffle=True,

--- a/tests/utils/test_dist__gather__losses.py
+++ b/tests/utils/test_dist__gather__losses.py
@@ -61,7 +61,6 @@ def close_torch_distributed() -> Generator[None, None, None]:
     torch.distributed.destroy_process_group()
 
 
-@pytest.mark.skip(reason="This test is flaky and needs to be fixed.")
 class TestGatherLayer_Losses:
     """
     Tests that the gather layer works as expected.
@@ -70,7 +69,7 @@ class TestGatherLayer_Losses:
     times, running a proper test is difficult. The approach used here:
 
     1. This test was run once with n_devices=1 and gather=False. The resulting
-    parameters after 10 epochs are saved as expected_params__10_epochs__no_gather.
+    parameters after 10 epochs are hardcoced as expected_params__10_epochs__no_gather.
 
     2. This test is now run with n_devices=2 and gather=True. The resulting
     parameters are asserted to be the same ad with n_devices=1 and gather=False.
@@ -172,63 +171,3 @@ class TestGatherLayer_Losses:
 
         params = list(model.parameters())[0]
         assert torch.allclose(params, expected_params__10_epochs__no_gather, rtol=1e-3)
-
-
-class TestGatherLayer_BenchmarkModule:
-    def test__benchmark_module(self, close_torch_distributed: None) -> None:
-        n_devices = 2
-        n_samples = 128
-        num_classes = 3
-        batch_size = int(n_samples / n_devices)
-
-        pl.seed_everything(0, workers=True)
-
-        dataset_train = LightlyDataset.from_torch_dataset(
-            FakeData(
-                size=n_samples,
-                image_size=(3, 32, 32),
-                num_classes=num_classes,
-                transform=ToTensor(),
-            )
-        )
-        dataloader_train = DataLoader(
-            dataset_train,
-            batch_size=batch_size,
-            num_workers=0,
-            shuffle=False,
-            drop_last=False,
-        )
-        dataset_val = LightlyDataset.from_torch_dataset(
-            FakeData(
-                size=n_samples,
-                image_size=(3, 32, 32),
-                num_classes=num_classes,
-                transform=ToTensor(),
-                random_offset=10,
-            )
-        )
-        dataloader_val = DataLoader(
-            dataset_val,
-            batch_size=batch_size,
-            num_workers=0,
-            shuffle=False,
-            drop_last=False,
-        )
-
-        model = _BenchmarkDummyModel(
-            dataloader_kNN=dataloader_train, num_classes=num_classes
-        )
-
-        trainer = Trainer(
-            devices=n_devices,
-            accelerator="cpu",
-            strategy=DDPStrategy(find_unused_parameters=False),
-            max_epochs=10,
-        )
-        trainer.fit(
-            model,
-            train_dataloaders=dataloader_train,
-            val_dataloaders=dataloader_val,
-        )
-
-        assert model.max_accuracy == 0.953125

--- a/tests/utils/test_dist__gather__losses.py
+++ b/tests/utils/test_dist__gather__losses.py
@@ -136,7 +136,7 @@ class TestGatherLayer_Losses:
         expected_params__10_epochs__no_gather: Tensor,
         learning_rate: float,
     ) -> None:
-        n_devices = 1
+        n_devices = 2
         n_samples = 8
         batch_size = int(n_samples / n_devices)
         gather = n_devices > 1


### PR DESCRIPTION
## Tests for losses

- Moved the `test_dist__gather.py` to `test_dist__gather__losses.py`.
- Extended it to not only test `NTXentLoss`, but also `TiCoLoss`, `VICRegLoss` and `DCLLoss`
- Not included `VICRegLLoss`, as it requires the global and local features and grids as input, which does not fit into the current framework. I think the effort to also test it is not worth it for the moment. If we want to do it, we should do it in a follow-up issue.
- This covers all losses using `gather(...)`
![image](https://github.com/lightly-ai/lightly/assets/20324507/6ba526bb-06e1-4cae-bde9-7d0046fff76f)


Aligning the import style is another topic. Here it is a bit more difficult, as there is the name clash between `lightly.utils.dist` and `torch.dist`. Currently some files import the one and some the other as `dist`.

## Test for Benchmark module

Added `test_dist__gather__benchmark_module.py` for benchmarking the `BenchmarkModule`. Also fixed bug in the `BenchmarkModule.on_validation_epoch_start `: As the `self.dataloader_kNN` is not split by the DDP, all devices have the full dataloader and no gathering is necessary.

## Other changes

Some typing updates

## Missing

### No missing test for `lightly.utils.dist.gather`

All usages of lightly.utils.dist.gather are covered now (except `VICRegLLoss`):
![image](https://github.com/lightly-ai/lightly/assets/20324507/8dc20188-5702-4782-9922-903c4e293c03)
![image](https://github.com/lightly-ai/lightly/assets/20324507/179dcbd6-480e-41de-957d-7f78d20ac7a3)

### Missing test for other DDP functions

We also have more gather-like functions, e.g. `concat_all_gather` in `lightly/models/utils.py`. 
![image](https://github.com/lightly-ai/lightly/assets/20324507/7efbb9fd-1a00-42eb-b20d-659149d59778)

And the kNN also use some gather functions:
![image](https://github.com/lightly-ai/lightly/assets/20324507/81b9faee-5458-48ff-9f85-c27c0483ad65)

However, these are out of scope for this issue.




