### PR TITLE
Add uniform drop path rate for timm ViT

### DIFF
--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -6,17 +6,7 @@ from __future__ import annotations
 
 import math
 import warnings
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    Iterable,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -867,7 +867,7 @@ def normalize_mean_var(x: Tensor, dim: int = -1, eps: float = 1.0e-6) -> Tensor:
 def update_drop_path_rate(
     model: VisionTransformer,
     drop_path_rate: float,
-    mode: Literal["linear", "uniform"] = "linear",
+    mode: str = "linear",
 ) -> None:
     """Updates the drop path rate in a TIMM VisionTransformer model.
 
@@ -889,7 +889,9 @@ def update_drop_path_rate(
     elif mode == "uniform":
         drop_probabilities = [drop_path_rate for _ in range(total_depth)]
     else:
-        raise ValueError(f"Unknown mode: {mode}")
+        raise ValueError(
+            f"Unknown mode: '{mode}', supported modes are 'linear' and 'uniform'."
+        )
 
     for block, drop_prob in zip(model.blocks, drop_probabilities):
         if drop_prob > 0.0:

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -2,10 +2,21 @@
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
+from __future__ import annotations
 
 import math
 import warnings
-from typing import Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 import torch
@@ -13,13 +24,16 @@ import torch.distributed as dist
 import torch.nn as nn
 from numpy.typing import NDArray
 from torch import Tensor
-from torch.nn import Module, Sequential, functional
+from torch.nn import Identity, Module, Sequential, functional
 from torch.nn.modules import CrossMapLRN2d, GroupNorm, LayerNorm, LocalResponseNorm
 from torch.nn.modules.batchnorm import _NormBase
 from torch.nn.parameter import Parameter
 from torchvision.ops import StochasticDepth
 
 from lightly.utils import dependency
+
+if TYPE_CHECKING:
+    from timm.models.vision_transformer import VisionTransformer
 
 
 @torch.no_grad()
@@ -848,3 +862,39 @@ def normalize_mean_var(x: Tensor, dim: int = -1, eps: float = 1.0e-6) -> Tensor:
     mean = x.mean(dim=dim, keepdim=True)
     var = x.var(dim=dim, keepdim=True)
     return (x - mean) / (var + eps).sqrt()
+
+
+def update_drop_path_rate(
+    model: VisionTransformer,
+    drop_path_rate: float,
+    mode: Literal["linear", "uniform"] = "linear",
+) -> None:
+    """Updates the drop path rate in a TIMM VisionTransformer model.
+
+    Args:
+        model:
+            TIMM VisionTransformer model.
+        drop_path_rate:
+            Maximum drop path rate.
+        mode:
+            Drop path rate update mode. Can be "linear" or "uniform". Linear increases
+            the drop path rate from 0 to drop_path_rate over the depth of the model.
+            Uniform sets the drop path rate to drop_path_rate for all blocks.
+    """
+    from timm.layers import DropPath
+
+    total_depth = len(model.blocks)
+    if mode == "linear":
+        drop_probabilities = np.linspace(0, drop_path_rate, total_depth)
+    elif mode == "uniform":
+        drop_probabilities = [drop_path_rate for _ in range(total_depth)]
+    else:
+        raise ValueError(f"Unknown mode: {mode}")
+
+    for block, drop_prob in zip(model.blocks, drop_probabilities):
+        if drop_prob > 0.0:
+            block.drop_path1 = DropPath(drop_prob=drop_path_rate)
+            block.drop_path2 = DropPath(drop_prob=drop_path_rate)
+        else:
+            block.drop_path1 = Identity()
+            block.drop_path2 = Identity()

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -579,3 +579,12 @@ def test_update_drop_path_rate__linear() -> None:
     ]:
         assert isinstance(drop_path, DropPath)
         assert drop_path.drop_prob == 0.1
+
+
+def test_update_drop_path_rate__unknown_mode() -> None:
+    pytest.importorskip("timm.models.vision_transformer")
+    from timm.models.vision_transformer import VisionTransformer
+
+    model = VisionTransformer(drop_path_rate=0, depth=4)
+    with pytest.raises(ValueError, match="Unknown mode"):
+        utils.update_drop_path_rate(model=model, drop_path_rate=0.1, mode="unknown")

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -5,6 +5,7 @@ from typing import List
 import pytest
 import torch
 import torch.nn as nn
+from torch.nn import Identity
 
 from lightly.models import utils
 from lightly.models.utils import (
@@ -538,3 +539,43 @@ def test_normalize_mean_var() -> None:
     norm = utils.normalize_mean_var(x)
     assert torch.allclose(norm.mean(dim=-1), torch.tensor(0.0), rtol=0.0001, atol=1e-5)
     assert torch.allclose(norm.var(dim=-1), torch.tensor(1.0), rtol=0.0001, atol=1e-5)
+
+
+def test_update_drop_path_rate__uniform() -> None:
+    pytest.importorskip("timm.models.vision_transformer")
+    from timm.layers import DropPath
+    from timm.models.vision_transformer import VisionTransformer
+
+    model = VisionTransformer(drop_path_rate=0.2, depth=4)
+    utils.update_drop_path_rate(model=model, drop_path_rate=0.1, mode="uniform")
+
+    for drop_path in [
+        model.blocks[0].drop_path1,
+        model.blocks[0].drop_path2,
+        model.blocks[-1].drop_path1,
+        model.blocks[-1].drop_path2,
+    ]:
+        assert isinstance(drop_path, DropPath)
+        assert drop_path.drop_prob == 0.1
+
+
+def test_update_drop_path_rate__linear() -> None:
+    pytest.importorskip("timm.models.vision_transformer")
+    from timm.layers import DropPath
+    from timm.models.vision_transformer import VisionTransformer
+
+    model = VisionTransformer(drop_path_rate=0, depth=4)
+    utils.update_drop_path_rate(model=model, drop_path_rate=0.1, mode="linear")
+
+    for drop_path in [
+        model.blocks[0].drop_path1,
+        model.blocks[0].drop_path2,
+    ]:
+        assert isinstance(drop_path, Identity)
+
+    for drop_path in [
+        model.blocks[-1].drop_path1,
+        model.blocks[-1].drop_path2,
+    ]:
+        assert isinstance(drop_path, DropPath)
+        assert drop_path.drop_prob == 0.1


### PR DESCRIPTION
## Changes

* Add function to set uniform drop path rates for TIMM ViT

This corresponds to: https://github.com/facebookresearch/dinov2/blob/e1277af2ba9496fbadf7aec6eba56e8d882d1e35/dinov2/models/vision_transformer.py#L116-L119

We'll use it like this:
```
vit = timm.VisionTransformer()
update_drop_path_rate(vit, drop_path_rate=0.1, mode="uniform")
masked_vit = MaskedVisionTransformerTIMM(vit)
```

Maybe I'll also add it as an extra argument to `MaskedVisionTransformerTIMM` instead, so it can be used like:
```
vit = timm.VisionTransformer()
masked_vit = MaskedVisionTransformerTIMM(vit, drop_path_rate=0.1, drop_path_mode="uniform")
```


## How was it tested?
* Added unit tests