### PR TITLE
chore(pre-commit): add linters in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,15 +6,15 @@ repos:
   - id: check-added-large-files # prevent commit of files >500kB
     args: ['--maxkb=500']
 - repo: https://github.com/psf/black
-  rev: 23.1.0
+  rev: 23.1.0  # aligned with the version defined in pyproject.toml
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.5
+  rev: 5.11.5  # aligned with the version defined in pyproject.toml
   hooks:
   - id: isort
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.4.1
+  rev: v1.4.1  # aligned with the version defined in pyproject.toml
   hooks:
   - id: mypy
 - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,18 @@ repos:
   - id: detect-private-key      # check for private keys
   - id: check-added-large-files # prevent commit of files >500kB
     args: ['--maxkb=500']
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+  - id: black
+- repo: https://github.com/pycqa/isort
+  rev: 5.11.5
+  hooks:
+  - id: isort
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.4.1
+  hooks:
+  - id: mypy
 - repo: local
   hooks:
   - id: pytest-check                     # run all tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dev = [
   "toml",
   "torchmetrics",
   "lightning-bolts", # for LARS optimizer
+  # should be the same version as defined in .pre-commit-config.yaml
   "black==23.1.0", # frozen version to avoid differences between CI and local dev machines
   "isort==5.11.5", # frozen version to avoid differences between CI and local dev machines
   "mypy==1.4.1", # frozen version to avoid differences between CI and local dev machines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dev = [
   "toml",
   "torchmetrics",
   "lightning-bolts", # for LARS optimizer
-  # should be the same version as defined in .pre-commit-config.yaml
+  # black, isort and mypy should be the same version as defined in .pre-commit-config.yaml
   "black==23.1.0", # frozen version to avoid differences between CI and local dev machines
   "isort==5.11.5", # frozen version to avoid differences between CI and local dev machines
   "mypy==1.4.1", # frozen version to avoid differences between CI and local dev machines


### PR DESCRIPTION
Adds `black`, `isort` and `mypy` to pre-commit (with the versions specified in `pyproject.toml`).