### PR TITLE
Require NumPy 1.x

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 certifi>=14.05.14
 hydra-core>=1.0.0
 lightly_utils~=0.0.0
-numpy>=1.18.1
+numpy>=1.18.1,<2.0
 python_dateutil>=2.5.3
 requests>=2.23.0
 six>=1.10


### PR DESCRIPTION
# Require NumPy 1.x

Disallow NumPy 2.0 until torchvision supports it (see #1558 for more information).