### PR TITLE
Reintroduce MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+# exclude benchmarks, docs, examples, and tests
+prune docs
+prune benchmarks
+prune examples
+prune tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,14 +159,6 @@ version = {attr = "lightly.__version__"}
 [tool.setuptools.package-data]
 lightly = ["lightly/cli/config/*.yaml"]
 
-[tool.setuptools.exclude-package-data]
-lightly = [
-  "benchmarks/",
-  "docs/",
-  "examples/",
-  "tests/"
-]
-
 [tool.black]
 extend-exclude = "lightly/openapi_generated/.*"
 


### PR DESCRIPTION
# Reintroduce MANIFEST.in

With `[tool.setuptools.exclude-package-data]` the excluded directories are still packaged. Reintroducing `MANIFEST.in` fixes the problem. The test release on `pypitest` looks good: https://test.pypi.org/project/lightly/
