### PR TITLE
Torchvision transforms v2

### DIFF
--- a/lightly/transforms/__init__.py
+++ b/lightly/transforms/__init__.py
@@ -8,6 +8,10 @@ transforms.
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
+import importlib
+import logging
+import sys
+
 from lightly.transforms.aim_transform import AIMTransform
 from lightly.transforms.byol_transform import (
     BYOLTransform,
@@ -36,3 +40,12 @@ from lightly.transforms.swav_transform import SwaVTransform, SwaVViewTransform
 from lightly.transforms.vicreg_transform import VICRegTransform, VICRegViewTransform
 from lightly.transforms.vicregl_transform import VICRegLTransform, VICRegLViewTransform
 from lightly.transforms.wmse_transform import WMSETransform
+
+logger = logging.getLogger(__name__)
+
+if importlib.util.find_spec("torchvision.transforms.v2") is not None:
+    importlib.import_module("torchvision.transforms.v2")
+    sys.modules["torchvision.transforms"] = sys.modules.pop("torchvision.transforms.v2")
+    logger.info(
+        "Lightly overrides 'torchvision.transforms' with 'torchvision.transforms.v2'."
+    )

--- a/tests/transforms/test_torchvision_transform_v2.py
+++ b/tests/transforms/test_torchvision_transform_v2.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_override_torchvision_transform():
+    # CutMix is only available in torchvision.transforms.v2, so it should not be
+    # available within the torchvision.transforms module.
+    try:
+        from torchvision.transforms import CutMix
+    except ImportError:
+        pytest.fail("CutMix could not be imported from torchvision.transforms")


### PR DESCRIPTION
Resolves #1547

It deviates a little from the proposed method by @guarin in that lightly makes the importer think `torchvision.transforms` is `torchvision.transforms.v2`. I chose for this option as this would only require a change in `lightly.transforms.__init__.py`.