### PR TITLE
Add CenterCrop to Val Transform in Finetuning Tutorial

### DIFF
--- a/docs/source/tutorials_source/package/tutorial_checkpoint_finetuning.py
+++ b/docs/source/tutorials_source/package/tutorial_checkpoint_finetuning.py
@@ -122,6 +122,7 @@ train_dataloader = DataLoader(
 val_transform = transforms.Compose(
     [
         transforms.Resize(input_size),
+        transforms.CenterCrop(input_size),
         transforms.ToTensor(),
         transforms.Normalize(
             mean=IMAGENET_NORMALIZE["mean"],


### PR DESCRIPTION
### Changes

* Add CenterCrop to val transform in finetuning tutorial
* This fixes size issues because the Resize transform resizes the shorter edge to the target length

It is standard to use Resize + CenterCrop for validation transforms.