### PR TITLE
Lightly server https

### DIFF
--- a/lightly/cli/config/lightly-serve.yaml
+++ b/lightly/cli/config/lightly-serve.yaml
@@ -2,8 +2,8 @@ input_mount: ''     # Path to the input directory.
 lightly_mount: ''   # Path to the lightly directory.
 host: 'localhost'   # Hostname for serving the data.
 port: 3456          # Port for serving the data.
-ssl_cert: ''
-ssl_key: ''
+ssl_cert: ''        # Path to the SSL certificate.
+ssl_key: ''         # Path to the SSL key.
 
 # Disable Hydra log directories.
 defaults:  

--- a/lightly/cli/config/lightly-serve.yaml
+++ b/lightly/cli/config/lightly-serve.yaml
@@ -2,7 +2,8 @@ input_mount: ''     # Path to the input directory.
 lightly_mount: ''   # Path to the lightly directory.
 host: 'localhost'   # Hostname for serving the data.
 port: 3456          # Port for serving the data.
-
+ssl_cert: ''
+ssl_key: ''
 
 # Disable Hydra log directories.
 defaults:  

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -1,5 +1,5 @@
-import sys
 import ssl
+import sys
 from pathlib import Path
 
 import hydra
@@ -61,10 +61,10 @@ def lightly_serve(cfg):
     # setup https/ssl if key or cert are provided
     if cfg.ssl_key or cfg.ssl_cert:
         httpd.socket = ssl.wrap_socket(
-            httpd.socket, 
-            keyfile= Path(cfg.ssl_key) if cfg.ssl_key else None, 
-            certfile= Path(cfg.ssl_cert) if cfg.ssl_cert else None,
-            server_side=True
+            httpd.socket,
+            keyfile=Path(cfg.ssl_key) if cfg.ssl_key else None,
+            certfile=Path(cfg.ssl_cert) if cfg.ssl_cert else None,
+            server_side=True,
         )
 
     print(

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -21,6 +21,7 @@ def lightly_serve(cfg):
             Path to the Lightly directory.
         host:
             Hostname for serving the data (defaults to localhost). If you want to expose it to the internet or your local network, use '0.0.0.0'.
+            See our docs on lightly-serve for more information: https://docs.lightly.ai/docs/local-storage#view-the-local-data-securely-over-the-networkvpn
         port:
             Port for serving the data (defaults to 3456).
         ssl_key:

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -20,7 +20,7 @@ def lightly_serve(cfg):
         lightly_mount:
             Path to the Lightly directory.
         host:
-            Hostname for serving the data (defaults to localhost).
+            Hostname for serving the data (defaults to localhost). If you want to expose this to the world, use '0.0.0.0'.
         port:
             Port for serving the data (defaults to 3456).
         ssl_key:
@@ -58,11 +58,12 @@ def lightly_serve(cfg):
         port=cfg.port,
     )
 
-    # setup ssl if key and cert are provided
-    if cfg.ssl_key and cfg.ssl_cert:
-        httpd.socket = ssl.wrap_socket(httpd.socket, 
-            keyfile=cfg.ssl_key, 
-            certfile=cfg.ssl_cert,
+    # setup https/ssl if key or cert are provided
+    if cfg.ssl_key or cfg.ssl_cert:
+        httpd.socket = ssl.wrap_socket(
+            httpd.socket, 
+            keyfile= Path(cfg.ssl_key) if cfg.ssl_key else None, 
+            certfile= Path(cfg.ssl_cert) if cfg.ssl_cert else None,
             server_side=True
         )
 

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -20,7 +20,7 @@ def lightly_serve(cfg):
         lightly_mount:
             Path to the Lightly directory.
         host:
-            Hostname for serving the data (defaults to localhost). If you want to expose this to the world, use '0.0.0.0'.
+            Hostname for serving the data (defaults to localhost). If you want to expose it to the internet or your local network, use '0.0.0.0'.
         port:
             Port for serving the data (defaults to 3456).
         ssl_key:

--- a/lightly/cli/serve_cli.py
+++ b/lightly/cli/serve_cli.py
@@ -1,4 +1,5 @@
 import sys
+import ssl
 from pathlib import Path
 
 import hydra
@@ -22,6 +23,10 @@ def lightly_serve(cfg):
             Hostname for serving the data (defaults to localhost).
         port:
             Port for serving the data (defaults to 3456).
+        ssl_key:
+            Optional path to the ssl key file.
+        ssl_cert:
+            Optional path to the ssl cert file.
 
     Examples:
         >>> lightly-serve input_mount=data/ lightly_mount=lightly/ port=3456
@@ -52,6 +57,15 @@ def lightly_serve(cfg):
         host=cfg.host,
         port=cfg.port,
     )
+
+    # setup ssl if key and cert are provided
+    if cfg.ssl_key and cfg.ssl_cert:
+        httpd.socket = ssl.wrap_socket(httpd.socket, 
+            keyfile=cfg.ssl_key, 
+            certfile=cfg.ssl_cert,
+            server_side=True
+        )
+
     print(
         f"Starting server, listening at '{bcolors.OKBLUE}{httpd.server_name}:{httpd.server_port}{bcolors.ENDC}'"
     )


### PR DESCRIPTION
closes lig-5082
- allow to pass ssl certs to lightly-serve to start it in HTTPS mode
