### PR TITLE
Lightly serve stability

### DIFF
--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -1,4 +1,4 @@
-from http.server import HTTPServer, SimpleHTTPRequestHandler
+from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from typing import Sequence
 from urllib import parse
@@ -35,7 +35,7 @@ def get_server(
     class _LocalDatasourceRequestHandler(SimpleHTTPRequestHandler):
         def translate_path(self, path: str) -> str:
             return _translate_path(path=path, directories=paths)
-
+        
         def do_OPTIONS(self) -> None:
             self.send_response(204)
             self.send_header("Access-Control-Allow-Origin", "*")
@@ -49,7 +49,7 @@ def get_server(
             )
             self.send_header("Expires", "0")
 
-    return HTTPServer((host, port), _LocalDatasourceRequestHandler)
+    return ThreadingHTTPServer((host, port), _LocalDatasourceRequestHandler)
 
 
 def validate_input_mount(input_mount: Path) -> None:

--- a/lightly/api/serve.py
+++ b/lightly/api/serve.py
@@ -1,4 +1,4 @@
-from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Sequence
 from urllib import parse
@@ -35,7 +35,7 @@ def get_server(
     class _LocalDatasourceRequestHandler(SimpleHTTPRequestHandler):
         def translate_path(self, path: str) -> str:
             return _translate_path(path=path, directories=paths)
-        
+
         def do_OPTIONS(self) -> None:
             self.send_response(204)
             self.send_header("Access-Control-Allow-Origin", "*")

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -63,9 +63,8 @@ def lightly_serve(cfg):
     )
     try:
         httpd.serve_forever()
-    except KeyboardInterrupt:
-        pass
-    httpd.server_close()
+    finally:
+        httpd.server_close()
 
 
 def entry() -> None:

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -61,7 +61,11 @@ def lightly_serve(cfg):
     print(
         f"Please follow our docs if you are facing any issues: https://docs.lightly.ai/docs/local-storage#optional-after-run-view-local-data-in-lightly-platform"
     )
-    httpd.serve_forever()
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
 
 
 def entry() -> None:


### PR DESCRIPTION
try to stabilize lightly-serve by
- ensuring we correctly shutdown the server
- use `ThreadingHTTPServer` instead of `HTTPServer`