### PR TITLE
feat: add ability to return intermediates

### DIFF
--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -82,9 +82,9 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
     def forward_intermediates(
         self,
         images: Tensor,
-        norm: bool = False,
         idx_mask: Optional[Tensor] = None,
         idx_keep: Optional[Tensor] = None,
+        norm: bool = False,
     ) -> Tuple[Tensor, List[Tensor]]:
         """Encode input images and return features from the intermediate layers.
 

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -183,7 +183,9 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
             Batch of encoded output tokens.
         """
         # preprocess images, convert to tokens and add positional embeddings
-        tokens: Tensor = self.preprocess(images=images, idx_mask=idx_mask, idx_keep=idx_keep)
+        tokens: Tensor = self.preprocess(
+            images=images, idx_mask=idx_mask, idx_keep=idx_keep
+        )
         # normalization layer
         tokens = self.vit.norm_pre(tokens)
         # apply Transformer blocks

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -183,13 +183,13 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
             Batch of encoded output tokens.
         """
         # preprocess images, convert to tokens and add positional embeddings
-        tokens = self.preprocess(images=images, idx_mask=idx_mask, idx_keep=idx_keep)
+        tokens: Tensor = self.preprocess(images=images, idx_mask=idx_mask, idx_keep=idx_keep)
         # normalization layer
         tokens = self.vit.norm_pre(tokens)
         # apply Transformer blocks
         tokens = self.vit.blocks(tokens)
         # normalize
-        tokens: Tensor = self.vit.norm(tokens)
+        tokens = self.vit.norm(tokens)
         return tokens
 
     def images_to_tokens(self, images: Tensor) -> Tensor:

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 import torch.nn as nn

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -24,10 +24,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
     """
 
     def __init__(
-            self,
-            vit: VisionTransformer,
-            initialize_weights: bool = True,
-            mask_token: Optional[Parameter] = None,
+        self,
+        vit: VisionTransformer,
+        initialize_weights: bool = True,
+        mask_token: Optional[Parameter] = None,
     ) -> None:
         super().__init__()
         self.vit = vit
@@ -45,10 +45,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
         return seq_len
 
     def forward(
-            self,
-            images: Tensor,
-            idx_mask: Optional[Tensor] = None,
-            idx_keep: Optional[Tensor] = None,
+        self,
+        images: Tensor,
+        idx_mask: Optional[Tensor] = None,
+        idx_keep: Optional[Tensor] = None,
     ) -> Tensor:
         """Returns encoded class tokens from a batch of images.
 
@@ -80,10 +80,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
         return x
 
     def forward_intermediates(
-            self,
-            images: Tensor,
-            idx_mask: Optional[Tensor] = None,
-            idx_keep: Optional[Tensor] = None,
+        self,
+        images: Tensor,
+        idx_mask: Optional[Tensor] = None,
+        idx_keep: Optional[Tensor] = None,
     ) -> List[Tensor]:
         """Encode input images.
 
@@ -116,10 +116,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
         return intermediates
 
     def preprocess(
-            self,
-            images: Tensor,
-            idx_mask: Optional[Tensor] = None,
-            idx_keep: Optional[Tensor] = None,
+        self,
+        images: Tensor,
+        idx_mask: Optional[Tensor] = None,
+        idx_keep: Optional[Tensor] = None,
     ) -> Tensor:
         """
         preprocess images, convert to tokens and add positional embeddings
@@ -156,10 +156,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer, Module):
         return tokens
 
     def encode(
-            self,
-            images: Tensor,
-            idx_mask: Optional[Tensor] = None,
-            idx_keep: Optional[Tensor] = None,
+        self,
+        images: Tensor,
+        idx_mask: Optional[Tensor] = None,
+        idx_keep: Optional[Tensor] = None,
     ) -> Tensor:
         """Encode input images.
 

--- a/tests/models/modules/test_masked_autoencoder_timm.py
+++ b/tests/models/modules/test_masked_autoencoder_timm.py
@@ -54,6 +54,42 @@ class TestMaskedVisionTransformerTIMM(unittest.TestCase):
     def test_forward_cuda(self) -> None:
         self._test_forward(torch.device("cuda"))
 
+    def _test_forward_intermediates(
+            self, device: torch.device, batch_size: int = 8, seed: int = 0
+    ) -> None:
+        torch.manual_seed(seed)
+        vit = self._vit()
+        backbone = MaskedVisionTransformerTIMM(vit=vit).to(device)
+        images = torch.rand(
+            batch_size, 3, vit.patch_embed.img_size[0], vit.patch_embed.img_size[0]
+        ).to(device)
+        _idx_keep, _ = utils.random_token_mask(
+            size=(batch_size, backbone.sequence_length),
+            device=device,
+        )
+        for idx_keep in [None, _idx_keep]:
+            with self.subTest(idx_keep=idx_keep):
+                class_tokens = backbone(images=images, idx_keep=idx_keep)
+
+                # output shape must be correct
+                expected_shape = [batch_size, vit.embed_dim]
+                self.assertListEqual(list(class_tokens.shape), expected_shape)
+
+                intermediates = backbone.forward_intermediates(
+                    images=images, idx_keep=idx_keep
+                )
+                self.assertTrue(len(intermediates) == len(vit.blocks))
+
+                # output must have reasonable numbers
+                self.assertTrue(torch.all(torch.not_equal(class_tokens, torch.inf)))
+
+    def test_forward_intermediates(self) -> None:
+        self._test_forward_intermediates(torch.device("cpu"))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Cuda not available.")
+    def test_forward_intermediates_cuda(self) -> None:
+        self._test_forward_intermediates(torch.device("cuda"))
+
     def test_images_to_tokens(self) -> None:
         torch.manual_seed(0)
         vit = self._vit()


### PR DESCRIPTION
* Add the ability to return intermediate representations from Masked Vision Transformers.
* Fixes docstring reference to `images` (was `input` earlier)
* Rename some variables so as to not shadow builtin name `input`