### PR TITLE
Fix MemoryBank Gather Distributed with Single GPU

### DIFF
--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -11,6 +11,7 @@ from torch import Tensor
 from torch.nn import Module
 
 from lightly.models import utils
+from lightly.utils import dist
 
 
 class MemoryBankModule(Module):
@@ -119,7 +120,7 @@ class MemoryBankModule(Module):
                 The latest batch of keys to add to the memory bank.
 
         """
-        if self.gather_distributed:
+        if self.gather_distributed and dist.world_size() > 1:
             batch = utils.concat_all_gather(batch)
 
         batch_size = batch.shape[0]


### PR DESCRIPTION
## Changes

* Fix distributed error when setting gather_distributed=True in MemoryBank but training with single GPU

## How has it been tested?
* Ran MoCo example with `gather_distributed=True`

Error before fix:
```
Epoch 0:   0%|                                                                                                                                                                                                       | 0/195 [00:00<?, ?it/s]Traceback (most recent call last):
  File "examples/pytorch_lightning_distributed/moco.py", line 88, in <module>
...
  File "/home/ubuntu/.local/lib/python3.8/site-packages/torch/distributed/distributed_c10d.py", line 707, in _get_default_group
    raise RuntimeError(
RuntimeError: Default process group has not been initialized, please make sure to call init_process_group.
```

No more error after the fix :)

Didn't add a unit test because this scenario is difficult to test.