### PR TITLE
Missing import in tutorial 5: #1539

### DIFF
--- a/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
+++ b/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
@@ -28,13 +28,13 @@ on most Linux systems.
 
 """
 
-import copy
 
 # %%
 # Imports
 # -------
 #
 # Import the Python frameworks we need for this tutorial.
+import copy
 import os
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Changed the example code. Moved the import into the cell. 

You still need to correct the documentation, which I did not find in the repo.