### PR TITLE
Add support for pydantic v2

### DIFF
--- a/lightly/openapi_generated/swagger_client/api/collaboration_api.py
+++ b/lightly/openapi_generated/swagger_client/api/collaboration_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/datasets_api.py
+++ b/lightly/openapi_generated/swagger_client/api/datasets_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr, conint, conlist, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/datasources_api.py
+++ b/lightly/openapi_generated/swagger_client/api/datasources_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictStr, conint, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/docker_api.py
+++ b/lightly/openapi_generated/swagger_client/api/docker_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictStr, conint, conlist, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/embeddings2d_api.py
+++ b/lightly/openapi_generated/swagger_client/api/embeddings2d_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/embeddings_api.py
+++ b/lightly/openapi_generated/swagger_client/api/embeddings_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/jobs_api.py
+++ b/lightly/openapi_generated/swagger_client/api/jobs_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr

--- a/lightly/openapi_generated/swagger_client/api/mappings_api.py
+++ b/lightly/openapi_generated/swagger_client/api/mappings_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr, conint, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/meta_data_configurations_api.py
+++ b/lightly/openapi_generated/swagger_client/api/meta_data_configurations_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/predictions_api.py
+++ b/lightly/openapi_generated/swagger_client/api/predictions_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, conint, conlist, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/quota_api.py
+++ b/lightly/openapi_generated/swagger_client/api/quota_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 

--- a/lightly/openapi_generated/swagger_client/api/samples_api.py
+++ b/lightly/openapi_generated/swagger_client/api/samples_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictStr, conint, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/samplings_api.py
+++ b/lightly/openapi_generated/swagger_client/api/samplings_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/scores_api.py
+++ b/lightly/openapi_generated/swagger_client/api/scores_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, conint, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/tags_api.py
+++ b/lightly/openapi_generated/swagger_client/api/tags_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr, conint, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/teams_api.py
+++ b/lightly/openapi_generated/swagger_client/api/teams_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr, constr, validator

--- a/lightly/openapi_generated/swagger_client/api/versioning_api.py
+++ b/lightly/openapi_generated/swagger_client/api/versioning_api.py
@@ -17,7 +17,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import validate_arguments, ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import validate_arguments, ValidationError
 from typing_extensions import Annotated
 
 from pydantic import StrictStr

--- a/lightly/openapi_generated/swagger_client/api_response.py
+++ b/lightly/openapi_generated/swagger_client/api_response.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import Field, StrictInt, StrictStr
+except ImportError:
+    # Pydantic v1
+    from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/lightly/openapi_generated/swagger_client/models/active_learning_score_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/active_learning_score_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ActiveLearningScoreCreateRequest(BaseModel):
     """
@@ -42,7 +49,7 @@ class ActiveLearningScoreCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/active_learning_score_data.py
+++ b/lightly/openapi_generated/swagger_client/models/active_learning_score_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ActiveLearningScoreData(BaseModel):
     """
@@ -59,7 +66,7 @@ class ActiveLearningScoreData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/active_learning_score_types_v2_data.py
+++ b/lightly/openapi_generated/swagger_client/models/active_learning_score_types_v2_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ActiveLearningScoreTypesV2Data(BaseModel):
     """
@@ -67,7 +74,7 @@ class ActiveLearningScoreTypesV2Data(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/active_learning_score_v2_data.py
+++ b/lightly/openapi_generated/swagger_client/models/active_learning_score_v2_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ActiveLearningScoreV2Data(BaseModel):
     """
@@ -68,7 +75,7 @@ class ActiveLearningScoreV2Data(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/annotation_savings.py
+++ b/lightly/openapi_generated/swagger_client/models/annotation_savings.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.task_annotation_savings import TaskAnnotationSavings
 
 class AnnotationSavings(BaseModel):
@@ -37,7 +44,7 @@ class AnnotationSavings(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/api_error_code.py
+++ b/lightly/openapi_generated/swagger_client/models/api_error_code.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class ApiErrorCode(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/api_error_response.py
+++ b/lightly/openapi_generated/swagger_client/models/api_error_response.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.api_error_code import ApiErrorCode
 
 class ApiErrorResponse(BaseModel):
@@ -38,7 +45,7 @@ class ApiErrorResponse(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/async_task_data.py
+++ b/lightly/openapi_generated/swagger_client/models/async_task_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class AsyncTaskData(BaseModel):
     """
@@ -34,7 +41,7 @@ class AsyncTaskData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/auth0_on_sign_up_request.py
+++ b/lightly/openapi_generated/swagger_client/models/auth0_on_sign_up_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.auth0_on_sign_up_request_user import Auth0OnSignUpRequestUser
 
 class Auth0OnSignUpRequest(BaseModel):
@@ -35,7 +42,7 @@ class Auth0OnSignUpRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/auth0_on_sign_up_request_user.py
+++ b/lightly/openapi_generated/swagger_client/models/auth0_on_sign_up_request_user.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class Auth0OnSignUpRequestUser(BaseModel):
     """
@@ -40,7 +47,7 @@ class Auth0OnSignUpRequestUser(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/categorical_distribution.py
+++ b/lightly/openapi_generated/swagger_client/models/categorical_distribution.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Dict
-from pydantic import Extra,  BaseModel, Field, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.categorical_distribution_metrics import CategoricalDistributionMetrics
 
 class CategoricalDistribution(BaseModel):
@@ -36,7 +43,7 @@ class CategoricalDistribution(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/categorical_distribution_metrics.py
+++ b/lightly/openapi_generated/swagger_client/models/categorical_distribution_metrics.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class CategoricalDistributionMetrics(BaseModel):
     """
@@ -35,7 +42,7 @@ class CategoricalDistributionMetrics(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/categorical_distribution_per_set.py
+++ b/lightly/openapi_generated/swagger_client/models/categorical_distribution_per_set.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.categorical_distribution import CategoricalDistribution
 
 class CategoricalDistributionPerSet(BaseModel):
@@ -39,7 +46,7 @@ class CategoricalDistributionPerSet(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/configuration_data.py
+++ b/lightly/openapi_generated/swagger_client/models/configuration_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.configuration_entry import ConfigurationEntry
 
 class ConfigurationData(BaseModel):
@@ -46,7 +53,7 @@ class ConfigurationData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/configuration_entry.py
+++ b/lightly/openapi_generated/swagger_client/models/configuration_entry.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Optional
-from pydantic import Extra,  BaseModel, Field, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.configuration_value_data_type import ConfigurationValueDataType
 
 class ConfigurationEntry(BaseModel):
@@ -38,7 +45,7 @@ class ConfigurationEntry(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/configuration_set_request.py
+++ b/lightly/openapi_generated/swagger_client/models/configuration_set_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.configuration_entry import ConfigurationEntry
 
 class ConfigurationSetRequest(BaseModel):
@@ -36,7 +43,7 @@ class ConfigurationSetRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/configuration_value_data_type.py
+++ b/lightly/openapi_generated/swagger_client/models/configuration_value_data_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class ConfigurationValueDataType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/create_cf_bucket_activity_request.py
+++ b/lightly/openapi_generated/swagger_client/models/create_cf_bucket_activity_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class CreateCFBucketActivityRequest(BaseModel):
     """
@@ -35,7 +42,7 @@ class CreateCFBucketActivityRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/create_docker_worker_registry_entry_request.py
+++ b/lightly/openapi_generated/swagger_client/models/create_docker_worker_registry_entry_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 from lightly.openapi_generated.swagger_client.models.docker_worker_type import DockerWorkerType
 
@@ -47,7 +54,7 @@ class CreateDockerWorkerRegistryEntryRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/create_entity_response.py
+++ b/lightly/openapi_generated/swagger_client/models/create_entity_response.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class CreateEntityResponse(BaseModel):
     """
@@ -41,7 +48,7 @@ class CreateEntityResponse(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/create_sample_with_write_urls_response.py
+++ b/lightly/openapi_generated/swagger_client/models/create_sample_with_write_urls_response.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sample_write_urls import SampleWriteUrls
 
 class CreateSampleWithWriteUrlsResponse(BaseModel):
@@ -43,7 +50,7 @@ class CreateSampleWithWriteUrlsResponse(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/create_team_membership_request.py
+++ b/lightly/openapi_generated/swagger_client/models/create_team_membership_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.team_role import TeamRole
 
 class CreateTeamMembershipRequest(BaseModel):
@@ -36,7 +43,7 @@ class CreateTeamMembershipRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/creator.py
+++ b/lightly/openapi_generated/swagger_client/models/creator.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class Creator(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/crop_data.py
+++ b/lightly/openapi_generated/swagger_client/models/crop_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class CropData(BaseModel):
     """
@@ -53,7 +60,7 @@ class CropData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_analysis.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_analysis.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.embedding_information import EmbeddingInformation
 from lightly.openapi_generated.swagger_client.models.metadata_information import MetadataInformation
 
@@ -37,7 +44,7 @@ class DatasetAnalysis(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dataset_creator import DatasetCreator
 from lightly.openapi_generated.swagger_client.models.dataset_type import DatasetType
 from lightly.openapi_generated.swagger_client.models.image_type import ImageType
@@ -58,7 +65,7 @@ class DatasetCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_creator.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_creator.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DatasetCreator(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/dataset_data.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dataset_type import DatasetType
 from lightly.openapi_generated.swagger_client.models.image_type import ImageType
 from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
@@ -106,7 +113,7 @@ class DatasetData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_data_enriched.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_data_enriched.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dataset_type import DatasetType
 from lightly.openapi_generated.swagger_client.models.image_type import ImageType
 from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
@@ -108,7 +115,7 @@ class DatasetDataEnriched(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_embedding_data.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_embedding_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasetEmbeddingData(BaseModel):
     """
@@ -45,7 +52,7 @@ class DatasetEmbeddingData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_information.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_information.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dataset_sizes import DatasetSizes
 
 class DatasetInformation(BaseModel):
@@ -39,7 +46,7 @@ class DatasetInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_sizes.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_sizes.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasetSizes(BaseModel):
     """
@@ -40,7 +47,7 @@ class DatasetSizes(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dataset_type.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DatasetType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/dataset_update_request.py
+++ b/lightly/openapi_generated/swagger_client/models/dataset_update_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasetUpdateRequest(BaseModel):
     """
@@ -41,7 +48,7 @@ class DatasetUpdateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config.py
@@ -20,7 +20,14 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_azure import DatasourceConfigAzure
 from lightly.openapi_generated.swagger_client.models.datasource_config_gcs import DatasourceConfigGCS
 from lightly.openapi_generated.swagger_client.models.datasource_config_lightly import DatasourceConfigLIGHTLY
@@ -29,7 +36,12 @@ from lightly.openapi_generated.swagger_client.models.datasource_config_obs impor
 from lightly.openapi_generated.swagger_client.models.datasource_config_s3 import DatasourceConfigS3
 from lightly.openapi_generated.swagger_client.models.datasource_config_s3_delegated_access import DatasourceConfigS3DelegatedAccess
 from typing import Any, List
-from pydantic import StrictStr, Field, Extra
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import StrictStr, Field
+except ImportError:
+    # Pydantic v1
+    from pydantic import StrictStr, Field
 
 DATASOURCECONFIG_ONE_OF_SCHEMAS = ["DatasourceConfigAzure", "DatasourceConfigGCS", "DatasourceConfigLIGHTLY", "DatasourceConfigLOCAL", "DatasourceConfigOBS", "DatasourceConfigS3", "DatasourceConfigS3DelegatedAccess"]
 
@@ -57,7 +69,7 @@ class DatasourceConfig(BaseModel):
     class Config:
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     discriminator_value_class_map = {
     }

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_azure.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_azure.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_base import DatasourceConfigBase
 
 class DatasourceConfigAzure(DatasourceConfigBase):
@@ -37,7 +44,7 @@ class DatasourceConfigAzure(DatasourceConfigBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_azure_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_azure_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceConfigAzureAllOf(BaseModel):
     """
@@ -35,7 +42,7 @@ class DatasourceConfigAzureAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_base.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_base.py
@@ -21,7 +21,14 @@ import lightly.openapi_generated.swagger_client.models
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_purpose import DatasourcePurpose
 
 class DatasourceConfigBase(BaseModel):
@@ -49,7 +56,7 @@ class DatasourceConfigBase(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     # JSON field name that stores the object type
     __discriminator_property_name = 'type'

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_base_full_path.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_base_full_path.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceConfigBaseFullPath(BaseModel):
     """
@@ -34,7 +41,7 @@ class DatasourceConfigBaseFullPath(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_gcs.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_gcs.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_base import DatasourceConfigBase
 
 class DatasourceConfigGCS(DatasourceConfigBase):
@@ -37,7 +44,7 @@ class DatasourceConfigGCS(DatasourceConfigBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_gcs_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_gcs_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceConfigGCSAllOf(BaseModel):
     """
@@ -35,7 +42,7 @@ class DatasourceConfigGCSAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_lightly.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_lightly.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_base import DatasourceConfigBase
 
 class DatasourceConfigLIGHTLY(DatasourceConfigBase):
@@ -35,7 +42,7 @@ class DatasourceConfigLIGHTLY(DatasourceConfigBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_local.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_local.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_base import DatasourceConfigBase
 
 class DatasourceConfigLOCAL(DatasourceConfigBase):
@@ -46,7 +53,7 @@ class DatasourceConfigLOCAL(DatasourceConfigBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_local_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_local_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceConfigLOCALAllOf(BaseModel):
     """
@@ -45,7 +52,7 @@ class DatasourceConfigLOCALAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_obs.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_obs.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_base import DatasourceConfigBase
 
 class DatasourceConfigOBS(DatasourceConfigBase):
@@ -45,7 +52,7 @@ class DatasourceConfigOBS(DatasourceConfigBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_obs_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_obs_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceConfigOBSAllOf(BaseModel):
     """
@@ -43,7 +50,7 @@ class DatasourceConfigOBSAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_s3.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_s3.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_base import DatasourceConfigBase
 from lightly.openapi_generated.swagger_client.models.s3_region import S3Region
 
@@ -50,7 +57,7 @@ class DatasourceConfigS3(DatasourceConfigBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_s3_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_s3_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.s3_region import S3Region
 
 class DatasourceConfigS3AllOf(BaseModel):
@@ -48,7 +55,7 @@ class DatasourceConfigS3AllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_s3_delegated_access.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_s3_delegated_access.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_base import DatasourceConfigBase
 from lightly.openapi_generated.swagger_client.models.s3_region import S3Region
 
@@ -64,7 +71,7 @@ class DatasourceConfigS3DelegatedAccess(DatasourceConfigBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_s3_delegated_access_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_s3_delegated_access_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.s3_region import S3Region
 
 class DatasourceConfigS3DelegatedAccessAllOf(BaseModel):
@@ -62,7 +69,7 @@ class DatasourceConfigS3DelegatedAccessAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_verify_data.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_verify_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_config_verify_data_errors import DatasourceConfigVerifyDataErrors
 
 class DatasourceConfigVerifyData(BaseModel):
@@ -39,7 +46,7 @@ class DatasourceConfigVerifyData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_config_verify_data_errors.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_config_verify_data_errors.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceConfigVerifyDataErrors(BaseModel):
     """
@@ -37,7 +44,7 @@ class DatasourceConfigVerifyDataErrors(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_processed_until_timestamp_request.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_processed_until_timestamp_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceProcessedUntilTimestampRequest(BaseModel):
     """
@@ -34,7 +41,7 @@ class DatasourceProcessedUntilTimestampRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_processed_until_timestamp_response.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_processed_until_timestamp_response.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceProcessedUntilTimestampResponse(BaseModel):
     """
@@ -34,7 +41,7 @@ class DatasourceProcessedUntilTimestampResponse(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_purpose.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_purpose.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DatasourcePurpose(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_data.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_data_row import DatasourceRawSamplesDataRow
 
 class DatasourceRawSamplesData(BaseModel):
@@ -37,7 +44,7 @@ class DatasourceRawSamplesData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_data_row.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_data_row.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceRawSamplesDataRow(BaseModel):
     """
@@ -35,7 +42,7 @@ class DatasourceRawSamplesDataRow(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_metadata_data.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_metadata_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_metadata_data_row import DatasourceRawSamplesMetadataDataRow
 
 class DatasourceRawSamplesMetadataData(BaseModel):
@@ -37,7 +44,7 @@ class DatasourceRawSamplesMetadataData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_metadata_data_row.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_metadata_data_row.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceRawSamplesMetadataDataRow(BaseModel):
     """
@@ -35,7 +42,7 @@ class DatasourceRawSamplesMetadataDataRow(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_predictions_data.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_predictions_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.datasource_raw_samples_predictions_data_row import DatasourceRawSamplesPredictionsDataRow
 
 class DatasourceRawSamplesPredictionsData(BaseModel):
@@ -37,7 +44,7 @@ class DatasourceRawSamplesPredictionsData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_predictions_data_row.py
+++ b/lightly/openapi_generated/swagger_client/models/datasource_raw_samples_predictions_data_row.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DatasourceRawSamplesPredictionsDataRow(BaseModel):
     """
@@ -35,7 +42,7 @@ class DatasourceRawSamplesPredictionsDataRow(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/delegated_access_external_ids_inner.py
+++ b/lightly/openapi_generated/swagger_client/models/delegated_access_external_ids_inner.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DelegatedAccessExternalIdsInner(BaseModel):
     """
@@ -43,7 +50,7 @@ class DelegatedAccessExternalIdsInner(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/detection_frame_prediction.py
+++ b/lightly/openapi_generated/swagger_client/models/detection_frame_prediction.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.object_detection_prediction import ObjectDetectionPrediction
 
 class DetectionFramePrediction(BaseModel):
@@ -36,7 +43,7 @@ class DetectionFramePrediction(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/detection_task_information.py
+++ b/lightly/openapi_generated/swagger_client/models/detection_task_information.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.detection_frame_prediction import DetectionFramePrediction
 from lightly.openapi_generated.swagger_client.models.embedding_information import EmbeddingInformation
 
@@ -37,7 +44,7 @@ class DetectionTaskInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/dimensionality_reduction_method.py
+++ b/lightly/openapi_generated/swagger_client/models/dimensionality_reduction_method.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DimensionalityReductionMethod(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_authorization_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_authorization_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_task_description import DockerTaskDescription
 
 class DockerAuthorizationRequest(BaseModel):
@@ -36,7 +43,7 @@ class DockerAuthorizationRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_authorization_response.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_authorization_response.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerAuthorizationResponse(BaseModel):
     """
@@ -35,7 +42,7 @@ class DockerAuthorizationResponse(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_license_information.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_license_information.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerLicenseInformation(BaseModel):
     """
@@ -36,7 +43,7 @@ class DockerLicenseInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_artifact_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_artifact_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_artifact_storage_location import DockerRunArtifactStorageLocation
 from lightly.openapi_generated.swagger_client.models.docker_run_artifact_type import DockerRunArtifactType
 
@@ -38,7 +45,7 @@ class DockerRunArtifactCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_artifact_created_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_artifact_created_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerRunArtifactCreatedData(BaseModel):
     """
@@ -35,7 +42,7 @@ class DockerRunArtifactCreatedData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_artifact_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_artifact_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_artifact_storage_location import DockerRunArtifactStorageLocation
 from lightly.openapi_generated.swagger_client.models.docker_run_artifact_type import DockerRunArtifactType
 
@@ -47,7 +54,7 @@ class DockerRunArtifactData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_artifact_storage_location.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_artifact_storage_location.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerRunArtifactStorageLocation(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_run_artifact_type.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_artifact_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerRunArtifactType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_run_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 
 class DockerRunCreateRequest(BaseModel):
@@ -70,7 +77,7 @@ class DockerRunCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_artifact_data import DockerRunArtifactData
 from lightly.openapi_generated.swagger_client.models.docker_run_state import DockerRunState
 
@@ -84,7 +91,7 @@ class DockerRunData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_log_create_entry_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_log_create_entry_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_log_docker_load import DockerRunLogDockerLoad
 from lightly.openapi_generated.swagger_client.models.docker_run_log_level import DockerRunLogLevel
 from lightly.openapi_generated.swagger_client.models.docker_run_state import DockerRunState
@@ -43,7 +50,7 @@ class DockerRunLogCreateEntryData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_log_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_log_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_log_entry_data import DockerRunLogEntryData
 
 class DockerRunLogData(BaseModel):
@@ -36,7 +43,7 @@ class DockerRunLogData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_log_docker_load.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_log_docker_load.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerRunLogDockerLoad(BaseModel):
     """
@@ -35,7 +42,7 @@ class DockerRunLogDockerLoad(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_log_entry_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_log_entry_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_log_docker_load import DockerRunLogDockerLoad
 from lightly.openapi_generated.swagger_client.models.docker_run_log_level import DockerRunLogLevel
 from lightly.openapi_generated.swagger_client.models.docker_run_state import DockerRunState
@@ -43,7 +50,7 @@ class DockerRunLogEntryData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_log_entry_data_base.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_log_entry_data_base.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_log_docker_load import DockerRunLogDockerLoad
 from lightly.openapi_generated.swagger_client.models.docker_run_log_level import DockerRunLogLevel
 from lightly.openapi_generated.swagger_client.models.docker_run_state import DockerRunState
@@ -43,7 +50,7 @@ class DockerRunLogEntryDataBase(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_log_level.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_log_level.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerRunLogLevel(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_priority import DockerRunScheduledPriority
 
@@ -46,7 +53,7 @@ class DockerRunScheduledCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_priority import DockerRunScheduledPriority
 from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_state import DockerRunScheduledState
 
@@ -76,7 +83,7 @@ class DockerRunScheduledData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_priority.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_priority.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerRunScheduledPriority(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_state.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_state.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerRunScheduledState(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_update_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_scheduled_update_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_priority import DockerRunScheduledPriority
 from lightly.openapi_generated.swagger_client.models.docker_run_scheduled_state import DockerRunScheduledState
 
@@ -38,7 +45,7 @@ class DockerRunScheduledUpdateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_run_state.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_state.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerRunState(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_run_update_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_run_update_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_run_state import DockerRunState
 
 class DockerRunUpdateRequest(BaseModel):
@@ -37,7 +44,7 @@ class DockerRunUpdateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_task_description.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_task_description.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, StrictStr, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sampling_config import SamplingConfig
 from lightly.openapi_generated.swagger_client.models.sampling_method import SamplingMethod
 
@@ -43,7 +50,7 @@ class DockerTaskDescription(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_user_stats.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_user_stats.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerUserStats(BaseModel):
     """
@@ -39,7 +46,7 @@ class DockerUserStats(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_authorization_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_authorization_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerAuthorizationRequest(BaseModel):
     """
@@ -34,7 +41,7 @@ class DockerWorkerAuthorizationRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_type import DockerWorkerType
 from lightly.openapi_generated.swagger_client.models.selection_config import SelectionConfig
 
@@ -39,7 +46,7 @@ class DockerWorkerConfig(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 from lightly.openapi_generated.swagger_client.models.docker_worker_config import DockerWorkerConfig
 
@@ -37,7 +44,7 @@ class DockerWorkerConfigCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v2_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v2_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_omni_vx_create_request_base import DockerWorkerConfigOmniVXCreateRequestBase
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2 import DockerWorkerConfigV2
 
@@ -36,7 +43,7 @@ class DockerWorkerConfigOmniV2CreateRequest(DockerWorkerConfigOmniVXCreateReques
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v2_create_request_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v2_create_request_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2 import DockerWorkerConfigV2
 
 class DockerWorkerConfigOmniV2CreateRequestAllOf(BaseModel):
@@ -35,7 +42,7 @@ class DockerWorkerConfigOmniV2CreateRequestAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v3_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v3_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_omni_vx_create_request_base import DockerWorkerConfigOmniVXCreateRequestBase
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3 import DockerWorkerConfigV3
 
@@ -36,7 +43,7 @@ class DockerWorkerConfigOmniV3CreateRequest(DockerWorkerConfigOmniVXCreateReques
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v3_create_request_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v3_create_request_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3 import DockerWorkerConfigV3
 
 class DockerWorkerConfigOmniV3CreateRequestAllOf(BaseModel):
@@ -35,7 +42,7 @@ class DockerWorkerConfigOmniV3CreateRequestAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v4_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v4_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_omni_vx_create_request_base import DockerWorkerConfigOmniVXCreateRequestBase
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v4 import DockerWorkerConfigV4
 
@@ -36,7 +43,7 @@ class DockerWorkerConfigOmniV4CreateRequest(DockerWorkerConfigOmniVXCreateReques
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v4_create_request_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_v4_create_request_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v4 import DockerWorkerConfigV4
 
 class DockerWorkerConfigOmniV4CreateRequestAllOf(BaseModel):
@@ -35,7 +42,7 @@ class DockerWorkerConfigOmniV4CreateRequestAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_vx_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_vx_create_request.py
@@ -20,12 +20,24 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_omni_v2_create_request import DockerWorkerConfigOmniV2CreateRequest
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_omni_v3_create_request import DockerWorkerConfigOmniV3CreateRequest
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_omni_v4_create_request import DockerWorkerConfigOmniV4CreateRequest
 from typing import Any, List
-from pydantic import StrictStr, Field, Extra
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import StrictStr, Field
+except ImportError:
+    # Pydantic v1
+    from pydantic import StrictStr, Field
 
 DOCKERWORKERCONFIGOMNIVXCREATEREQUEST_ONE_OF_SCHEMAS = ["DockerWorkerConfigOmniV2CreateRequest", "DockerWorkerConfigOmniV3CreateRequest", "DockerWorkerConfigOmniV4CreateRequest"]
 
@@ -45,7 +57,7 @@ class DockerWorkerConfigOmniVXCreateRequest(BaseModel):
     class Config:
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     discriminator_value_class_map = {
     }

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_vx_create_request_base.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_omni_vx_create_request_base.py
@@ -21,7 +21,14 @@ import lightly.openapi_generated.swagger_client.models
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 
 class DockerWorkerConfigOmniVXCreateRequestBase(BaseModel):
@@ -37,7 +44,7 @@ class DockerWorkerConfigOmniVXCreateRequestBase(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     # JSON field name that stores the object type
     __discriminator_property_name = 'version'

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v0_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v0_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config import DockerWorkerConfig
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_vx_data_base import DockerWorkerConfigVXDataBase
 
@@ -37,7 +44,7 @@ class DockerWorkerConfigV0Data(DockerWorkerConfigVXDataBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v0_data_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v0_data_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config import DockerWorkerConfig
 
 class DockerWorkerConfigV0DataAllOf(BaseModel):
@@ -36,7 +43,7 @@ class DockerWorkerConfigV0DataAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_docker import DockerWorkerConfigV2Docker
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_lightly import DockerWorkerConfigV2Lightly
 from lightly.openapi_generated.swagger_client.models.docker_worker_type import DockerWorkerType
@@ -41,7 +48,7 @@ class DockerWorkerConfigV2(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2 import DockerWorkerConfigV2
 
@@ -37,7 +44,7 @@ class DockerWorkerConfigV2CreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2 import DockerWorkerConfigV2
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_vx_data_base import DockerWorkerConfigVXDataBase
 
@@ -37,7 +44,7 @@ class DockerWorkerConfigV2Data(DockerWorkerConfigVXDataBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_data_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_data_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2 import DockerWorkerConfigV2
 
 class DockerWorkerConfigV2DataAllOf(BaseModel):
@@ -36,7 +43,7 @@ class DockerWorkerConfigV2DataAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_docker_datasource import DockerWorkerConfigV2DockerDatasource
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_docker_object_level import DockerWorkerConfigV2DockerObjectLevel
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_docker_stopping_condition import DockerWorkerConfigV2DockerStoppingCondition
@@ -53,7 +60,7 @@ class DockerWorkerConfigV2Docker(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker_datasource.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker_datasource.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV2DockerDatasource(BaseModel):
     """
@@ -36,7 +43,7 @@ class DockerWorkerConfigV2DockerDatasource(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker_object_level.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker_object_level.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV2DockerObjectLevel(BaseModel):
     """
@@ -56,7 +63,7 @@ class DockerWorkerConfigV2DockerObjectLevel(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker_stopping_condition.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_docker_stopping_condition.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV2DockerStoppingCondition(BaseModel):
     """
@@ -35,7 +42,7 @@ class DockerWorkerConfigV2DockerStoppingCondition(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_lightly_collate import DockerWorkerConfigV2LightlyCollate
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_lightly_model import DockerWorkerConfigV2LightlyModel
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_lightly_trainer import DockerWorkerConfigV2LightlyTrainer
@@ -45,7 +52,7 @@ class DockerWorkerConfigV2Lightly(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly_collate.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly_collate.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV2LightlyCollate(BaseModel):
     """
@@ -47,7 +54,7 @@ class DockerWorkerConfigV2LightlyCollate(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly_model.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly_model.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.lightly_model_v2 import LightlyModelV2
 
 class DockerWorkerConfigV2LightlyModel(BaseModel):
@@ -38,7 +45,7 @@ class DockerWorkerConfigV2LightlyModel(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly_trainer.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v2_lightly_trainer.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.lightly_trainer_precision_v2 import LightlyTrainerPrecisionV2
 
 class DockerWorkerConfigV2LightlyTrainer(BaseModel):
@@ -37,7 +44,7 @@ class DockerWorkerConfigV2LightlyTrainer(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_docker import DockerWorkerConfigV3Docker
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_lightly import DockerWorkerConfigV3Lightly
 from lightly.openapi_generated.swagger_client.models.docker_worker_type import DockerWorkerType
@@ -41,7 +48,7 @@ class DockerWorkerConfigV3(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3 import DockerWorkerConfigV3
 
@@ -37,7 +44,7 @@ class DockerWorkerConfigV3CreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3 import DockerWorkerConfigV3
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_vx_data_base import DockerWorkerConfigVXDataBase
 
@@ -37,7 +44,7 @@ class DockerWorkerConfigV3Data(DockerWorkerConfigVXDataBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_data_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_data_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3 import DockerWorkerConfigV3
 
 class DockerWorkerConfigV3DataAllOf(BaseModel):
@@ -36,7 +43,7 @@ class DockerWorkerConfigV3DataAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_datasource_input_expiration.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_datasource_input_expiration.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.expiry_handling_strategy_v3 import ExpiryHandlingStrategyV3
 
 class DockerWorkerConfigV3DatasourceInputExpiration(BaseModel):
@@ -36,7 +43,7 @@ class DockerWorkerConfigV3DatasourceInputExpiration(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_docker_corruptness_check import DockerWorkerConfigV3DockerCorruptnessCheck
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_docker_datasource import DockerWorkerConfigV3DockerDatasource
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_docker_training import DockerWorkerConfigV3DockerTraining
@@ -63,7 +70,7 @@ class DockerWorkerConfigV3Docker(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker_corruptness_check.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker_corruptness_check.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV3DockerCorruptnessCheck(BaseModel):
     """
@@ -34,7 +41,7 @@ class DockerWorkerConfigV3DockerCorruptnessCheck(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker_datasource.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker_datasource.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_datasource_input_expiration import DockerWorkerConfigV3DatasourceInputExpiration
 
 class DockerWorkerConfigV3DockerDatasource(BaseModel):
@@ -38,7 +45,7 @@ class DockerWorkerConfigV3DockerDatasource(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker_training.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_docker_training.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV3DockerTraining(BaseModel):
     """
@@ -44,7 +51,7 @@ class DockerWorkerConfigV3DockerTraining(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_lightly_checkpoint_callback import DockerWorkerConfigV3LightlyCheckpointCallback
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_lightly_collate import DockerWorkerConfigV3LightlyCollate
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_lightly_criterion import DockerWorkerConfigV3LightlyCriterion
@@ -48,7 +55,7 @@ class DockerWorkerConfigV3Lightly(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_checkpoint_callback.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_checkpoint_callback.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV3LightlyCheckpointCallback(BaseModel):
     """
@@ -34,7 +41,7 @@ class DockerWorkerConfigV3LightlyCheckpointCallback(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_collate.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_collate.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV3LightlyCollate(BaseModel):
     """
@@ -48,7 +55,7 @@ class DockerWorkerConfigV3LightlyCollate(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_criterion.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_criterion.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV3LightlyCriterion(BaseModel):
     """
@@ -34,7 +41,7 @@ class DockerWorkerConfigV3LightlyCriterion(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_loader.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_loader.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV3LightlyLoader(BaseModel):
     """
@@ -37,7 +44,7 @@ class DockerWorkerConfigV3LightlyLoader(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_model.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_model.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.lightly_model_v3 import LightlyModelV3
 
 class DockerWorkerConfigV3LightlyModel(BaseModel):
@@ -38,7 +45,7 @@ class DockerWorkerConfigV3LightlyModel(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_optimizer.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_optimizer.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigV3LightlyOptimizer(BaseModel):
     """
@@ -35,7 +42,7 @@ class DockerWorkerConfigV3LightlyOptimizer(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_trainer.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v3_lightly_trainer.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.lightly_trainer_precision_v3 import LightlyTrainerPrecisionV3
 
 class DockerWorkerConfigV3LightlyTrainer(BaseModel):
@@ -37,7 +44,7 @@ class DockerWorkerConfigV3LightlyTrainer(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_lightly import DockerWorkerConfigV3Lightly
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v4_docker import DockerWorkerConfigV4Docker
 from lightly.openapi_generated.swagger_client.models.docker_worker_type import DockerWorkerType
@@ -41,7 +48,7 @@ class DockerWorkerConfigV4(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v4 import DockerWorkerConfigV4
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_vx_data_base import DockerWorkerConfigVXDataBase
 
@@ -37,7 +44,7 @@ class DockerWorkerConfigV4Data(DockerWorkerConfigVXDataBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4_data_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4_data_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v4 import DockerWorkerConfigV4
 
 class DockerWorkerConfigV4DataAllOf(BaseModel):
@@ -36,7 +43,7 @@ class DockerWorkerConfigV4DataAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4_docker.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_v4_docker.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_docker_corruptness_check import DockerWorkerConfigV3DockerCorruptnessCheck
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_docker_datasource import DockerWorkerConfigV3DockerDatasource
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_docker_training import DockerWorkerConfigV3DockerTraining
@@ -65,7 +72,7 @@ class DockerWorkerConfigV4Docker(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_vx_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_vx_data.py
@@ -20,13 +20,25 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v0_data import DockerWorkerConfigV0Data
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v2_data import DockerWorkerConfigV2Data
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v3_data import DockerWorkerConfigV3Data
 from lightly.openapi_generated.swagger_client.models.docker_worker_config_v4_data import DockerWorkerConfigV4Data
 from typing import Any, List
-from pydantic import StrictStr, Field, Extra
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import StrictStr, Field
+except ImportError:
+    # Pydantic v1
+    from pydantic import StrictStr, Field
 
 DOCKERWORKERCONFIGVXDATA_ONE_OF_SCHEMAS = ["DockerWorkerConfigV0Data", "DockerWorkerConfigV2Data", "DockerWorkerConfigV3Data", "DockerWorkerConfigV4Data"]
 
@@ -48,7 +60,7 @@ class DockerWorkerConfigVXData(BaseModel):
     class Config:
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     discriminator_value_class_map = {
     }

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_config_vx_data_base.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_config_vx_data_base.py
@@ -21,7 +21,14 @@ import lightly.openapi_generated.swagger_client.models
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class DockerWorkerConfigVXDataBase(BaseModel):
     """
@@ -44,7 +51,7 @@ class DockerWorkerConfigVXDataBase(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     # JSON field name that stores the object type
     __discriminator_property_name = 'version'

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_registry_entry_data.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_registry_entry_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_state import DockerWorkerState
 from lightly.openapi_generated.swagger_client.models.docker_worker_type import DockerWorkerType
 
@@ -59,7 +66,7 @@ class DockerWorkerRegistryEntryData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_state.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_state.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerWorkerState(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/docker_worker_type.py
+++ b/lightly/openapi_generated/swagger_client/models/docker_worker_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class DockerWorkerType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/embedding2d_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/embedding2d_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dimensionality_reduction_method import DimensionalityReductionMethod
 
 class Embedding2dCreateRequest(BaseModel):
@@ -38,7 +45,7 @@ class Embedding2dCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/embedding2d_data.py
+++ b/lightly/openapi_generated/swagger_client/models/embedding2d_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dimensionality_reduction_method import DimensionalityReductionMethod
 
 class Embedding2dData(BaseModel):
@@ -63,7 +70,7 @@ class Embedding2dData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/embedding_data.py
+++ b/lightly/openapi_generated/swagger_client/models/embedding_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class EmbeddingData(BaseModel):
     """
@@ -50,7 +57,7 @@ class EmbeddingData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/embedding_data2_d.py
+++ b/lightly/openapi_generated/swagger_client/models/embedding_data2_d.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.scatter_plot_example_image import ScatterPlotExampleImage
 
 class EmbeddingData2D(BaseModel):
@@ -38,7 +45,7 @@ class EmbeddingData2D(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/embedding_information.py
+++ b/lightly/openapi_generated/swagger_client/models/embedding_information.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.numeric_distribution_per_set import NumericDistributionPerSet
 from lightly.openapi_generated.swagger_client.models.scatter_plot_data import ScatterPlotData
 
@@ -38,7 +45,7 @@ class EmbeddingInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/expiry_handling_strategy_v3.py
+++ b/lightly/openapi_generated/swagger_client/models/expiry_handling_strategy_v3.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class ExpiryHandlingStrategyV3(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/file_name_format.py
+++ b/lightly/openapi_generated/swagger_client/models/file_name_format.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class FileNameFormat(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/file_output_format.py
+++ b/lightly/openapi_generated/swagger_client/models/file_output_format.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class FileOutputFormat(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/filename_and_read_url.py
+++ b/lightly/openapi_generated/swagger_client/models/filename_and_read_url.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class FilenameAndReadUrl(BaseModel):
     """
@@ -35,7 +42,7 @@ class FilenameAndReadUrl(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/general_information.py
+++ b/lightly/openapi_generated/swagger_client/models/general_information.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.annotation_savings import AnnotationSavings
 from lightly.openapi_generated.swagger_client.models.dataset_information import DatasetInformation
 from lightly.openapi_generated.swagger_client.models.run_information import RunInformation
@@ -43,7 +50,7 @@ class GeneralInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/image_type.py
+++ b/lightly/openapi_generated/swagger_client/models/image_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class ImageType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/initial_tag_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/initial_tag_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.image_type import ImageType
 from lightly.openapi_generated.swagger_client.models.tag_creator import TagCreator
 
@@ -59,7 +66,7 @@ class InitialTagCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/internal_debug_latency.py
+++ b/lightly/openapi_generated/swagger_client/models/internal_debug_latency.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.internal_debug_latency_mongodb import InternalDebugLatencyMongodb
 
 class InternalDebugLatency(BaseModel):
@@ -38,7 +45,7 @@ class InternalDebugLatency(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/internal_debug_latency_mongodb.py
+++ b/lightly/openapi_generated/swagger_client/models/internal_debug_latency_mongodb.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class InternalDebugLatencyMongodb(BaseModel):
     """
@@ -35,7 +42,7 @@ class InternalDebugLatencyMongodb(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/job_result_type.py
+++ b/lightly/openapi_generated/swagger_client/models/job_result_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class JobResultType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/job_state.py
+++ b/lightly/openapi_generated/swagger_client/models/job_state.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class JobState(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/job_status_data.py
+++ b/lightly/openapi_generated/swagger_client/models/job_status_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.job_state import JobState
 from lightly.openapi_generated.swagger_client.models.job_status_data_result import JobStatusDataResult
 from lightly.openapi_generated.swagger_client.models.job_status_meta import JobStatusMeta
@@ -63,7 +70,7 @@ class JobStatusData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/job_status_data_result.py
+++ b/lightly/openapi_generated/swagger_client/models/job_status_data_result.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.job_result_type import JobResultType
 
 class JobStatusDataResult(BaseModel):
@@ -36,7 +43,7 @@ class JobStatusDataResult(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/job_status_meta.py
+++ b/lightly/openapi_generated/swagger_client/models/job_status_meta.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictBool, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictBool, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.job_status_upload_method import JobStatusUploadMethod
 
 class JobStatusMeta(BaseModel):
@@ -38,7 +45,7 @@ class JobStatusMeta(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/job_status_upload_method.py
+++ b/lightly/openapi_generated/swagger_client/models/job_status_upload_method.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class JobStatusUploadMethod(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/jobs_data.py
+++ b/lightly/openapi_generated/swagger_client/models/jobs_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.job_result_type import JobResultType
 from lightly.openapi_generated.swagger_client.models.job_state import JobState
 
@@ -59,7 +66,7 @@ class JobsData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/label_box_data_row.py
+++ b/lightly/openapi_generated/swagger_client/models/label_box_data_row.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class LabelBoxDataRow(BaseModel):
     """
@@ -35,7 +42,7 @@ class LabelBoxDataRow(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/label_box_v4_data_row.py
+++ b/lightly/openapi_generated/swagger_client/models/label_box_v4_data_row.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class LabelBoxV4DataRow(BaseModel):
     """
@@ -36,7 +43,7 @@ class LabelBoxV4DataRow(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/label_studio_task.py
+++ b/lightly/openapi_generated/swagger_client/models/label_studio_task.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.label_studio_task_data import LabelStudioTaskData
 
 class LabelStudioTask(BaseModel):
@@ -36,7 +43,7 @@ class LabelStudioTask(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/label_studio_task_data.py
+++ b/lightly/openapi_generated/swagger_client/models/label_studio_task_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sample_data import SampleData
 
 class LabelStudioTaskData(BaseModel):
@@ -37,7 +44,7 @@ class LabelStudioTaskData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/lightly_docker_selection_method.py
+++ b/lightly/openapi_generated/swagger_client/models/lightly_docker_selection_method.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class LightlyDockerSelectionMethod(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/lightly_model_v2.py
+++ b/lightly/openapi_generated/swagger_client/models/lightly_model_v2.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class LightlyModelV2(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/lightly_model_v3.py
+++ b/lightly/openapi_generated/swagger_client/models/lightly_model_v3.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class LightlyModelV3(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/lightly_trainer_precision_v2.py
+++ b/lightly/openapi_generated/swagger_client/models/lightly_trainer_precision_v2.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class LightlyTrainerPrecisionV2(int, Enum):

--- a/lightly/openapi_generated/swagger_client/models/lightly_trainer_precision_v3.py
+++ b/lightly/openapi_generated/swagger_client/models/lightly_trainer_precision_v3.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class LightlyTrainerPrecisionV3(int, Enum):

--- a/lightly/openapi_generated/swagger_client/models/metadata_information.py
+++ b/lightly/openapi_generated/swagger_client/models/metadata_information.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Dict
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.categorical_distribution_per_set import CategoricalDistributionPerSet
 from lightly.openapi_generated.swagger_client.models.numeric_distribution_per_set import NumericDistributionPerSet
 
@@ -38,7 +45,7 @@ class MetadataInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/numeric_distribution.py
+++ b/lightly/openapi_generated/swagger_client/models/numeric_distribution.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.numeric_distribution_metrics import NumericDistributionMetrics
 
 class NumericDistribution(BaseModel):
@@ -36,7 +43,7 @@ class NumericDistribution(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/numeric_distribution_metrics.py
+++ b/lightly/openapi_generated/swagger_client/models/numeric_distribution_metrics.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class NumericDistributionMetrics(BaseModel):
     """
@@ -38,7 +45,7 @@ class NumericDistributionMetrics(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/numeric_distribution_per_set.py
+++ b/lightly/openapi_generated/swagger_client/models/numeric_distribution_per_set.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.numeric_distribution import NumericDistribution
 
 class NumericDistributionPerSet(BaseModel):
@@ -41,7 +48,7 @@ class NumericDistributionPerSet(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/object_detection_prediction.py
+++ b/lightly/openapi_generated/swagger_client/models/object_detection_prediction.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ObjectDetectionPrediction(BaseModel):
     """
@@ -38,7 +45,7 @@ class ObjectDetectionPrediction(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton.py
@@ -20,14 +20,26 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_classification import PredictionSingletonClassification
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_instance_segmentation import PredictionSingletonInstanceSegmentation
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_keypoint_detection import PredictionSingletonKeypointDetection
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_object_detection import PredictionSingletonObjectDetection
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_semantic_segmentation import PredictionSingletonSemanticSegmentation
 from typing import Any, List
-from pydantic import StrictStr, Field, Extra
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import StrictStr, Field
+except ImportError:
+    # Pydantic v1
+    from pydantic import StrictStr, Field
 
 PREDICTIONSINGLETON_ONE_OF_SCHEMAS = ["PredictionSingletonClassification", "PredictionSingletonInstanceSegmentation", "PredictionSingletonKeypointDetection", "PredictionSingletonObjectDetection", "PredictionSingletonSemanticSegmentation"]
 
@@ -51,7 +63,7 @@ class PredictionSingleton(BaseModel):
     class Config:
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     discriminator_value_class_map = {
     }

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_base.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_base.py
@@ -21,7 +21,14 @@ import lightly.openapi_generated.swagger_client.models
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictStr, confloat, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, confloat, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, confloat, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionSingletonBase(BaseModel):
     """
@@ -67,7 +74,7 @@ class PredictionSingletonBase(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     # JSON field name that stores the object type
     __discriminator_property_name = 'type'

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_classification.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_classification.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_base import PredictionSingletonBase
 
 class PredictionSingletonClassification(PredictionSingletonBase):
@@ -35,7 +42,7 @@ class PredictionSingletonClassification(PredictionSingletonBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_classification_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_classification_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionSingletonClassificationAllOf(BaseModel):
     """
@@ -34,7 +41,7 @@ class PredictionSingletonClassificationAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_base import PredictionSingletonBase
 
 class PredictionSingletonInstanceSegmentation(PredictionSingletonBase):
@@ -37,7 +44,7 @@ class PredictionSingletonInstanceSegmentation(PredictionSingletonBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_instance_segmentation_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionSingletonInstanceSegmentationAllOf(BaseModel):
     """
@@ -36,7 +43,7 @@ class PredictionSingletonInstanceSegmentationAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_base import PredictionSingletonBase
 
 class PredictionSingletonKeypointDetection(PredictionSingletonBase):
@@ -37,7 +44,7 @@ class PredictionSingletonKeypointDetection(PredictionSingletonBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_keypoint_detection_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionSingletonKeypointDetectionAllOf(BaseModel):
     """
@@ -36,7 +43,7 @@ class PredictionSingletonKeypointDetectionAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_base import PredictionSingletonBase
 
 class PredictionSingletonObjectDetection(PredictionSingletonBase):
@@ -36,7 +43,7 @@ class PredictionSingletonObjectDetection(PredictionSingletonBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_object_detection_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionSingletonObjectDetectionAllOf(BaseModel):
     """
@@ -35,7 +42,7 @@ class PredictionSingletonObjectDetectionAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_semantic_segmentation.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_semantic_segmentation.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_singleton_base import PredictionSingletonBase
 
 class PredictionSingletonSemanticSegmentation(PredictionSingletonBase):
@@ -36,7 +43,7 @@ class PredictionSingletonSemanticSegmentation(PredictionSingletonBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_singleton_semantic_segmentation_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_singleton_semantic_segmentation_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionSingletonSemanticSegmentationAllOf(BaseModel):
     """
@@ -35,7 +42,7 @@ class PredictionSingletonSemanticSegmentationAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_information.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_information.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Dict, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.categorical_distribution_per_set import CategoricalDistributionPerSet
 from lightly.openapi_generated.swagger_client.models.detection_task_information import DetectionTaskInformation
 from lightly.openapi_generated.swagger_client.models.numeric_distribution_per_set import NumericDistributionPerSet
@@ -44,7 +51,7 @@ class PredictionTaskInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema.py
@@ -20,11 +20,23 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_keypoint import PredictionTaskSchemaKeypoint
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_simple import PredictionTaskSchemaSimple
 from typing import Any, List
-from pydantic import StrictStr, Field, Extra
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import StrictStr, Field
+except ImportError:
+    # Pydantic v1
+    from pydantic import StrictStr, Field
 
 PREDICTIONTASKSCHEMA_ONE_OF_SCHEMAS = ["PredictionTaskSchemaKeypoint", "PredictionTaskSchemaSimple"]
 
@@ -42,7 +54,7 @@ class PredictionTaskSchema(BaseModel):
     class Config:
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     discriminator_value_class_map = {
     }

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_base.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_base.py
@@ -21,7 +21,14 @@ import lightly.openapi_generated.swagger_client.models
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionTaskSchemaBase(BaseModel):
     """
@@ -43,7 +50,7 @@ class PredictionTaskSchemaBase(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     # JSON field name that stores the object type
     __discriminator_property_name = 'type'

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_category.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_category.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, conint, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionTaskSchemaCategory(BaseModel):
     """
@@ -35,7 +42,7 @@ class PredictionTaskSchemaCategory(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_category_keypoints.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_category_keypoints.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, conint, conlist, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionTaskSchemaCategoryKeypoints(BaseModel):
     """
@@ -37,7 +44,7 @@ class PredictionTaskSchemaCategoryKeypoints(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_category_keypoints_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_category_keypoints_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, conint, conlist, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class PredictionTaskSchemaCategoryKeypointsAllOf(BaseModel):
     """
@@ -35,7 +42,7 @@ class PredictionTaskSchemaCategoryKeypointsAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_keypoint.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_keypoint.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_base import PredictionTaskSchemaBase
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_category_keypoints import PredictionTaskSchemaCategoryKeypoints
 
@@ -36,7 +43,7 @@ class PredictionTaskSchemaKeypoint(PredictionTaskSchemaBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_keypoint_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_keypoint_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_category_keypoints import PredictionTaskSchemaCategoryKeypoints
 
 class PredictionTaskSchemaKeypointAllOf(BaseModel):
@@ -35,7 +42,7 @@ class PredictionTaskSchemaKeypointAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_simple.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_simple.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_base import PredictionTaskSchemaBase
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_category import PredictionTaskSchemaCategory
 
@@ -36,7 +43,7 @@ class PredictionTaskSchemaSimple(PredictionTaskSchemaBase):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schema_simple_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schema_simple_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema_category import PredictionTaskSchemaCategory
 
 class PredictionTaskSchemaSimpleAllOf(BaseModel):
@@ -35,7 +42,7 @@ class PredictionTaskSchemaSimpleAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/prediction_task_schemas.py
+++ b/lightly/openapi_generated/swagger_client/models/prediction_task_schemas.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.prediction_task_schema import PredictionTaskSchema
 
 class PredictionTaskSchemas(BaseModel):
@@ -36,7 +43,7 @@ class PredictionTaskSchemas(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/profile_basic_data.py
+++ b/lightly/openapi_generated/swagger_client/models/profile_basic_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.team_basic_data import TeamBasicData
 
 class ProfileBasicData(BaseModel):
@@ -42,7 +49,7 @@ class ProfileBasicData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/profile_me_data.py
+++ b/lightly/openapi_generated/swagger_client/models/profile_me_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr, conint, conlist, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.profile_me_data_settings import ProfileMeDataSettings
 from lightly.openapi_generated.swagger_client.models.team_basic_data import TeamBasicData
 from lightly.openapi_generated.swagger_client.models.user_type import UserType
@@ -48,7 +55,7 @@ class ProfileMeData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/profile_me_data_settings.py
+++ b/lightly/openapi_generated/swagger_client/models/profile_me_data_settings.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ProfileMeDataSettings(BaseModel):
     """
@@ -37,7 +44,7 @@ class ProfileMeDataSettings(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/questionnaire_data.py
+++ b/lightly/openapi_generated/swagger_client/models/questionnaire_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sector import Sector
 
 class QuestionnaireData(BaseModel):
@@ -36,7 +43,7 @@ class QuestionnaireData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/report_v2.py
+++ b/lightly/openapi_generated/swagger_client/models/report_v2.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Dict, Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dataset_analysis import DatasetAnalysis
 from lightly.openapi_generated.swagger_client.models.general_information import GeneralInformation
 from lightly.openapi_generated.swagger_client.models.prediction_task_information import PredictionTaskInformation
@@ -39,7 +46,7 @@ class ReportV2(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/run_information.py
+++ b/lightly/openapi_generated/swagger_client/models/run_information.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class RunInformation(BaseModel):
     """
@@ -38,7 +45,7 @@ class RunInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/s3_region.py
+++ b/lightly/openapi_generated/swagger_client/models/s3_region.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class S3Region(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/sama_task.py
+++ b/lightly/openapi_generated/swagger_client/models/sama_task.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sama_task_data import SamaTaskData
 
 class SamaTask(BaseModel):
@@ -37,7 +44,7 @@ class SamaTask(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sama_task_data.py
+++ b/lightly/openapi_generated/swagger_client/models/sama_task_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SamaTaskData(BaseModel):
     """
@@ -38,7 +45,7 @@ class SamaTaskData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sample_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.crop_data import CropData
 from lightly.openapi_generated.swagger_client.models.sample_meta_data import SampleMetaData
 from lightly.openapi_generated.swagger_client.models.video_frame_data import VideoFrameData
@@ -43,7 +50,7 @@ class SampleCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sample_data.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.crop_data import CropData
 from lightly.openapi_generated.swagger_client.models.sample_meta_data import SampleMetaData
 from lightly.openapi_generated.swagger_client.models.sample_type import SampleType
@@ -67,7 +74,7 @@ class SampleData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sample_data_modes.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_data_modes.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.crop_data import CropData
 from lightly.openapi_generated.swagger_client.models.sample_meta_data import SampleMetaData
 from lightly.openapi_generated.swagger_client.models.sample_type import SampleType
@@ -67,7 +74,7 @@ class SampleDataModes(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sample_meta_data.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_meta_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SampleMetaData(BaseModel):
     """
@@ -45,7 +52,7 @@ class SampleMetaData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sample_partial_mode.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_partial_mode.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SamplePartialMode(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/sample_sort_by.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_sort_by.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SampleSortBy(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/sample_type.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SampleType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/sample_update_request.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_update_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sample_meta_data import SampleMetaData
 
 class SampleUpdateRequest(BaseModel):
@@ -39,7 +46,7 @@ class SampleUpdateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sample_write_urls.py
+++ b/lightly/openapi_generated/swagger_client/models/sample_write_urls.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SampleWriteUrls(BaseModel):
     """
@@ -35,7 +42,7 @@ class SampleWriteUrls(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sampling_config.py
+++ b/lightly/openapi_generated/swagger_client/models/sampling_config.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sampling_config_stopping_condition import SamplingConfigStoppingCondition
 
 class SamplingConfig(BaseModel):
@@ -35,7 +42,7 @@ class SamplingConfig(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sampling_config_stopping_condition.py
+++ b/lightly/openapi_generated/swagger_client/models/sampling_config_stopping_condition.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SamplingConfigStoppingCondition(BaseModel):
     """
@@ -35,7 +42,7 @@ class SamplingConfigStoppingCondition(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sampling_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/sampling_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.sampling_config import SamplingConfig
 from lightly.openapi_generated.swagger_client.models.sampling_method import SamplingMethod
 
@@ -79,7 +86,7 @@ class SamplingCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sampling_method.py
+++ b/lightly/openapi_generated/swagger_client/models/sampling_method.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SamplingMethod(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/scatter_plot_data.py
+++ b/lightly/openapi_generated/swagger_client/models/scatter_plot_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.embedding_data2_d import EmbeddingData2D
 
 class ScatterPlotData(BaseModel):
@@ -36,7 +43,7 @@ class ScatterPlotData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/scatter_plot_example_image.py
+++ b/lightly/openapi_generated/swagger_client/models/scatter_plot_example_image.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ScatterPlotExampleImage(BaseModel):
     """
@@ -35,7 +42,7 @@ class ScatterPlotExampleImage(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/sector.py
+++ b/lightly/openapi_generated/swagger_client/models/sector.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class Sector(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/selected_and_removed_image_pair.py
+++ b/lightly/openapi_generated/swagger_client/models/selected_and_removed_image_pair.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SelectedAndRemovedImagePair(BaseModel):
     """
@@ -36,7 +43,7 @@ class SelectedAndRemovedImagePair(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_entry import SelectionConfigEntry
 
 class SelectionConfig(BaseModel):
@@ -37,7 +44,7 @@ class SelectionConfig(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_entry import SelectionConfigEntry
 
 class SelectionConfigAllOf(BaseModel):
@@ -35,7 +42,7 @@ class SelectionConfigAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_base.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_base.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SelectionConfigBase(BaseModel):
     """
@@ -35,7 +42,7 @@ class SelectionConfigBase(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_entry.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_entry.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_entry_input import SelectionConfigEntryInput
 from lightly.openapi_generated.swagger_client.models.selection_config_entry_strategy import SelectionConfigEntryStrategy
 
@@ -37,7 +44,7 @@ class SelectionConfigEntry(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_entry_input.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_entry_input.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_input_predictions_name import SelectionInputPredictionsName
 from lightly.openapi_generated.swagger_client.models.selection_input_type import SelectionInputType
 
@@ -84,7 +91,7 @@ class SelectionConfigEntryInput(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_entry_strategy.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_entry_strategy.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_strategy_threshold_operation import SelectionStrategyThresholdOperation
 from lightly.openapi_generated.swagger_client.models.selection_strategy_type import SelectionStrategyType
 
@@ -40,7 +47,7 @@ class SelectionConfigEntryStrategy(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v3.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v3.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v3_entry import SelectionConfigV3Entry
 
 class SelectionConfigV3(BaseModel):
@@ -37,7 +44,7 @@ class SelectionConfigV3(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v3_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v3_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v3_entry import SelectionConfigV3Entry
 
 class SelectionConfigV3AllOf(BaseModel):
@@ -35,7 +42,7 @@ class SelectionConfigV3AllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v3_entry_input import SelectionConfigV3EntryInput
 from lightly.openapi_generated.swagger_client.models.selection_config_v3_entry_strategy import SelectionConfigV3EntryStrategy
 
@@ -37,7 +44,7 @@ class SelectionConfigV3Entry(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_input.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_input.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_input_predictions_name import SelectionInputPredictionsName
 from lightly.openapi_generated.swagger_client.models.selection_input_type import SelectionInputType
 
@@ -84,7 +91,7 @@ class SelectionConfigV3EntryInput(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_strategy.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_strategy.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v3_entry_strategy_all_of_target_range import SelectionConfigV3EntryStrategyAllOfTargetRange
 from lightly.openapi_generated.swagger_client.models.selection_strategy_threshold_operation import SelectionStrategyThresholdOperation
 from lightly.openapi_generated.swagger_client.models.selection_strategy_type_v3 import SelectionStrategyTypeV3
@@ -46,7 +53,7 @@ class SelectionConfigV3EntryStrategy(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_strategy_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_strategy_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v3_entry_strategy_all_of_target_range import SelectionConfigV3EntryStrategyAllOfTargetRange
 from lightly.openapi_generated.swagger_client.models.selection_strategy_type_v3 import SelectionStrategyTypeV3
 
@@ -41,7 +48,7 @@ class SelectionConfigV3EntryStrategyAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_strategy_all_of_target_range.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v3_entry_strategy_all_of_target_range.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SelectionConfigV3EntryStrategyAllOfTargetRange(BaseModel):
     """
@@ -35,7 +42,7 @@ class SelectionConfigV3EntryStrategyAllOfTargetRange(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v4.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v4.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint, conlist, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v4_entry import SelectionConfigV4Entry
 
 class SelectionConfigV4(BaseModel):
@@ -38,7 +45,7 @@ class SelectionConfigV4(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v4_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v4_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, conlist, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conlist, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v4_entry import SelectionConfigV4Entry
 
 class SelectionConfigV4AllOf(BaseModel):
@@ -36,7 +43,7 @@ class SelectionConfigV4AllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v4_entry_input import SelectionConfigV4EntryInput
 from lightly.openapi_generated.swagger_client.models.selection_config_v4_entry_strategy import SelectionConfigV4EntryStrategy
 
@@ -37,7 +44,7 @@ class SelectionConfigV4Entry(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry_input.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry_input.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_input_predictions_name import SelectionInputPredictionsName
 from lightly.openapi_generated.swagger_client.models.selection_input_type import SelectionInputType
 
@@ -84,7 +91,7 @@ class SelectionConfigV4EntryInput(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry_strategy.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry_strategy.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr, confloat, conint, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr, confloat, conint, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr, confloat, conint, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_config_v3_entry_strategy_all_of_target_range import SelectionConfigV3EntryStrategyAllOfTargetRange
 from lightly.openapi_generated.swagger_client.models.selection_strategy_threshold_operation import SelectionStrategyThresholdOperation
 from lightly.openapi_generated.swagger_client.models.selection_strategy_type_v3 import SelectionStrategyTypeV3
@@ -57,7 +64,7 @@ class SelectionConfigV4EntryStrategy(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry_strategy_all_of.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_config_v4_entry_strategy_all_of.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.selection_strategy_type_v3 import SelectionStrategyTypeV3
 
 class SelectionConfigV4EntryStrategyAllOf(BaseModel):
@@ -46,7 +53,7 @@ class SelectionConfigV4EntryStrategyAllOf(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/selection_input_predictions_name.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_input_predictions_name.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SelectionInputPredictionsName(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/selection_input_type.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_input_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SelectionInputType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/selection_strategy_threshold_operation.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_strategy_threshold_operation.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SelectionStrategyThresholdOperation(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/selection_strategy_type.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_strategy_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SelectionStrategyType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/selection_strategy_type_v3.py
+++ b/lightly/openapi_generated/swagger_client/models/selection_strategy_type_v3.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SelectionStrategyTypeV3(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/service_account_basic_data.py
+++ b/lightly/openapi_generated/swagger_client/models/service_account_basic_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, constr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, constr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class ServiceAccountBasicData(BaseModel):
     """
@@ -37,7 +44,7 @@ class ServiceAccountBasicData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/set_embeddings_is_processed_flag_by_id_body_request.py
+++ b/lightly/openapi_generated/swagger_client/models/set_embeddings_is_processed_flag_by_id_body_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class SetEmbeddingsIsProcessedFlagByIdBodyRequest(BaseModel):
     """
@@ -34,7 +41,7 @@ class SetEmbeddingsIsProcessedFlagByIdBodyRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/shared_access_config_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/shared_access_config_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr, conlist
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conlist
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.creator import Creator
 from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
 
@@ -39,7 +46,7 @@ class SharedAccessConfigCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/shared_access_config_data.py
+++ b/lightly/openapi_generated/swagger_client/models/shared_access_config_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.shared_access_type import SharedAccessType
 
 class SharedAccessConfigData(BaseModel):
@@ -48,7 +55,7 @@ class SharedAccessConfigData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/shared_access_type.py
+++ b/lightly/openapi_generated/swagger_client/models/shared_access_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class SharedAccessType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/tag_active_learning_scores_data.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_active_learning_scores_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TagActiveLearningScoresData(BaseModel):
     """
@@ -58,7 +65,7 @@ class TagActiveLearningScoresData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_arithmetics_operation.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_arithmetics_operation.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class TagArithmeticsOperation(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/tag_arithmetics_request.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_arithmetics_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_arithmetics_operation import TagArithmeticsOperation
 from lightly.openapi_generated.swagger_client.models.tag_creator import TagCreator
 
@@ -75,7 +82,7 @@ class TagArithmeticsRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_arithmetics_response.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_arithmetics_response.py
@@ -20,11 +20,23 @@ import pprint
 import re  # noqa: F401
 
 from typing import Any, List, Optional
-from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, ValidationError, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.create_entity_response import CreateEntityResponse
 from lightly.openapi_generated.swagger_client.models.tag_bit_mask_response import TagBitMaskResponse
 from typing import Any, List
-from pydantic import StrictStr, Field, Extra
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import StrictStr, Field
+except ImportError:
+    # Pydantic v1
+    from pydantic import StrictStr, Field
 
 TAGARITHMETICSRESPONSE_ONE_OF_SCHEMAS = ["CreateEntityResponse", "TagBitMaskResponse"]
 
@@ -42,7 +54,7 @@ class TagArithmeticsResponse(BaseModel):
     class Config:
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/lightly/openapi_generated/swagger_client/models/tag_bit_mask_response.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_bit_mask_response.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TagBitMaskResponse(BaseModel):
     """
@@ -41,7 +48,7 @@ class TagBitMaskResponse(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_data_arithmetics import TagChangeDataArithmetics
 from lightly.openapi_generated.swagger_client.models.tag_change_data_initial import TagChangeDataInitial
 from lightly.openapi_generated.swagger_client.models.tag_change_data_metadata import TagChangeDataMetadata
@@ -50,7 +57,7 @@ class TagChangeData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_arithmetics.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_arithmetics.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TagChangeDataArithmetics(BaseModel):
     """
@@ -36,7 +43,7 @@ class TagChangeDataArithmetics(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_initial.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_initial.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TagChangeDataInitial(BaseModel):
     """
@@ -44,7 +51,7 @@ class TagChangeDataInitial(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_metadata.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_metadata.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Any, Dict, Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_data_operation_method import TagChangeDataOperationMethod
 
 class TagChangeDataMetadata(BaseModel):
@@ -39,7 +46,7 @@ class TagChangeDataMetadata(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_operation_method.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_operation_method.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class TagChangeDataOperationMethod(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_rename.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_rename.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TagChangeDataRename(BaseModel):
     """
@@ -35,7 +42,7 @@ class TagChangeDataRename(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_sampler.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_sampler.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TagChangeDataSampler(BaseModel):
     """
@@ -34,7 +41,7 @@ class TagChangeDataSampler(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_samples.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_samples.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_data_operation_method import TagChangeDataOperationMethod
 
 class TagChangeDataSamples(BaseModel):
@@ -38,7 +45,7 @@ class TagChangeDataSamples(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_scatterplot.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_scatterplot.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictStr, confloat, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, confloat, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_data_operation_method import TagChangeDataOperationMethod
 
 class TagChangeDataScatterplot(BaseModel):
@@ -39,7 +46,7 @@ class TagChangeDataScatterplot(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_data_upsize.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_data_upsize.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TagChangeDataUpsize(BaseModel):
     """
@@ -46,7 +53,7 @@ class TagChangeDataUpsize(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_change_entry.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_change_entry.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_data import TagChangeData
 from lightly.openapi_generated.swagger_client.models.tag_creator import TagCreator
 
@@ -39,7 +46,7 @@ class TagChangeEntry(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_create_request.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_create_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_data import TagChangeData
 from lightly.openapi_generated.swagger_client.models.tag_creator import TagCreator
 
@@ -95,7 +102,7 @@ class TagCreateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_creator.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_creator.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class TagCreator(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/tag_data.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import List, Optional
-from pydantic import Extra,  BaseModel, Field, StrictInt, conint, conlist, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictInt, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictInt, conint, conlist, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_entry import TagChangeEntry
 
 class TagData(BaseModel):
@@ -114,7 +121,7 @@ class TagData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_update_request.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_update_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_change_data import TagChangeData
 from lightly.openapi_generated.swagger_client.models.tag_creator import TagCreator
 
@@ -56,7 +63,7 @@ class TagUpdateRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/tag_upsize_request.py
+++ b/lightly/openapi_generated/swagger_client/models/tag_upsize_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.tag_creator import TagCreator
 
 class TagUpsizeRequest(BaseModel):
@@ -54,7 +61,7 @@ class TagUpsizeRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/task_annotation_savings.py
+++ b/lightly/openapi_generated/swagger_client/models/task_annotation_savings.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TaskAnnotationSavings(BaseModel):
     """
@@ -35,7 +42,7 @@ class TaskAnnotationSavings(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/task_type.py
+++ b/lightly/openapi_generated/swagger_client/models/task_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class TaskType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/team_basic_data.py
+++ b/lightly/openapi_generated/swagger_client/models/team_basic_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.team_role import TeamRole
 
 class TeamBasicData(BaseModel):
@@ -44,7 +51,7 @@ class TeamBasicData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/team_data.py
+++ b/lightly/openapi_generated/swagger_client/models/team_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr, conint, constr, validator
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr, conint, constr, validator
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class TeamData(BaseModel):
     """
@@ -44,7 +51,7 @@ class TeamData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/team_role.py
+++ b/lightly/openapi_generated/swagger_client/models/team_role.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class TeamRole(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/trigger2d_embedding_job_request.py
+++ b/lightly/openapi_generated/swagger_client/models/trigger2d_embedding_job_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.dimensionality_reduction_method import DimensionalityReductionMethod
 
 class Trigger2dEmbeddingJobRequest(BaseModel):
@@ -35,7 +42,7 @@ class Trigger2dEmbeddingJobRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/update_docker_worker_registry_entry_request.py
+++ b/lightly/openapi_generated/swagger_client/models/update_docker_worker_registry_entry_request.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.docker_worker_state import DockerWorkerState
 
 class UpdateDockerWorkerRegistryEntryRequest(BaseModel):
@@ -36,7 +43,7 @@ class UpdateDockerWorkerRegistryEntryRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/update_team_membership_request.py
+++ b/lightly/openapi_generated/swagger_client/models/update_team_membership_request.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 from lightly.openapi_generated.swagger_client.models.team_role import TeamRole
 
 class UpdateTeamMembershipRequest(BaseModel):
@@ -35,7 +42,7 @@ class UpdateTeamMembershipRequest(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/user_type.py
+++ b/lightly/openapi_generated/swagger_client/models/user_type.py
@@ -20,7 +20,14 @@ from enum import Enum
 from aenum import no_arg  # type: ignore
 
 
-
+try:
+    # Pydantic >=v1.10.17
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 
 class UserType(str, Enum):

--- a/lightly/openapi_generated/swagger_client/models/video_frame_data.py
+++ b/lightly/openapi_generated/swagger_client/models/video_frame_data.py
@@ -20,7 +20,14 @@ import json
 
 
 from typing import Optional, Union
-from pydantic import Extra,  BaseModel, Field, StrictFloat, StrictInt, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class VideoFrameData(BaseModel):
     """
@@ -36,7 +43,7 @@ class VideoFrameData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/worker_information.py
+++ b/lightly/openapi_generated/swagger_client/models/worker_information.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class WorkerInformation(BaseModel):
     """
@@ -35,7 +42,7 @@ class WorkerInformation(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/lightly/openapi_generated/swagger_client/models/write_csv_url_data.py
+++ b/lightly/openapi_generated/swagger_client/models/write_csv_url_data.py
@@ -20,7 +20,14 @@ import json
 
 
 
-from pydantic import Extra,  BaseModel, Field, StrictStr
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
+except ImportError:
+    # Pydantic v1
+    from pydantic import BaseModel, Field, StrictStr
+    pass # Add pass to avoid empty try/except if no imports are generated for this file.
 
 class WriteCSVUrlData(BaseModel):
     """
@@ -35,7 +42,7 @@ class WriteCSVUrlData(BaseModel):
         allow_population_by_field_name = True
         validate_assignment = True
         use_enum_values = True
-        extra = Extra.forbid
+        extra = "forbid"
 
     def to_str(self, by_alias: bool = False) -> str:
         """Returns the string representation of the model"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "tqdm>=4.44",
   "torch",
   "torchvision",
-  "pydantic >= 1.10.5, < 2",
+  "pydantic >= 1.10.5",
   # Note: pytorch_lightning>=1.5 is required for CLI
   # https://github.com/lightly-ai/lightly/issues/912
   "pytorch_lightning>=1.0.4",
@@ -131,7 +131,7 @@ openapi = [
   "python_dateutil >= 2.5.3",
   "setuptools >= 21.0.0",
   "urllib3 >= 1.25.3",
-  "pydantic >= 1.10.5, < 2",
+  "pydantic >= 1.10.5",
   "aenum >= 3.1.11"
 ]
 video = ["av>=8.0.3"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,5 +9,5 @@ requests>=2.23.0
 six>=1.10
 tqdm>=4.44
 urllib3 >= 1.25.3
-pydantic >= 1.10.5, < 2
+pydantic >= 1.10.5
 aenum >= 3.1.11

--- a/requirements/openapi.txt
+++ b/requirements/openapi.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3
-pydantic >= 1.10.5, < 2
+pydantic >= 1.10.5
 aenum >= 3.1.11

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -5,7 +5,14 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import ValidationError
+
+try:
+    # Pydantic >=v1.10.17
+    from pydantic.v1 import ValidationError
+except ImportError:
+    # Pydantic v1
+    from pydantic import ValidationError
+
 from pytest_mock import MockerFixture
 
 from lightly.api import ApiWorkflowClient, api_workflow_compute_worker


### PR DESCRIPTION
## Changes

* Add support for pydantic v2
* Use pydantic v1 internally

Closes #1526 

This allows installing lightly in an environment with Pydantic v2. Internally we still use Pydantic v1 for the API client (using `from pydantic.v1 import`).

## How was it tested?

* CI
* Ran our Lightly Worker e2e tests with the new client and Pydantic v2 installed.