### PR TITLE
LIG-5222 Allow skipping weight initialisation for Masked Vision Transformers

### DIFF
--- a/lightly/models/modules/masked_autoencoder_timm.py
+++ b/lightly/models/modules/masked_autoencoder_timm.py
@@ -62,7 +62,7 @@ class MAEDecoderTIMM(Module):
         proj_drop_rate: float = 0.0,
         attn_drop_rate: float = 0.0,
         norm_layer: Callable[..., nn.Module] = partial(LayerNorm, eps=1e-6),
-        initialize_weights: bool = False,
+        initialize_weights: bool = True,
         mask_token: Optional[Parameter] = None,
     ):
         super().__init__()

--- a/lightly/models/modules/masked_autoencoder_timm.py
+++ b/lightly/models/modules/masked_autoencoder_timm.py
@@ -42,6 +42,8 @@ class MAEDecoderTIMM(Module):
             Percentage of elements set to zero after the attention head.
         norm_layer:
             Normalization layer.
+        initialize_weights:
+            Flag that determines if weights should be initialized.
         mask_token:
             The mask token.
 
@@ -60,6 +62,7 @@ class MAEDecoderTIMM(Module):
         proj_drop_rate: float = 0.0,
         attn_drop_rate: float = 0.0,
         norm_layer: Callable[..., nn.Module] = partial(LayerNorm, eps=1e-6),
+        initialize_weights: bool = False,
         mask_token: Optional[Parameter] = None,
     ):
         super().__init__()
@@ -96,7 +99,8 @@ class MAEDecoderTIMM(Module):
             decoder_embed_dim, patch_size**2 * in_chans, bias=True
         )  # decoder to patch
 
-        self._initialize_weights()
+        if initialize_weights:
+            self._initialize_weights()
 
     def forward(self, input: Tensor) -> Tensor:
         """Returns predicted pixel values from encoded tokens.

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -26,7 +26,7 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
     def __init__(
         self,
         vit: VisionTransformer,
-        initialize_weights: bool = False,
+        initialize_weights: bool = True,
         mask_token: Optional[Parameter] = None,
     ) -> None:
         super().__init__()

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -26,6 +26,7 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
     def __init__(
         self,
         vit: VisionTransformer,
+        initialize_weights: bool = False,
         mask_token: Optional[Parameter] = None,
     ) -> None:
         super().__init__()
@@ -35,7 +36,8 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
             if mask_token is not None
             else Parameter(torch.zeros(1, 1, self.vit.embed_dim))
         )
-        self._initialize_weights()
+        if initialize_weights:
+            self._initialize_weights()
 
     @property
     def sequence_length(self) -> int:

--- a/lightly/models/modules/masked_vision_transformer_torchvision.py
+++ b/lightly/models/modules/masked_vision_transformer_torchvision.py
@@ -25,7 +25,7 @@ class MaskedVisionTransformerTorchvision(MaskedVisionTransformer, Module):
     def __init__(
         self,
         vit: VisionTransformer,
-        initialize_weights: bool = False,
+        initialize_weights: bool = True,
         mask_token: Optional[Parameter] = None,
     ) -> None:
         super().__init__()

--- a/lightly/models/modules/masked_vision_transformer_torchvision.py
+++ b/lightly/models/modules/masked_vision_transformer_torchvision.py
@@ -25,6 +25,7 @@ class MaskedVisionTransformerTorchvision(MaskedVisionTransformer, Module):
     def __init__(
         self,
         vit: VisionTransformer,
+        initialize_weights: bool = False,
         mask_token: Optional[Parameter] = None,
     ) -> None:
         super().__init__()
@@ -34,7 +35,8 @@ class MaskedVisionTransformerTorchvision(MaskedVisionTransformer, Module):
             if mask_token is not None
             else Parameter(torch.zeros(1, 1, self.vit.hidden_dim))
         )
-        self._initialize_weights()
+        if initialize_weights:
+            self._initialize_weights()
 
     @property
     def sequence_length(self) -> int:


### PR DESCRIPTION
Addresses issue #1511 and allows to skip weight initialization for  `MaskedVisionTransformerTIMM`, `MaskedVisionTransformerTorchvision` and `MAEDecoderTIMM`. This will enable to load a pretrained vit model.