### PR TITLE
Replace np.float_ by np.float64 (support numpy 2)

### DIFF
--- a/lightly/api/api_workflow_selection.py
+++ b/lightly/api/api_workflow_selection.py
@@ -29,7 +29,7 @@ def _parse_active_learning_scores(scores: Union[np.ndarray, List]):
 
 class _SelectionMixin:
     def upload_scores(
-        self, al_scores: Dict[str, NDArray[np.float_]], query_tag_id: str
+        self, al_scores: Dict[str, NDArray[np.float64]], query_tag_id: str
     ) -> None:
         """Uploads active learning scores for a tag.
 

--- a/lightly/embedding/embedding.py
+++ b/lightly/embedding/embedding.py
@@ -79,7 +79,7 @@ class SelfSupervisedEmbedding(BaseEmbedding):
         self,
         dataloader: DataLoader[LightlyDataset],
         device: Optional[torch.device] = None,
-    ) -> Tuple[NDArray[np.float_], List[int], List[str]]:
+    ) -> Tuple[NDArray[np.float64], List[int], List[str]]:
         """Embeds images in a vector space.
 
         Args:
@@ -114,7 +114,7 @@ class SelfSupervisedEmbedding(BaseEmbedding):
         pbar = tqdm(total=len(dataset), unit="imgs")
 
         efficiency = 0.0
-        embeddings: List[NDArray[np.float_]] = []
+        embeddings: List[NDArray[np.float64]] = []
         labels: List[int] = []
         with torch.no_grad():
             start_timepoint = time.time()


### PR DESCRIPTION
# Replace np.float_ by np.float64 (support numpy 2)

Part of #1558. I'm following the [migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html).
* Replace `np.float_` by `np.float64`.