### PR TITLE
fix(ci): install `libavformat-dev` and `libavdevice-dev` on CI

### DIFF
--- a/.github/workflows/test_minimal_deps.yml
+++ b/.github/workflows/test_minimal_deps.yml
@@ -45,7 +45,7 @@ jobs:
             pyproject.toml
       - name: Install Minimal Dependencies
         run: |
-          sudo apt-get install ffmpeg-dev
+          sudo apt-get install libavformat-dev libavdevice-dev
           pip install -e ."[minimal]"
       - name: Install Package Without Dependencies
         run: pip install --no-deps .

--- a/.github/workflows/test_minimal_deps.yml
+++ b/.github/workflows/test_minimal_deps.yml
@@ -44,7 +44,9 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
       - name: Install Minimal Dependencies
-        run: pip install -e ."[minimal]"
+        run: |
+          apt-get install ffmpeg-dev
+          pip install -e ."[minimal]"
       - name: Install Package Without Dependencies
         run: pip install --no-deps .
       - name: Run Tests

--- a/.github/workflows/test_minimal_deps.yml
+++ b/.github/workflows/test_minimal_deps.yml
@@ -45,7 +45,7 @@ jobs:
             pyproject.toml
       - name: Install Minimal Dependencies
         run: |
-          apt-get install ffmpeg-dev
+          sudo apt-get install ffmpeg-dev
           pip install -e ."[minimal]"
       - name: Install Package Without Dependencies
         run: pip install --no-deps .


### PR DESCRIPTION
Adds extra linux deps for `av`

## References

* https://community.home-assistant.io/t/av-not-found/145887/11