### PR TITLE
Fix import error in tutorial_checkpoint_finetuning.py

### DIFF
--- a/docs/source/tutorials_source/package/tutorial_checkpoint_finetuning.py
+++ b/docs/source/tutorials_source/package/tutorial_checkpoint_finetuning.py
@@ -28,7 +28,7 @@ PyTorch Lightning.
 import pytorch_lightning as pl
 import torch
 import torch.nn as nn
-from lightning.pytorch.loggers import TensorBoardLogger
+from pytorch_lightning.loggers import TensorBoardLogger
 from torchvision import transforms
 
 from lightly.transforms.utils import IMAGENET_NORMALIZE


### PR DESCRIPTION
## Description

The import is wrong. We must import from `pytorch_lightning`, not from `lightning.pytorch`.

See also the other tutorials
![image](https://github.com/user-attachments/assets/2856a201-8a1f-4bb9-84b5-52dec5609df1)

and how there is an import failure when building the docs:

![image](https://github.com/user-attachments/assets/c4cac8ab-8e6a-4615-867c-6c4dcd7eb446)


