### PR TITLE
Fix masking ratio calculation

### DIFF
--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -301,20 +301,22 @@ class TestModelUtils(unittest.TestCase):
 
 
 @pytest.mark.parametrize(
-    "mask_class_token, expected_num_masked",
+    "seq_length, mask_ratio, mask_class_token, expected_num_masked",
     [
-        (False, 2),
-        (True, 3),
+        (5, 0.5, False, 2),
+        (5, 0.5, True, 3),
+        (257, 0.75, False, 192),  # From issue #1583
+        (257, 0.75, True, 193),  # From issue #1583
     ],
 )
 def test_random_token_mask__mask_class_token(
-    mask_class_token: bool, expected_num_masked: int
+    seq_length: int, mask_ratio: float, mask_class_token: bool, expected_num_masked: int
 ) -> None:
     torch.manual_seed(0)
-    batch_size, seq_length = 2, 5
+    batch_size = 2
     idx_keep, idx_mask = utils.random_token_mask(
         size=(batch_size, seq_length),
-        mask_ratio=0.5,
+        mask_ratio=mask_ratio,
         mask_class_token=mask_class_token,
     )
     assert idx_mask.shape == (batch_size, expected_num_masked)

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -300,6 +300,27 @@ class TestModelUtils(unittest.TestCase):
         self._test_random_token_mask_parameters(device="cuda")
 
 
+@pytest.mark.parametrize(
+    "mask_class_token, expected_num_masked",
+    [
+        (False, 2),
+        (True, 3),
+    ],
+)
+def test_random_token_mask__mask_class_token(
+    mask_class_token: bool, expected_num_masked: int
+) -> None:
+    torch.manual_seed(0)
+    batch_size, seq_length = 2, 5
+    idx_keep, idx_mask = utils.random_token_mask(
+        size=(batch_size, seq_length),
+        mask_ratio=0.5,
+        mask_class_token=mask_class_token,
+    )
+    assert idx_mask.shape == (batch_size, expected_num_masked)
+    assert idx_keep.shape == (batch_size, seq_length - expected_num_masked)
+
+
 def test_get_weight_decay_parameters() -> None:
     linear = nn.Linear(10, 10)
     batch_norm1d = nn.BatchNorm1d(10)


### PR DESCRIPTION
## Changes
* Handle class token correctly in mask ratio calculation

Closes #1583

Fixes an issue where too many tokens were masked because the class token was included in the calculation for the number of masked tokens.

The new behavior is:
* If `mask_class_token=True`: Calculate number of masked tokens based on full sequence length and potentially mask class token
* If `mask_class_token=False`: Calculate number of masked tokens based on sequence length without the class token and never mask the class token

The original MAE code also calculates the masking ratio without the class token, see: https://github.com/facebookresearch/mae/blob/efb2a8062c206524e35e47d04501ed4f544c0ae8/models_mae.py#L130

## How was it tested?
* Added unit test
