### PR TITLE
Remove lightning-bolts dependency

### DIFF
--- a/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
@@ -34,8 +34,6 @@ import pytorch_lightning as pl
 import torch
 import torch.nn as nn
 import torchvision
-from pl_bolts.optimizers.lars import LARS
-from pl_bolts.optimizers.lr_scheduler import linear_warmup_decay
 from pytorch_lightning.loggers import TensorBoardLogger
 from torch.optim.lr_scheduler import LambdaLR
 
@@ -59,6 +57,8 @@ from lightly.transforms import (
 )
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 from lightly.utils.benchmarking import BenchmarkModule
+from lightly.utils.lars import LARS
+from lightly.utils.scheduler import CosineWarmupScheduler
 
 logs_root_dir = os.path.join(os.getcwd(), "benchmark_logs")
 
@@ -306,13 +306,10 @@ class SimCLRModel(BenchmarkModule):
             weight_decay=1e-6,
         )
         scheduler = {
-            "scheduler": LambdaLR(
+            "scheduler": CosineWarmupScheduler(
                 optimizer=optim,
-                lr_lambda=linear_warmup_decay(
-                    warmup_steps=steps_per_epoch * 10,
-                    total_steps=steps_per_epoch * max_epochs,
-                    cosine=True,
-                ),
+                warmup_epochs=steps_per_epoch * 10,
+                max_epochs=steps_per_epoch * max_epochs,
             ),
             "interval": "step",
             "frequency": 1,
@@ -409,13 +406,10 @@ class BarlowTwinsModel(BenchmarkModule):
             weight_decay=1.5 * 1e-6,
         )
         scheduler = {
-            "scheduler": LambdaLR(
+            "scheduler": CosineWarmupScheduler(
                 optimizer=optim,
-                lr_lambda=linear_warmup_decay(
-                    warmup_steps=steps_per_epoch * 10,
-                    total_steps=steps_per_epoch * max_epochs,
-                    cosine=True,
-                ),
+                warmup_epochs=steps_per_epoch * 10,
+                max_epochs=steps_per_epoch * max_epochs,
             ),
             "interval": "step",
             "frequency": 1,
@@ -482,13 +476,10 @@ class BYOLModel(BenchmarkModule):
             weight_decay=1.5 * 1e-6,
         )
         scheduler = {
-            "scheduler": LambdaLR(
+            "scheduler": CosineWarmupScheduler(
                 optimizer=optim,
-                lr_lambda=linear_warmup_decay(
-                    warmup_steps=steps_per_epoch * 10,
-                    total_steps=steps_per_epoch * max_epochs,
-                    cosine=True,
-                ),
+                warmup_epochs=steps_per_epoch * 10,
+                max_epochs=steps_per_epoch * max_epochs,
             ),
             "interval": "step",
             "frequency": 1,
@@ -583,13 +574,10 @@ class SwaVModel(BenchmarkModule):
             weight_decay=1e-6,
         )
         scheduler = {
-            "scheduler": LambdaLR(
+            "scheduler": CosineWarmupScheduler(
                 optimizer=optim,
-                lr_lambda=linear_warmup_decay(
-                    warmup_steps=steps_per_epoch * 10,
-                    total_steps=steps_per_epoch * max_epochs,
-                    cosine=True,
-                ),
+                warmup_epochs=steps_per_epoch * 10,
+                max_epochs=steps_per_epoch * max_epochs,
             ),
             "interval": "step",
             "frequency": 1,
@@ -648,13 +636,10 @@ class DINOModel(BenchmarkModule):
             momentum=0.9,
         )
         scheduler = {
-            "scheduler": LambdaLR(
+            "scheduler": CosineWarmupScheduler(
                 optimizer=optim,
-                lr_lambda=linear_warmup_decay(
-                    warmup_steps=steps_per_epoch * 10,
-                    total_steps=steps_per_epoch * max_epochs,
-                    cosine=True,
-                ),
+                warmup_epochs=steps_per_epoch * 10,
+                max_epochs=steps_per_epoch * max_epochs,
             ),
             "interval": "step",
             "frequency": 1,

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -69,7 +69,6 @@ import pytorch_lightning as pl
 import torch
 import torch.nn as nn
 import torchvision
-from pl_bolts.optimizers.lars import LARS
 from pytorch_lightning.loggers import TensorBoardLogger
 from timm.models.vision_transformer import vit_base_patch32_224
 from torchvision.models.vision_transformer import VisionTransformer
@@ -115,6 +114,7 @@ from lightly.transforms import (
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 from lightly.utils import scheduler
 from lightly.utils.benchmarking import BenchmarkModule
+from lightly.utils.lars import LARS
 
 logs_root_dir = os.path.join(os.getcwd(), "benchmark_logs")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ dev = [
   "pandas",
   "toml",
   "torchmetrics",
-  "lightning-bolts", # for LARS optimizer
   # black, isort and mypy should be the same version as defined in .pre-commit-config.yaml
   "black==23.1.0", # frozen version to avoid differences between CI and local dev machines
   "isort==5.11.5", # frozen version to avoid differences between CI and local dev machines


### PR DESCRIPTION
## Changes

* Remove lightning-bolts dependency

lightning-bolts has a dependency on pytorch lightning <2 (see [here](https://github.com/Lightning-Universe/lightning-bolts/blob/2c4602aa684e7b90e7ffdcea1d3f93a20f9c2ead/requirements/base.txt#L2)) which blocks #1607 