### PR TITLE
feat: drop duplicate code in modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,8 @@ repos:
   rev: v1.4.1  # aligned with the version defined in pyproject.toml
   hooks:
   - id: mypy
+    additional_dependencies:
+      - 'numpy'
 - repo: local
   hooks:
   - id: pytest-check                     # run all tests

--- a/lightly/models/modules/masked_autoencoder_timm.py
+++ b/lightly/models/modules/masked_autoencoder_timm.py
@@ -8,7 +8,7 @@ from torch import Tensor
 from torch.nn import LayerNorm, Module, Parameter, Sequential
 
 from lightly.models import utils
-from lightly.models.modules.masked_vision_transformer_timm import _init_weights
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 
 
 class MAEDecoderTIMM(Module):
@@ -114,7 +114,7 @@ class MAEDecoderTIMM(Module):
             Tensor with shape (batch_size, seq_length, out_dim).
 
         """
-        out: Tensor = self.embed(input)
+        out = self.embed(input)
         out = self.decode(out)
         return self.predict(out)
 
@@ -176,4 +176,4 @@ class MAEDecoderTIMM(Module):
         utils.initialize_2d_sine_cosine_positional_embedding(
             pos_embedding=self.decoder_pos_embed, has_class_token=True
         )
-        self.apply(_init_weights)
+        self.apply(init_weights)

--- a/lightly/models/modules/masked_autoencoder_timm.py
+++ b/lightly/models/modules/masked_autoencoder_timm.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 from timm.models.vision_transformer import Block
 from torch import Tensor
-from torch.nn import LayerNorm, Linear, Module, Parameter, Sequential
+from torch.nn import LayerNorm, Module, Parameter, Sequential
 
 from lightly.models import utils
 from lightly.models.modules.masked_vision_transformer_timm import _init_weights

--- a/lightly/models/modules/masked_autoencoder_timm.py
+++ b/lightly/models/modules/masked_autoencoder_timm.py
@@ -8,6 +8,7 @@ from torch import Tensor
 from torch.nn import LayerNorm, Linear, Module, Parameter, Sequential
 
 from lightly.models import utils
+from lightly.models.modules.masked_vision_transformer_timm import _init_weights
 
 
 class MAEDecoderTIMM(Module):
@@ -113,7 +114,7 @@ class MAEDecoderTIMM(Module):
             Tensor with shape (batch_size, seq_length, out_dim).
 
         """
-        out = self.embed(input)
+        out: Tensor = self.embed(input)
         out = self.decode(out)
         return self.predict(out)
 
@@ -176,13 +177,3 @@ class MAEDecoderTIMM(Module):
             pos_embedding=self.decoder_pos_embed, has_class_token=True
         )
         self.apply(_init_weights)
-
-
-def _init_weights(module: Module) -> None:
-    if isinstance(module, Linear):
-        nn.init.xavier_uniform_(module.weight)
-        if isinstance(module, Linear) and module.bias is not None:
-            nn.init.constant_(module.bias, 0)
-    elif isinstance(module, LayerNorm):
-        nn.init.constant_(module.bias, 0)
-        nn.init.constant_(module.weight, 1.0)

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -199,10 +199,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer):
             torch.nn.init.normal_(self.vit.cls_token, std=0.02)
 
         # initialize nn.Linear and nn.LayerNorm
-        self.apply(_init_weights)
+        self.apply(init_weights)
 
 
-def _init_weights(module: Module) -> None:
+def init_weights(module: Module) -> None:
     if isinstance(module, Linear):
         nn.init.xavier_uniform_(module.weight)
         if isinstance(module, Linear) and module.bias is not None:

--- a/tests/models/modules/test_masked_vision_transformer_timm.py
+++ b/tests/models/modules/test_masked_vision_transformer_timm.py
@@ -65,14 +65,14 @@ class TestMaskedVisionTransformerTIMM(MaskedVisionTransformerTest):
         assert isinstance(model.mask_token, Parameter)
 
     def test__init__weight_initialization(self, mocker: MockerFixture) -> None:
-        mock_init_weights = mocker.spy(masked_vision_transformer_timm, "_init_weights")
+        mock_init_weights = mocker.spy(masked_vision_transformer_timm, "init_weights")
         self.get_masked_vit(
             patch_size=32, depth=1, num_heads=1, weight_initialization=""
         )
         mock_init_weights.assert_called()
 
     def test__init__weight_initialization__skip(self, mocker: MockerFixture) -> None:
-        mock_init_weights = mocker.spy(masked_vision_transformer_timm, "_init_weights")
+        mock_init_weights = mocker.spy(masked_vision_transformer_timm, "init_weights")
         self.get_masked_vit(
             patch_size=32, depth=1, num_heads=1, weight_initialization="skip"
         )


### PR DESCRIPTION
* Remove duplicate code from `lightly/models/modules/masked_autoencoder_timm.py`.
* Drop redundant import + add type hint in `forward`.
* The `mypy` pre-commit hook was not recognising the plugin, so I added the additional dependency [source](https://github.com/numpy/numpy/issues/19215#issuecomment-1367434689)