### PR TITLE
Add timm optional dependency

### DIFF
--- a/docs/source/examples/mae.rst
+++ b/docs/source/examples/mae.rst
@@ -22,7 +22,7 @@ Reference:
 
     .. code-block:: bash
 
-        pip install "timm>=0.9.9"
+        pip install "lightly[timm]"
 
 .. tabs::
     .. tab:: PyTorch

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -30,14 +30,14 @@ If you want to work with video files you need to additionally install
 
 .. code-block:: bash
 
-    pip install av
+    pip install "lightly[video]"
 
-If you want to work use the Masked Autoencoder you need to additionally install
+If you want to work with the Masked Autoencoder you need to additionally install
 `TIMM <https://github.com/huggingface/pytorch-image-models>`_.
 
 .. code-block:: bash
 
-    pip install "timm>=0.9.9"
+    pip install "lightly[timm]"
 
 Next Steps
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dynamic = ["version", "readme"]
 
 [project.optional-dependencies]
 all = [
-  "lightly[dev, video]"
+  "lightly[dev,timm,video]"
 ]
 dev = [
   "tox",
@@ -134,6 +134,7 @@ openapi = [
   "pydantic >= 1.10.5",
   "aenum >= 3.1.11"
 ]
+timm = ["timm>=1.0.3"]
 video = ["av>=8.0.3"]
 
 [project.urls]

--- a/tests/models/modules/test_masked_autoencoder_timm.py
+++ b/tests/models/modules/test_masked_autoencoder_timm.py
@@ -1,108 +1,115 @@
 import unittest
 
+import pytest
 import torch
 
 from lightly.models import utils
 from lightly.utils import dependency
 
-if dependency.timm_vit_available():
-    from timm.models.vision_transformer import VisionTransformer, vit_base_patch32_224
+if not dependency.timm_vit_available():
+    # We do not use pytest.importorskip on module level because it makes mypy unhappy.
+    pytest.skip("TIMM vision transformer is not available", allow_module_level=True)
 
-    from lightly.models.modules import MAEDecoderTIMM, MaskedVisionTransformerTIMM
 
-    class TestMaskedVisionTransformerTIMM(unittest.TestCase):
-        def _vit(self) -> VisionTransformer:
-            return vit_base_patch32_224()
+from timm.models.vision_transformer import VisionTransformer, vit_base_patch32_224
 
-        def test_from_vit(self) -> None:
-            MaskedVisionTransformerTIMM(vit=self._vit())
+from lightly.models.modules import MAEDecoderTIMM, MaskedVisionTransformerTIMM
 
-        def _test_forward(
-            self, device: torch.device, batch_size: int = 8, seed: int = 0
-        ) -> None:
-            torch.manual_seed(seed)
-            vit = self._vit()
-            backbone = MaskedVisionTransformerTIMM(vit=vit).to(device)
-            images = torch.rand(
-                batch_size, 3, vit.patch_embed.img_size[0], vit.patch_embed.img_size[0]
-            ).to(device)
-            _idx_keep, _ = utils.random_token_mask(
-                size=(batch_size, backbone.sequence_length),
-                device=device,
-            )
-            for idx_keep in [None, _idx_keep]:
-                with self.subTest(idx_keep=idx_keep):
-                    class_tokens = backbone(images=images, idx_keep=idx_keep)
 
-                    # output shape must be correct
-                    expected_shape = [batch_size, vit.embed_dim]
-                    self.assertListEqual(list(class_tokens.shape), expected_shape)
+class TestMaskedVisionTransformerTIMM(unittest.TestCase):
+    def _vit(self) -> VisionTransformer:
+        return vit_base_patch32_224()
 
-                    # output must have reasonable numbers
-                    self.assertTrue(torch.all(torch.not_equal(class_tokens, torch.inf)))
+    def test_from_vit(self) -> None:
+        MaskedVisionTransformerTIMM(vit=self._vit())
 
-        def test_forward(self) -> None:
-            self._test_forward(torch.device("cpu"))
+    def _test_forward(
+        self, device: torch.device, batch_size: int = 8, seed: int = 0
+    ) -> None:
+        torch.manual_seed(seed)
+        vit = self._vit()
+        backbone = MaskedVisionTransformerTIMM(vit=vit).to(device)
+        images = torch.rand(
+            batch_size, 3, vit.patch_embed.img_size[0], vit.patch_embed.img_size[0]
+        ).to(device)
+        _idx_keep, _ = utils.random_token_mask(
+            size=(batch_size, backbone.sequence_length),
+            device=device,
+        )
+        for idx_keep in [None, _idx_keep]:
+            with self.subTest(idx_keep=idx_keep):
+                class_tokens = backbone(images=images, idx_keep=idx_keep)
 
-        @unittest.skipUnless(torch.cuda.is_available(), "Cuda not available.")
-        def test_forward_cuda(self) -> None:
-            self._test_forward(torch.device("cuda"))
+                # output shape must be correct
+                expected_shape = [batch_size, vit.embed_dim]
+                self.assertListEqual(list(class_tokens.shape), expected_shape)
 
-        def test_images_to_tokens(self) -> None:
-            torch.manual_seed(0)
-            vit = self._vit()
-            backbone = MaskedVisionTransformerTIMM(vit=vit)
-            images = torch.rand(2, 3, 224, 224)
-            assert torch.all(
-                vit.patch_embed(images) == backbone.images_to_tokens(images=images)
-            )
+                # output must have reasonable numbers
+                self.assertTrue(torch.all(torch.not_equal(class_tokens, torch.inf)))
 
-    class TestMAEDecoderTIMM(unittest.TestCase):
-        def test_init(self) -> None:
-            MAEDecoderTIMM(
-                num_patches=49,
-                patch_size=32,
-                embed_dim=128,
-                decoder_embed_dim=256,
-                decoder_depth=2,
-                decoder_num_heads=4,
-                mlp_ratio=4.0,
-                proj_drop_rate=0.0,
-                attn_drop_rate=0.0,
-            )
+    def test_forward(self) -> None:
+        self._test_forward(torch.device("cpu"))
 
-        def _test_forward(
-            self, device: torch.device, batch_size: int = 8, seed: int = 0
-        ) -> None:
-            torch.manual_seed(seed)
-            seq_length = 50
-            embed_input_dim = 128
-            patch_size = 32
-            out_dim = 3 * patch_size**2
-            decoder = MAEDecoderTIMM(
-                num_patches=49,
-                patch_size=32,
-                embed_dim=embed_input_dim,
-                decoder_embed_dim=256,
-                decoder_depth=2,
-                decoder_num_heads=4,
-                mlp_ratio=4.0,
-                proj_drop_rate=0.0,
-                attn_drop_rate=0.0,
-            ).to(device)
-            tokens = torch.rand(batch_size, seq_length, embed_input_dim).to(device)
-            predictions = decoder(tokens)
+    @unittest.skipUnless(torch.cuda.is_available(), "Cuda not available.")
+    def test_forward_cuda(self) -> None:
+        self._test_forward(torch.device("cuda"))
 
-            # output shape must be correct
-            expected_shape = [batch_size, seq_length, out_dim]
-            self.assertListEqual(list(predictions.shape), expected_shape)
+    def test_images_to_tokens(self) -> None:
+        torch.manual_seed(0)
+        vit = self._vit()
+        backbone = MaskedVisionTransformerTIMM(vit=vit)
+        images = torch.rand(2, 3, 224, 224)
+        assert torch.all(
+            vit.patch_embed(images) == backbone.images_to_tokens(images=images)
+        )
 
-            # output must have reasonable numbers
-            self.assertTrue(torch.all(torch.not_equal(predictions, torch.inf)))
 
-        def test_forward(self) -> None:
-            self._test_forward(torch.device("cpu"))
+class TestMAEDecoderTIMM(unittest.TestCase):
+    def test_init(self) -> None:
+        MAEDecoderTIMM(
+            num_patches=49,
+            patch_size=32,
+            embed_dim=128,
+            decoder_embed_dim=256,
+            decoder_depth=2,
+            decoder_num_heads=4,
+            mlp_ratio=4.0,
+            proj_drop_rate=0.0,
+            attn_drop_rate=0.0,
+        )
 
-        @unittest.skipUnless(torch.cuda.is_available(), "Cuda not available.")
-        def test_forward_cuda(self) -> None:
-            self._test_forward(torch.device("cuda"))
+    def _test_forward(
+        self, device: torch.device, batch_size: int = 8, seed: int = 0
+    ) -> None:
+        torch.manual_seed(seed)
+        seq_length = 50
+        embed_input_dim = 128
+        patch_size = 32
+        out_dim = 3 * patch_size**2
+        decoder = MAEDecoderTIMM(
+            num_patches=49,
+            patch_size=32,
+            embed_dim=embed_input_dim,
+            decoder_embed_dim=256,
+            decoder_depth=2,
+            decoder_num_heads=4,
+            mlp_ratio=4.0,
+            proj_drop_rate=0.0,
+            attn_drop_rate=0.0,
+        ).to(device)
+        tokens = torch.rand(batch_size, seq_length, embed_input_dim).to(device)
+        predictions = decoder(tokens)
+
+        # output shape must be correct
+        expected_shape = [batch_size, seq_length, out_dim]
+        self.assertListEqual(list(predictions.shape), expected_shape)
+
+        # output must have reasonable numbers
+        self.assertTrue(torch.all(torch.not_equal(predictions, torch.inf)))
+
+    def test_forward(self) -> None:
+        self._test_forward(torch.device("cpu"))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Cuda not available.")
+    def test_forward_cuda(self) -> None:
+        self._test_forward(torch.device("cuda"))


### PR DESCRIPTION
## Changes

* Add timm as optional dependency to pyproject.toml
* Increase timm version from 0.9.9 to 1.0.3
  * 0.9.9 is still supported but now that timm 1.0 is out we should encourage installing a >1 version

## How was it tested?

* Ran tests and type-check locally with and without timm
