### PR TITLE
Add unpatchify model utils operation

### DIFF
--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -434,6 +434,33 @@ def patchify(images: torch.Tensor, patch_size: int) -> torch.Tensor:
     return patches
 
 
+def unpatchify(
+    patches: torch.Tensor, patch_size: int, channels: int = 3
+) -> torch.Tensor:
+    """
+    Reconstructs images from their patches.
+
+     Args:
+         patches:
+             Patches tensor with shape (batch_size, num_patches, channels * patch_size ** 2).
+         patch_size:
+             The patch size in pixels used to create the patches.
+         channels:
+             The number of channels the image must have
+
+     Returns:
+         Reconstructed images tensor with shape (batch_size, channels, height, width).
+    """
+    N, C = patches.shape[0], channels
+    patch_h = patch_w = int(patches.shape[1] ** 0.5)
+    assert patch_h * patch_w == patches.shape[1]
+
+    images = patches.reshape(shape=(N, patch_h, patch_w, patch_size, patch_size, C))
+    images = torch.einsum("nhwpqc->nchpwq", images)
+    images = images.reshape(shape=(N, C, patch_h * patch_size, patch_h * patch_size))
+    return images
+
+
 def random_token_mask(
     size: Tuple[int, int],
     mask_ratio: float = 0.6,

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -199,6 +199,16 @@ class TestModelUtils(unittest.TestCase):
                     img_patch = img_patches[i * width_patches + j]
                     self._assert_tensor_equal(img_patch, expected_patch)
 
+    def test_unpatchify(self, seed=0):
+        torch.manual_seed(seed)
+        batch_size, channels, height, width = (2, 3, 8, 8)
+        patch_size = 4
+        images = torch.rand(batch_size, channels, height, width)
+        batch_patches = utils.patchify(images, patch_size)
+        unpatched_images = utils.unpatchify(batch_patches, patch_size)
+
+        self._assert_tensor_equal(images, unpatched_images)
+
     def _test_random_token_mask(
         self, seed=0, mask_ratio=0.6, mask_class_token=False, device="cpu"
     ):


### PR DESCRIPTION
This utility function is usefull to visualize the predicted images by the MAE model for example:

```python
def validation_step(self, batch: torch.Tensor, batch_idx: int):
    images, _ = batch
    loss, preds, idx_mask = self(images)

    idx_mask = idx_mask - 1  # must adjust idx_mask for missing class token

    # visualize predictions
    patches = utils.patchify(images, self.patch_size)

    pred_patches = utils.set_at_index(patches, idx_mask, preds)
    pred_img = utils.unpatchify(pred_patches, self.patch_size)

    masked_patches = utils.set_at_index(patches, idx_mask, torch.zeros_like(preds))
    masked_img = utils.unpatchify(masked_patches, self.patch_size)

    img = torch.stack([zip(images, pred_img, masked_img)])
    grid = torchvision.utils.make_grid(img, nrow=6)
    self.logger.experiment.add_image("generated_images", grid, 0)
```