### PR TITLE
Deprecate most CLI commands

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -50,10 +50,10 @@ jobs:
         run: |
           source .venv/bin/activate
           LIGHTLY_SERVER_LOCATION="localhost:-1"
-          lightly-crop --help
-          lightly-train --help
-          lightly-embed --help
-          lightly-magic --help
+          lightly-crop-deprecated --help
+          lightly-train-deprecated --help
+          lightly-embed-deprecated --help
+          lightly-magic-deprecated --help
           lightly-download --help
           lightly-version
       - name: Test CLI on Dataset
@@ -62,5 +62,5 @@ jobs:
           LIGHTLY_SERVER_LOCATION="localhost:-1"
           git clone https://github.com/alexeygrigorev/clothing-dataset-small clothing_dataset_small
           INPUT_DIR_1="clothing_dataset_small/test/dress"
-          lightly-train input_dir=$INPUT_DIR_1 trainer.max_epochs=1 loader.num_workers=6
-          lightly-embed input_dir=$INPUT_DIR_1
+          lightly-train-deprecated input_dir=$INPUT_DIR_1 trainer.max_epochs=1 loader.num_workers=6
+          lightly-embed-deprecated input_dir=$INPUT_DIR_1

--- a/docs/source/getting_started/command_line_tool.rst
+++ b/docs/source/getting_started/command_line_tool.rst
@@ -7,6 +7,22 @@ The Lightly\ **SSL** framework provides you with a command-line interface (CLI) 
 self-supervised models and create embeddings without having to write a single 
 line of code.
 
+.. warning::
+
+    Most commands of the CLI are deprecated since version 1.6.
+
+    The following commands were renamed in version 1.6 and will be removed in version
+    1.7:
+    - `lightly-crop` -> `lightly-crop-deprecated`
+    - `lightly-train` -> `lightly-train-deprecated`
+    - `lightly-embed` -> `lightly-embed-deprecated`
+    - `lightly-magic` -> `lightly-magic-deprecated`
+
+    If you would like to continue using these commands, please create an issue on the
+    :ref:`issue tracker <https://github.com/lightly-ai/lightly/issues>`_ or contact us
+    at info@lightly.ai
+
+
 You can also have a look at this video to get an overview of how to work with 
 the CLI.
 
@@ -41,6 +57,13 @@ If Lightly\ **SSL** was installed correctly, you should see something like this:
 
 Crop Images using Labels or Predictions
 ---------------------------------------------------
+
+.. warning::
+
+    This functionality is deprecated since version 1.6. The `lightly-crop` command
+    was renamed to `lightly-crop-deprecated` in version 1.6 and will be completely
+    removed in version 1.7.
+
 For some tasks, self-supervised learning on an image level has disadvantages. For 
 example, when training an object detection model we care about local features
 describing the objects rather than features describing the full image.
@@ -49,17 +72,17 @@ One simple trick to overcome this limitation, is to use labels or to use a pre-t
 to get bounding boxes around the objects and then cropping the objects out of the
 image.
 
-We can do this using the **lightly-crop** CLI command. The CLI command crops 
+We can do this using the **lightly-crop-deprecated** CLI command. The CLI command crops 
 objects out of the input images based on labels and copies them into an output folder.
 The new folder consists now of the cropped images.
 
 .. code-block:: bash
 
     # Crop images and set the crop to be 20% around the bounding box
-    lightly-crop input_dir=images label_dir=labels output_dir=cropped_images crop_padding=0.2
+    lightly-crop-deprecated input_dir=images label_dir=labels output_dir=cropped_images crop_padding=0.2
 
     # Crop images and use the class names in the filename
-    lightly-crop input_dir=images label_dir=labels output_dir=cropped_images \
+    lightly-crop-deprecated input_dir=images label_dir=labels output_dir=cropped_images \
                  label_names_file=data.yaml
 
 The labels should be in the yolo format. For each image you should have a
@@ -78,12 +101,19 @@ An example for the label names .yaml file:
 
     names: [cat, dog]
 
-You can use the output of the lightly-crop command as the *input_dir* for your
-lightly-train command.
+You can use the output of the lightly-crop-deprecated command as the *input_dir* for your
+lightly-train-deprecated command.
 
 Training and Embedding in a Go – Magic
 ---------------------------------------------------
-Lightly-magic is a singular command for training a self-supervised model and use it to compute embeddings
+
+.. warning::
+
+    This functionality is deprecated since version 1.6. The `lightly-magic` command
+    was renamed to `lightly-magic-deprecated` in version 1.6 and will be completely
+    removed in version 1.7.
+
+Lightly-magic-deprecated is a singular command for training a self-supervised model and use it to compute embeddings
 
 * To start with, we need to input the directory of the dataset, pass it to input_dir.
 * It requires information on the number of epochs to perform, set trainer.max_epochs.
@@ -98,12 +128,12 @@ Lightly-magic is a singular command for training a self-supervised model and use
     # Embed images from an input directory
     # Setting trainer.max_epochs=10 trains a model for 10 epochs.
     # loader.num_workers=8 specifies the number of cpu cores used for loading images.
-    lightly-magic input_dir=data_dir trainer.max_epochs=10 loader.num_workers=8
+    lightly-magic-deprecated input_dir=data_dir trainer.max_epochs=10 loader.num_workers=8
 
 
     # To use a custom batch size, pass the batch size to loader.batch_size parameter
     # updating the previous example by passing value for loader.batch_size
-    lightly-magic input_dir=data_dir trainer.max_epochs=10 loader.batch_size=128 \
+    lightly-magic-deprecated input_dir=data_dir trainer.max_epochs=10 loader.batch_size=128 \
     loader.num_workers=8
 
 
@@ -111,6 +141,13 @@ Lightly-magic is a singular command for training a self-supervised model and use
 
 Train a model using the CLI
 ---------------------------------------
+
+.. warning::
+
+    This functionality is deprecated since version 1.6. The `lightly-train` command
+    was renamed to `lightly-train-deprecated` in version 1.6 and will be completely
+    removed in version 1.7.
+
 Training a model using default parameters can be done with just one command. Let's
 assume you have a folder of cat images named `cat` and want to train a model on it.
 You can use the following command to train a model and save the checkpoint:
@@ -118,23 +155,23 @@ You can use the following command to train a model and save the checkpoint:
 .. code-block:: bash
 
     # train a model using default parameters
-    lightly-train input_dir=cat
+    lightly-train-deprecated input_dir=cat
 
     # train a model for 5 epochs
-    lightly-train input_dir=cat trainer.max_epochs=5
+    lightly-train-deprecated input_dir=cat trainer.max_epochs=5
 
     # continue training from a checkpoint for another 10 epochs
-    lightly-train input_dir=cat trainer.max_epochs=10 checkpoint=mycheckpoint.ckpt
+    lightly-train-deprecated input_dir=cat trainer.max_epochs=10 checkpoint=mycheckpoint.ckpt
 
     # continue training from the last checkpoint
-    lightly-train input_dir=cat trainer.max_epochs=10 \
+    lightly-train-deprecated input_dir=cat trainer.max_epochs=10 \
                   checkpoint=$LIGHTLY_LAST_CHECKPOINT_PATH
 
     # train with multiple gpus
     # the total batch size will be trainer.gpus * loader.batch_size
-    lightly-train input_dir=data_dir trainer.gpus=2
+    lightly-train-deprecated input_dir=data_dir trainer.gpus=2
 
-The path to the latest checkpoint you created using the `lightly-train` command
+The path to the latest checkpoint you created using the `lightly-train-deprecated` command
 will be saved under an environment variable named LIGHTLY_LAST_CHECKPOINT_PATH.
 This can be useful for continuing training or for creating embeddings from
 a checkpoint.
@@ -143,7 +180,7 @@ For a full list of supported arguments run
 
 .. code-block:: bash
     
-    lightly-train --help
+    lightly-train-deprecated --help
 
 
 You can get an overview of the various CLI parameters you can set in 
@@ -159,15 +196,15 @@ Once you have a trained model checkpoint, you can create an embedding of a datas
 .. code-block:: bash
 
     # use pre-trained models provided by Lighly
-    lightly-embed input_dir=cat
+    lightly-embed-deprecated input_dir=cat
 
     # use custom checkpoint
-    lightly-embed input_dir=cat checkpoint=mycheckpoint.ckpt
+    lightly-embed-deprecated input_dir=cat checkpoint=mycheckpoint.ckpt
 
     # use the last checkpoint you created
-    lightly-embed input_dir=cat checkpoint=$LIGHTLY_LAST_CHECKPOINT_PATH
+    lightly-embed-deprecated input_dir=cat checkpoint=$LIGHTLY_LAST_CHECKPOINT_PATH
 
-The path to the latest embeddings you created using the `lightly-embed` command
+The path to the latest embeddings you created using the `lightly-embed-deprecated` command
 will be saved under an environment variable named LIGHTLY_LAST_EMBEDDING_PATH.
 
 The embeddings.csv file should look like the following:
@@ -197,40 +234,37 @@ without the need to download them explicitly.
 .. code-block:: bash
 
     # download a list of files
-    lightly-download tag_name=my_tag_name dataset_id=your_dataset_id token=your_token
+    lightly-download-deprecated tag_name=my_tag_name dataset_id=your_dataset_id token=your_token
 
     # download the images and store them in an output directory
-    lightly-download tag_name=my_tag_name dataset_id=your_dataset_id token=your_token \
+    lightly-download-deprecated tag_name=my_tag_name dataset_id=your_dataset_id token=your_token \
                      output_dir=path/to/output/dir
 
     # copy images from an input directory to an output directory
-    lightly-download tag_name=my_tag_name dataset_id=your_dataset_id token=your_token \
+    lightly-download-deprecated tag_name=my_tag_name dataset_id=your_dataset_id token=your_token \
                      input_dir=path/to/input/dir output_dir=path/to/output/dir
 
 .. _ref-breakdown-lightly-magic:
 
-Breakdown of lightly-magic
---------------------------
+Breakdown of lightly-magic-deprecated
+-------------------------------------
 
-If you want to break the lightly-magic command into separate steps,
+.. warning::
+
+    This functionality is deprecated since version 1.6. The `lightly-magic` command
+    was renamed to `lightly-magic-deprecated` in version 1.6 and will be completely
+    removed in version 1.7.
+
+If you want to break the lightly-magic-deprecated command into separate steps,
 you can use the following:
 
 .. code-block:: bash
 
-    # lightly-magic command
-    lightly-magic input_dir=data_dir
+    # lightly-magic-deprecated command
+    lightly-magic-deprecated input_dir=data_dir
     # equivalent breakdown into single commands
 
     # train the embedding model
-    lightly-train input_dir=data_dir
+    lightly-train-deprecated input_dir=data_dir
     # embed the images with the embedding model just trained
-    lightly-embed input_dir=data_dir checkpoint=$LIGHTLY_LAST_CHECKPOINT_PATH
-
-
-
-
-    
-
-
-
-
+    lightly-embed-deprecated input_dir=data_dir checkpoint=$LIGHTLY_LAST_CHECKPOINT_PATH

--- a/docs/source/lightly.cli.rst
+++ b/docs/source/lightly.cli.rst
@@ -50,7 +50,7 @@ and empty string so it must be overwritten:
 .. code-block:: bash
 
    # train the default model on my data
-   lightly-train input_dir='path/to/my/data'
+   lightly-train-deprecated input_dir='path/to/my/data'
 
 An argument which is grouped under a certain namespace can be accessed by specifying the namespace and the argument,
 separated by a dot. For example the argument "name" in the namespace "model" can be accessed like so:
@@ -58,7 +58,7 @@ separated by a dot. For example the argument "name" in the namespace "model" can
 .. code-block:: bash
 
    # train a ResNet-34 on my data
-   lightly-train input_dir='path/to/my/data' model.name='resnet-34'
+   lightly-train-deprecated input_dir='path/to/my/data' model.name='resnet-34'
 
 Additional Arguments
 ^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ This can be done by adding a + right before the argument:
 .. code-block:: bash
 
    # train a ResNet-34 with momentum on my data
-   lightly-train input_dir='path/to/my/data' model.name='resnet-34' +optimizer.momentum=0.9
+   lightly-train-deprecated input_dir='path/to/my/data' model.name='resnet-34' +optimizer.momentum=0.9
 
 .. _ref-cli-config-default:
 

--- a/lightly/cli/__init__.py
+++ b/lightly/cli/__init__.py
@@ -1,6 +1,19 @@
 """ The lightly.cli module provides a console interface
     for training self-supervised models, embedding,
     and filtering datasets
+
+    Warning: Most commands of the CLI are deprecated since version 1.6.
+    
+    The following commands were renamed in version 1.6 and will be removed in version
+    1.7:
+    - `lightly-crop` -> `lightly-crop-deprecated`
+    - `lightly-train` -> `lightly-train-deprecated`
+    - `lightly-embed` -> `lightly-embed-deprecated`
+    - `lightly-magic` -> `lightly-magic-deprecated`
+
+    If you would like to continue using these commands, please create an issue on the
+    issue tracker at https://github.com/lightly-ai/lightly/issues or contact us
+    at info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.

--- a/lightly/cli/__init__.py
+++ b/lightly/cli/__init__.py
@@ -1,19 +1,21 @@
-""" The lightly.cli module provides a console interface
-    for training self-supervised models, embedding,
-    and filtering datasets
+""" The lightly.cli module provides a console interface for training self-supervised
+models, embedding, and filtering datasets
 
-    Warning: Most commands of the CLI are deprecated since version 1.6.
-    
+.. warning::
+
+    Most commands of the CLI are deprecated since version 1.6.
+
     The following commands were renamed in version 1.6 and will be removed in version
     1.7:
+
     - `lightly-crop` -> `lightly-crop-deprecated`
     - `lightly-train` -> `lightly-train-deprecated`
     - `lightly-embed` -> `lightly-embed-deprecated`
     - `lightly-magic` -> `lightly-magic-deprecated`
 
     If you would like to continue using these commands, please create an issue on the
-    issue tracker at https://github.com/lightly-ai/lightly/issues or contact us
-    at info@lightly.ai
+    `issue tracker <https://github.com/lightly-ai/lightly/issues>`_ or contact us at
+    info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -121,26 +121,40 @@ hydra:
       == Description ==
       The lightly Python package is a command-line tool for self-supervised learning.
 
+      == Warning ==
+      Most commands of the CLI are deprecated since version 1.6.
+
+      The following commands were renamed in version 1.6 and will be removed in version
+      1.7:
+      - `lightly-crop` -> `lightly-crop-deprecated`
+      - `lightly-train` -> `lightly-train-deprecated`
+      - `lightly-embed` -> `lightly-embed-deprecated`
+      - `lightly-magic` -> `lightly-magic-deprecated`
+
+      If you would like to continue using these commands, please create an issue on the
+      issue tracker https://github.com/lightly-ai/lightly/issues> or contact us at
+      info@lightly.ai
+
     footer: |
       == Examples ==
 
       Use a pre-trained resnet-18 to embed your images
-      > lightly-embed input='path/to/image/folder' collate.input_size=224
+      > lightly-embed-deprecated input='path/to/image/folder' collate.input_size=224
 
       Load a model from a custom checkpoint to embed your images
-      > lightly-embed input_dir='path/to/image/folder' collate.input_size=224 checkpoint='path/to/checkpoint.ckpt'
+      > lightly-embed-deprecated input_dir='path/to/image/folder' collate.input_size=224 checkpoint='path/to/checkpoint.ckpt'
 
       Train a self-supervised model on your image dataset from scratch
-      > lightly-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 pre_trained=False
+      > lightly-train-deprecated input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 pre_trained=False
 
       Train a self-supervised model starting from the pre-trained checkpoint
-      > lightly-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224
+      > lightly-train-deprecated input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224
 
       Train a self-supervised model starting from a custom checkpoint
-      > lightly-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 checkpoint='path/to/checkpoint.ckpt'
+      > lightly-train-deprecated input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 checkpoint='path/to/checkpoint.ckpt'
 
       Train using half-precision
-      > lightly-train input_dir='path/to/image/folder' trainer.precision=16
+      > lightly-train-deprecated input_dir='path/to/image/folder' trainer.precision=16
       
       Download a list of files in a given tag from the Lightly Platform
       > lightly-download tag_name='my-tag' dataset_id='your_dataset_id' token='your_access_token'

--- a/lightly/cli/crop_cli.py
+++ b/lightly/cli/crop_cli.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 """**Lightly Train:** Train a self-supervised model from the command-line.
 
-This module contains the entrypoint for the **lightly-train**
+This module contains the entrypoint for the **lightly-crop-deprecated**
 command-line interface.
+
+Warning: This functionality is deprecated since version 1.6. The `lightly-crop` command
+was renamed to `lightly-crop-deprecated` in version 1.6 and will be completely removed
+in version 1.7. If you would like to continue using the command, please create an issue
+on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
+info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -76,6 +82,12 @@ def _crop_cli(cfg, is_cli_call=True):
 def crop_cli(cfg):
     """Crops images into one sub-image for each object.
 
+    Warning: This functionality is deprecated since version 1.6. The lightly-crop
+    command was renamed to lightly-crop-deprecated in version 1.6 and will be
+    completely removed in version 1.7. If you would like to continue using the
+    command, please create an issue on the issue tracker at
+    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+
     Args:
         cfg:
             The default configs are loaded from the config file.
@@ -102,10 +114,10 @@ def crop_cli(cfg):
 
     Examples:
         >>> # Crop images and set the crop to be 20% around the bounding box
-        >>> lightly-crop input_dir=data/images label_dir=data/labels output_dir=data/cropped_images crop_padding=0.2
+        >>> lightly-crop-deprecated input_dir=data/images label_dir=data/labels output_dir=data/cropped_images crop_padding=0.2
 
         >>> # Crop images and use the class names in the filename
-        >>> lightly-crop input_dir=data/images label_dir=data/labels output_dir=data/cropped_images label_names_file=data/data.yaml
+        >>> lightly-crop-deprecated input_dir=data/images label_dir=data/labels output_dir=data/cropped_images label_names_file=data/data.yaml
 
     """
     return _crop_cli(cfg)

--- a/lightly/cli/crop_cli.py
+++ b/lightly/cli/crop_cli.py
@@ -3,12 +3,6 @@
 
 This module contains the entrypoint for the **lightly-crop-deprecated**
 command-line interface.
-
-Warning: This functionality is deprecated since version 1.6. The `lightly-crop` command
-was renamed to `lightly-crop-deprecated` in version 1.6 and will be completely removed
-in version 1.7. If you would like to continue using the command, please create an issue
-on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
-info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -26,10 +20,17 @@ from lightly.utils.cropping.crop_image_by_bounding_boxes import (
     crop_dataset_by_bounding_boxes_and_save,
 )
 from lightly.utils.cropping.read_yolo_label_file import read_yolo_label_file
-from lightly.utils.hipify import bcolors
+from lightly.utils.hipify import bcolors, print_as_warning
 
 
 def _crop_cli(cfg, is_cli_call=True):
+    print_as_warning(
+        "The lightly-crop-deprecated command is deprecated since version 1.6 and "
+        "will be removed in version 1.7. If you would like to continue using the "
+        "command, please create an issue on the issue tracker at "
+        "https://github.com/lightly-ai/lightly/issues or contact us at "
+        "info@lightly.ai"
+    )
     input_dir = cfg["input_dir"]
     if input_dir and is_cli_call:
         input_dir = fix_input_path(input_dir)
@@ -82,11 +83,14 @@ def _crop_cli(cfg, is_cli_call=True):
 def crop_cli(cfg):
     """Crops images into one sub-image for each object.
 
-    Warning: This functionality is deprecated since version 1.6. The lightly-crop
-    command was renamed to lightly-crop-deprecated in version 1.6 and will be
-    completely removed in version 1.7. If you would like to continue using the
-    command, please create an issue on the issue tracker at
-    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+    .. warning::
+
+        This functionality is deprecated since version 1.6. The lightly-crop
+        command was renamed to lightly-crop-deprecated in version 1.6 and will be
+        completely removed in version 1.7. If you would like to continue using the
+        command, please create an issue on the
+        `issue tracker <https://github.com/lightly-ai/lightly/issues>`_
+        or contact us at info@lightly.ai
 
     Args:
         cfg:

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 """**Lightly Embed:** Embed images with one command.
 
-This module contains the entrypoint for the **lightly-embed**
+This module contains the entrypoint for the **lightly-embed-deprecated**
 command-line interface.
+
+Warning: This functionality is deprecated since version 1.6. The `lightly-embed` command
+was renamed to `lightly-embed-deprecated` in version 1.6 and will be completely removed
+in version 1.7. If you would like to continue using the command, please create an issue
+on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
+info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -23,7 +29,7 @@ from lightly.cli._helpers import (
     get_model_from_config,
 )
 from lightly.data import LightlyDataset
-from lightly.utils.hipify import bcolors
+from lightly.utils.hipify import bcolors, print_as_warning
 from lightly.utils.io import save_embeddings
 
 
@@ -40,6 +46,13 @@ def _embed_cli(
             Embeddings are of shape (n_samples, embedding_size)
             len(labels) = len(filenames) = n_samples
     """
+    print_as_warning(
+        "The lightly-embed-deprecated command is deprecated since version 1.6 and "
+        "will be removed in version 1.7. If you would like to continue using the "
+        "command, please create an issue on the issue tracker at "
+        "https://github.com/lightly-ai/lightly/issues or contact us at "
+        "info@lightly.ai"
+    )
     input_dir = cfg["input_dir"]
     if input_dir and is_cli_call:
         input_dir = fix_input_path(input_dir)
@@ -97,6 +110,12 @@ def _embed_cli(
 def embed_cli(cfg) -> str:
     """Embed images from the command-line.
 
+    Warning: This functionality is deprecated since version 1.6. The lightly-embed
+    command was renamed to lightly-embed-deprecated in version 1.6 and will be
+    completely removed in version 1.7. If you would like to continue using the
+    command, please create an issue on the issue tracker at
+    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+
     Args:
         cfg:
             The default configs are loaded from the config file.
@@ -115,13 +134,13 @@ def embed_cli(cfg) -> str:
 
     Examples:
         >>> # embed images with default settings and a lightly model
-        >>> lightly-embed input_dir=data/
+        >>> lightly-embed-deprecated input_dir=data/
         >>>
         >>> # embed images with default settings and a custom checkpoint
-        >>> lightly-embed input_dir=data/ checkpoint=my_checkpoint.ckpt
+        >>> lightly-embed-deprecated input_dir=data/ checkpoint=my_checkpoint.ckpt
         >>>
         >>> # embed images with custom settings
-        >>> lightly-embed input_dir=data/ model.num_ftrs=32
+        >>> lightly-embed-deprecated input_dir=data/ model.num_ftrs=32
 
     """
     return _embed_cli(cfg)

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -3,12 +3,6 @@
 
 This module contains the entrypoint for the **lightly-embed-deprecated**
 command-line interface.
-
-Warning: This functionality is deprecated since version 1.6. The `lightly-embed` command
-was renamed to `lightly-embed-deprecated` in version 1.6 and will be completely removed
-in version 1.7. If you would like to continue using the command, please create an issue
-on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
-info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -98,9 +92,9 @@ def _embed_cli(
         path = os.path.join(os.getcwd(), "embeddings.csv")
         save_embeddings(path, embeddings, labels, filenames)
         print(f"Embeddings are stored at {bcolors.OKBLUE}{path}{bcolors.ENDC}")
-        os.environ[
-            cfg["environment_variable_names"]["lightly_last_embedding_path"]
-        ] = path
+        os.environ[cfg["environment_variable_names"]["lightly_last_embedding_path"]] = (
+            path
+        )
         return path
 
     return embeddings, labels, filenames
@@ -110,11 +104,14 @@ def _embed_cli(
 def embed_cli(cfg) -> str:
     """Embed images from the command-line.
 
-    Warning: This functionality is deprecated since version 1.6. The lightly-embed
-    command was renamed to lightly-embed-deprecated in version 1.6 and will be
-    completely removed in version 1.7. If you would like to continue using the
-    command, please create an issue on the issue tracker at
-    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+    .. warning::
+
+        This functionality is deprecated since version 1.6. The lightly-embed
+        command was renamed to lightly-embed-deprecated in version 1.6 and will be
+        completely removed in version 1.7. If you would like to continue using the
+        command, please create an issue on the
+        `issue tracker <https://github.com/lightly-ai/lightly/issues>`_
+        or contact us at info@lightly.ai
 
     Args:
         cfg:

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -3,12 +3,6 @@
 
 This module contains the entrypoint for the **lightly-magic-deprecated**
 command-line interface.
-
-Warning: This functionality is deprecated since version 1.6. The `lightly-train` command
-was renamed to `lightly-train-deprecated` in version 1.6 and will be completely removed
-in version 1.7. If you would like to continue using the command, please create an issue
-on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
-info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -54,11 +48,14 @@ def _lightly_cli(cfg, is_cli_call=True):
 def lightly_cli(cfg):
     """Train a self-supervised model and use it to embed your dataset.
 
-    Warning: This functionality is deprecated since version 1.6. The lightly-magic
-    command was renamed to lightly-magic-deprecated in version 1.6 and will be
-    completely removed in version 1.7. If you would like to continue using the
-    command, please create an issue on the issue tracker at
-    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+    .. warning::
+
+        This functionality is deprecated since version 1.6. The lightly-magic
+        command was renamed to lightly-magic-deprecated in version 1.6 and will be
+        completely removed in version 1.7. If you would like to continue using the
+        command, please create an issue on the
+        `issue tracker <https://github.com/lightly-ai/lightly/issues>`_
+        or contact us at info@lightly.ai
 
     Args:
         cfg:

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 """**Lightly Magic:** Train and embed in one command.
 
-This module contains the entrypoint for the **lightly-magic**
+This module contains the entrypoint for the **lightly-magic-deprecated**
 command-line interface.
+
+Warning: This functionality is deprecated since version 1.6. The `lightly-train` command
+was renamed to `lightly-train-deprecated` in version 1.6 and will be completely removed
+in version 1.7. If you would like to continue using the command, please create an issue
+on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
+info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -18,6 +24,12 @@ from lightly.utils.hipify import print_as_warning
 
 
 def _lightly_cli(cfg, is_cli_call=True):
+    print_as_warning(
+        "The lightly-magic-deprecated command is deprecated since version 1.6 and "
+        "will be removed in version 1.7. If you would like to continue using the "
+        "command, please create an issue on the issue tracker at "
+        "https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai"
+    )
     cfg["loader"]["shuffle"] = True
     cfg["loader"]["drop_last"] = True
 
@@ -42,6 +54,12 @@ def _lightly_cli(cfg, is_cli_call=True):
 def lightly_cli(cfg):
     """Train a self-supervised model and use it to embed your dataset.
 
+    Warning: This functionality is deprecated since version 1.6. The lightly-magic
+    command was renamed to lightly-magic-deprecated in version 1.6 and will be
+    completely removed in version 1.7. If you would like to continue using the
+    command, please create an issue on the issue tracker at
+    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+
     Args:
         cfg:
             The default configs are loaded from the config file.
@@ -54,10 +72,10 @@ def lightly_cli(cfg):
 
     Examples:
         >>> # train model and embed images with default settings
-        >>> lightly-magic input_dir=data/
+        >>> lightly-magic-deprecated input_dir=data/
         >>>
         >>> # train model for 10 epochs and embed images
-        >>> lightly-magic input_dir=data/ trainer.max_epochs=10
+        >>> lightly-magic-deprecated input_dir=data/ trainer.max_epochs=10
 
 
     """

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 """**Lightly Train:** Train a self-supervised model from the command-line.
 
-This module contains the entrypoint for the **lightly-train**
+This module contains the entrypoint for the **lightly-train-deprecated**
 command-line interface.
+
+Warning: This functionality is deprecated since version 1.6. The `lightly-train` command
+was renamed to `lightly-train-deprecated` in version 1.6 and will be completely removed
+in version 1.7. If you would like to continue using the command, please create an issue
+on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
+info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -31,10 +37,17 @@ from lightly.embedding import SelfSupervisedEmbedding
 from lightly.loss import NTXentLoss
 from lightly.models import ResNetGenerator
 from lightly.models.batchnorm import get_norm_layer
-from lightly.utils.hipify import bcolors
+from lightly.utils.hipify import bcolors, print_as_warning
 
 
 def _train_cli(cfg, is_cli_call=True):
+    print_as_warning(
+        "The lightly-train-deprecated command is deprecated since version 1.6 and "
+        "will be removed in version 1.7. If you would like to continue using the "
+        "command, please create an issue on the issue tracker at "
+        "https://github.com/lightly-ai/lightly/issues or contact us at "
+        "info@lightly.ai"
+    )
     input_dir = cfg["input_dir"]
     if input_dir and is_cli_call:
         input_dir = fix_input_path(input_dir)
@@ -156,6 +169,12 @@ def _train_cli(cfg, is_cli_call=True):
 def train_cli(cfg):
     """Train a self-supervised model from the command-line.
 
+    Warning: This functionality is deprecated since version 1.6. The lightly-train
+    command was renamed to lightly-train-deprecated in version 1.6 and will be
+    completely removed in version 1.7. If you would like to continue using the
+    command, please create an issue on the issue tracker at
+    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+
     Args:
         cfg:
             The default configs are loaded from the config file.
@@ -168,16 +187,16 @@ def train_cli(cfg):
 
     Examples:
         >>> # train model with default settings
-        >>> lightly-train input_dir=data/
+        >>> lightly-train-deprecated input_dir=data/
         >>>
         >>> # train model with batches of size 128
-        >>> lightly-train input_dir=data/ loader.batch_size=128
+        >>> lightly-train-deprecated input_dir=data/ loader.batch_size=128
         >>>
         >>> # train model for 10 epochs
-        >>> lightly-train input_dir=data/ trainer.max_epochs=10
+        >>> lightly-train-deprecated input_dir=data/ trainer.max_epochs=10
         >>>
         >>> # print a full summary of the model
-        >>> lightly-train input_dir=data/ trainer.weights_summary=full
+        >>> lightly-train-deprecated input_dir=data/ trainer.weights_summary=full
 
     """
     return _train_cli(cfg)

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -3,12 +3,6 @@
 
 This module contains the entrypoint for the **lightly-train-deprecated**
 command-line interface.
-
-Warning: This functionality is deprecated since version 1.6. The `lightly-train` command
-was renamed to `lightly-train-deprecated` in version 1.6 and will be completely removed
-in version 1.7. If you would like to continue using the command, please create an issue
-on the issue tracker at https://github.com/lightly-ai/lightly/issues or contact us at
-info@lightly.ai
 """
 
 # Copyright (c) 2020. Lightly AG and its affiliates.
@@ -159,9 +153,9 @@ def _train_cli(cfg, is_cli_call=True):
     print(
         f"Best model is stored at: {bcolors.OKBLUE}{encoder.checkpoint}{bcolors.ENDC}"
     )
-    os.environ[
-        cfg["environment_variable_names"]["lightly_last_checkpoint_path"]
-    ] = encoder.checkpoint
+    os.environ[cfg["environment_variable_names"]["lightly_last_checkpoint_path"]] = (
+        encoder.checkpoint
+    )
     return encoder.checkpoint
 
 
@@ -169,11 +163,14 @@ def _train_cli(cfg, is_cli_call=True):
 def train_cli(cfg):
     """Train a self-supervised model from the command-line.
 
-    Warning: This functionality is deprecated since version 1.6. The lightly-train
-    command was renamed to lightly-train-deprecated in version 1.6 and will be
-    completely removed in version 1.7. If you would like to continue using the
-    command, please create an issue on the issue tracker at
-    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+    .. warning::
+
+        This functionality is deprecated since version 1.6. The lightly-train
+        command was renamed to lightly-train-deprecated in version 1.6 and will be
+        completely removed in version 1.7. If you would like to continue using the
+        command, please create an issue on the
+        `issue tracker <https://github.com/lightly-ai/lightly/issues>`_
+        or contact us at info@lightly.ai
 
     Args:
         cfg:

--- a/lightly/core.py
+++ b/lightly/core.py
@@ -131,11 +131,14 @@ def train_embedding_model(config_path: str = None, **kwargs):
     lightly-train-deprecated can also be passed to this function (see below for an
     example).
 
-    Warning: This functionality is deprecated since version 1.6. The lightly-train
-    command was renamed to lightly-train-deprecated in version 1.6 and will be
-    completely removed in version 1.7. If you would like to continue using the
-    command, please create an issue on the issue tracker at
-    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+    .. warning::
+
+        This functionality is deprecated since version 1.6. The lightly-train
+        command was renamed to lightly-train-deprecated in version 1.6 and will be
+        completely removed in version 1.7. If you would like to continue using the
+        command, please create an issue on the
+        `issue tracker <https://github.com/lightly-ai/lightly/issues>`_ or contact us at
+        info@lightly.ai
 
     Args:
         config_path:
@@ -184,11 +187,14 @@ def embed_images(checkpoint: str, config_path: str = None, **kwargs):
     lightly-embed-deprecated can also be passed to this function (see below for an
     example).
 
-    Warning: This functionality is deprecated since version 1.6. The lightly-embed
-    command was renamed to lightly-embed-deprecated in version 1.6 and will be
-    completely removed in version 1.7. If you would like to continue using the
-    command, please create an issue on the issue tracker at
-    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
+    .. warning::
+
+        This functionality is deprecated since version 1.6. The lightly-embed
+        command was renamed to lightly-embed-deprecated in version 1.6 and will be
+        completely removed in version 1.7. If you would like to continue using the
+        command, please create an issue on the
+        `issue tracker <https://github.com/lightly-ai/lightly/issues>`_ or contact us at
+        info@lightly.ai
 
     Args:
         checkpoint:

--- a/lightly/core.py
+++ b/lightly/core.py
@@ -127,9 +127,15 @@ def train_model_and_embed_images(
 def train_embedding_model(config_path: str = None, **kwargs):
     """Train a self-supervised model.
 
-    Calls the same function as lightly-train. All arguments passed to
-    lightly-train can also be passed to this function (see below for an
+    Calls the same function as lightly-train-deprecated. All arguments passed to
+    lightly-train-deprecated can also be passed to this function (see below for an
     example).
+
+    Warning: This functionality is deprecated since version 1.6. The lightly-train
+    command was renamed to lightly-train-deprecated in version 1.6 and will be
+    completely removed in version 1.7. If you would like to continue using the
+    command, please create an issue on the issue tracker at
+    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
 
     Args:
         config_path:
@@ -162,7 +168,7 @@ def train_embedding_model(config_path: str = None, **kwargs):
         >>> checkpoint_path = lightly.train_embedding_model(
         >>>     input_dir='path/to/data', loader=my_loader)
         >>> # the command above is equivalent to:
-        >>> # lightly-train input_dir='path/to/data' loader.batch_size=100 loader.num_workers=8
+        >>> # lightly-train-deprecated input_dir='path/to/data' loader.batch_size=100 loader.num_workers=8
     """
     config_path = _get_config_path(config_path)
     config_args = _load_config_file(config_path)
@@ -174,9 +180,15 @@ def train_embedding_model(config_path: str = None, **kwargs):
 def embed_images(checkpoint: str, config_path: str = None, **kwargs):
     """Embed images with a self-supervised model.
 
-    Calls the same function as lightly-embed. All arguments passed to
-    lightly-embed can also be passed to this function (see below for an
+    Calls the same function as lightly-embed-deprecated. All arguments passed to
+    lightly-embed-deprecated can also be passed to this function (see below for an
     example).
+
+    Warning: This functionality is deprecated since version 1.6. The lightly-embed
+    command was renamed to lightly-embed-deprecated in version 1.6 and will be
+    completely removed in version 1.7. If you would like to continue using the
+    command, please create an issue on the issue tracker at
+    https://github.com/lightly-ai/lightly/issues or contact us at info@lightly.ai
 
     Args:
         checkpoint:
@@ -208,7 +220,7 @@ def embed_images(checkpoint: str, config_path: str = None, **kwargs):
         >>> embeddings, _, _ = lightly.embed_images(
         >>>     my_checkpoint_path, input_dir='path/to/data', collate=my_collate)
         >>> # the command above is equivalent to:
-        >>> # lightly-embed input_dir='path/to/data' collate.input_size=256
+        >>> # lightly-embed-deprecated input_dir='path/to/data' collate.input_size=256
 
     """
     config_path = _get_config_path(config_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,13 +114,15 @@ matplotlib = ["matplotlib>=3"]
 "Discord" = "https://discord.gg/xvNJW94"
 
 [project.scripts]
-lightly-crop = "lightly.cli.crop_cli:entry"
 lightly-download = "lightly.cli.download_cli:entry"
-lightly-embed = "lightly.cli.embed_cli:entry"
-lightly-magic = "lightly.cli.lightly_cli:entry"
 lightly-serve = "lightly.cli.serve_cli:entry"
-lightly-train = "lightly.cli.train_cli:entry"
 lightly-version = "lightly.cli.version_cli:entry"
+
+lightly-crop-deprecated = "lightly.cli.crop_cli:entry"
+lightly-embed-deprecated = "lightly.cli.embed_cli:entry"
+lightly-magic-deprecated = "lightly.cli.lightly_cli:entry"
+lightly-train-deprecated = "lightly.cli.train_cli:entry"
+
 
 [tool.setuptools.packages.find]
 include = ["lightly*"]

--- a/tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh
+++ b/tests/UNMOCKED_end2end_tests/run_all_unmocked_tests.sh
@@ -22,10 +22,10 @@ python tests/UNMOCKED_end2end_tests/create_custom_metadata_from_input_dir.py $IN
 
 # Run the tests
 echo "############################### Test 1"
-lightly-magic input_dir=$INPUT_DIR trainer.max_epochs=0
+lightly-magic-deprecated input_dir=$INPUT_DIR trainer.max_epochs=0
 
 echo "############################### Test 2"
-lightly-magic input_dir=$INPUT_DIR trainer.max_epochs=1
+lightly-magic-deprecated input_dir=$INPUT_DIR trainer.max_epochs=1
 
 echo "############################### Delete dataset again"
 rm -rf $DIR_DATASET

--- a/tests/cli/test_cli_crop.py
+++ b/tests/cli/test_cli_crop.py
@@ -86,7 +86,7 @@ class TestCLICrop(MockedApiWorkflowSetup):
             yaml.dump(yaml_dict, file)
 
     def parse_cli_string(self, cli_words: str):
-        cli_words = cli_words.replace("lightly-crop ", "")
+        cli_words = cli_words.replace("lightly-crop-deprecated ", "")
         cli_words = re.split("=| ", cli_words)
         assert len(cli_words) % 2 == 0
         dict_keys = cli_words[0::2]
@@ -97,7 +97,7 @@ class TestCLICrop(MockedApiWorkflowSetup):
             self.cfg[key] = value
 
     def test_parse_cli_string(self):
-        cli_string = "lightly-crop label_dir=/blub"
+        cli_string = "lightly-crop-deprecated label_dir=/blub"
         self.parse_cli_string(cli_string)
         self.assertEqual(self.cfg["label_dir"], "/blub")
 
@@ -143,12 +143,12 @@ class TestCLICrop(MockedApiWorkflowSetup):
                 )
 
     def test_crop_with_class_names(self):
-        cli_string = "lightly-crop crop_padding=0.1"
+        cli_string = "lightly-crop-deprecated crop_padding=0.1"
         self.parse_cli_string(cli_string)
         lightly.cli.crop_cli(self.cfg)
 
     def test_crop_without_class_names(self):
-        cli_string = "lightly-crop crop_padding=0.1"
+        cli_string = "lightly-crop-deprecated crop_padding=0.1"
         self.parse_cli_string(cli_string)
         self.cfg["label_names_file"] = ""
         lightly.cli.crop_cli(self.cfg)

--- a/tests/cli/test_cli_magic.py
+++ b/tests/cli/test_cli_magic.py
@@ -48,7 +48,7 @@ class TestCLIMagic(MockedApiWorkflowSetup):
             data[0].save(path)
 
     def parse_cli_string(self, cli_words: str):
-        cli_words = cli_words.replace("lightly-magic ", "")
+        cli_words = cli_words.replace("lightly-magic-deprecated ", "")
         cli_words = re.split("=| ", cli_words)
         assert len(cli_words) % 2 == 0
         dict_keys = cli_words[0::2]
@@ -73,13 +73,13 @@ class TestCLIMagic(MockedApiWorkflowSetup):
                 )
 
     def test_parse_cli_string(self):
-        cli_string = "lightly-magic trainer.max_epochs=3"
+        cli_string = "lightly-magic-deprecated trainer.max_epochs=3"
         self.parse_cli_string(cli_string)
         self.assertEqual(self.cfg["trainer"]["max_epochs"], 3)
 
     def test_magic_with_trainer(self):
         MockedApiWorkflowClient.n_dims_embeddings_on_server = 32
-        cli_string = "lightly-magic trainer.max_epochs=1"
+        cli_string = "lightly-magic-deprecated trainer.max_epochs=1"
         self.parse_cli_string(cli_string)
         cli.lightly_cli(self.cfg)
 


### PR DESCRIPTION
### Changes

* Deprecate lightly-train, lightly-embed, lightly-magic, and lightly-crop
* Rename commands to lightly-train-deprecated, lightly-embed-deprecated, lightly-magic-deprecated, and lightly-crop deprecated

CLI Docs:
[Command-line tool — lightly 1.5.11 documentation.pdf](https://github.com/user-attachments/files/16601180/Command-line.tool.lightly.1.5.11.documentation.pdf)

API Docs:
[lightly.cli — lightly 1.5.11 documentation.pdf](https://github.com/user-attachments/files/16601331/lightly.cli.lightly.1.5.11.documentation.pdf)

Unmocked tests: https://github.com/lightly-ai/lightly/actions/runs/10372191934/job/28714336765
