### PR TITLE
Add update_param_groups

### DIFF
--- a/lightly/utils/optim.py
+++ b/lightly/utils/optim.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict, Iterable, Optional
+
+from torch.optim import Optimizer
+
+
+def update_param_groups(
+    optimizer: Optimizer,
+    default_update: Optional[Dict[str, Any]] = None,
+    updates: Optional[Iterable[Dict[str, Any]]] = None,
+) -> None:
+    """Update the values in the param groups of the optimizer.
+
+    This is useful to update values following a schedule during training.
+
+    Args:
+        optimizer:
+            A PyTorch optimizer.
+        default_update:
+            Key value pairs that will be updated for all param groups. The value is only
+            updated if the respective key already exists in the param group.
+        updates:
+            A list of dicts with key value pairs. Each dict must contain a key "name"
+            that specifies the name of the param group(s) that should be updated. All
+            values of the dict will be updated in the param group(s) with the same name.
+
+    Examples:
+        >>> optimizer = torch.optim.SGD(
+        >>>     [
+        >>>         {
+        >>>             "name": "model",
+        >>>             "params": params,
+        >>>         },
+        >>>         {
+        >>>             "name": "model_no_weight_decay",
+        >>>             "params": params_no_weight_decay,
+        >>>             "weight_decay": 0.0,
+        >>>         },
+        >>>         {
+        >>>             "name": "head",
+        >>>             "params": head_params,
+        >>>             "weight_decay": 0.5,
+        >>>         },
+        >>>     ],
+        >>>     lr=0.1,
+        >>>     weight_decay=0.2,
+        >>> )
+        >>>
+        >>> update_param_groups(
+        >>>     optimizer=optimizer,
+        >>>     default_update={"weight_decay": 0.3},
+        >>>     updates=[
+        >>>         {"name": "model_no_weight_decay", "weight_decay": 0.0},
+        >>>         {"name": "head", "weight_decay": 0.6},
+        >>>     ]
+        >>> )
+        >>>
+        >>> # Param group "model" has now weight decay 0.3
+        >>> # Param group "model_no_weight_decay" has still weight decay 0.0
+        >>> # Param group "head" has now weight decay 0.6
+
+    """
+    if default_update is None:
+        default_update = {}
+    if updates is None:
+        updates = []
+
+    # Update the optimizer's param_groups with the provided default values.
+    for param_group in optimizer.param_groups:
+        for key, value in default_update.items():
+            # Update the value only if it already exists in the param_group, we don't
+            # want to accidentally add new keys/values.
+            if key in param_group:
+                param_group[key] = value
+
+    # Update the optimizer's param_groups with the provided updates.
+    for update in updates:
+        found_group = False
+        name = update["name"]
+        for param_group in optimizer.param_groups:
+            if param_group.get("name") == name:
+                found_group = True
+                for key, value in update.items():
+                    if key in param_group:
+                        param_group[key] = value
+                    else:
+                        raise ValueError(
+                            f"Key '{key}' not found in param group with name '{name}'."
+                        )
+        if not found_group:
+            raise ValueError(f"No param group with name '{name}' in optimizer.")

--- a/lightly/utils/optim.py
+++ b/lightly/utils/optim.py
@@ -22,6 +22,8 @@ def update_param_groups(
             A list of dicts with key value pairs. Each dict must contain a key "name"
             that specifies the name of the param group(s) that should be updated. All
             values of the dict will be updated in the param group(s) with the same name.
+            If a key is in default_update and in updates, the value in updates has
+            precedence.
 
     Examples:
         >>> optimizer = torch.optim.SGD(
@@ -65,8 +67,8 @@ def update_param_groups(
         updates = []
 
     # Update the optimizer's param_groups with the provided default values.
-    for param_group in optimizer.param_groups:
-        for key, value in default_update.items():
+    for key, value in default_update.items():
+        for param_group in optimizer.param_groups:
             # Update the value only if it already exists in the param_group, we don't
             # want to accidentally add new keys/values.
             if key in param_group:

--- a/tests/utils/test_optim.py
+++ b/tests/utils/test_optim.py
@@ -7,24 +7,25 @@ from torch.optim import SGD
 from lightly.utils import optim
 
 
-def test_update_param_groups():
+def test_update_param_groups() -> None:
+    params: List[Dict[Any, Any]] = [
+        {
+            "name": "default",
+            "params": Linear(1, 1).parameters(),
+        },
+        {
+            "name": "no_wd",
+            "params": Linear(1, 1).parameters(),
+            "weight_decay": 0.0,
+        },
+        {
+            "name": "wd",
+            "params": Linear(1, 1).parameters(),
+            "weight_decay": 0.5,
+        },
+    ]
     optimizer = SGD(
-        [
-            {
-                "name": "default",
-                "params": Linear(1, 1).parameters(),
-            },
-            {
-                "name": "no_wd",
-                "params": Linear(1, 1).parameters(),
-                "weight_decay": 0.0,
-            },
-            {
-                "name": "wd",
-                "params": Linear(1, 1).parameters(),
-                "weight_decay": 0.5,
-            },
-        ],
+        params=params,
         lr=0.1,
         weight_decay=0.2,
     )
@@ -57,7 +58,7 @@ def test_update_param_groups__default_no_add_entry() -> None:
     assert "unknown" not in optimizer.param_groups[0]
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize(  # type: ignore[misc]
     "updates, match",
     [
         ([{"name": "unknown"}], "No param group with name 'unknown' in optimizer."),

--- a/tests/utils/test_optim.py
+++ b/tests/utils/test_optim.py
@@ -1,0 +1,73 @@
+from typing import Any, Dict, List
+
+import pytest
+from torch.nn import Linear
+from torch.optim import SGD
+
+from lightly.utils import optim
+
+
+def test_update_param_groups():
+    optimizer = SGD(
+        [
+            {
+                "name": "default",
+                "params": Linear(1, 1).parameters(),
+            },
+            {
+                "name": "no_wd",
+                "params": Linear(1, 1).parameters(),
+                "weight_decay": 0.0,
+            },
+            {
+                "name": "wd",
+                "params": Linear(1, 1).parameters(),
+                "weight_decay": 0.5,
+            },
+        ],
+        lr=0.1,
+        weight_decay=0.2,
+    )
+
+    assert optimizer.param_groups[0]["weight_decay"] == 0.2
+    assert optimizer.param_groups[1]["weight_decay"] == 0.0
+    assert optimizer.param_groups[2]["weight_decay"] == 0.5
+
+    optim.update_param_groups(
+        optimizer=optimizer,
+        default_update={"weight_decay": 0.3},
+        updates=[
+            {"name": "no_wd", "weight_decay": 0.0},
+            {"name": "wd", "weight_decay": 0.6},
+        ],
+    )
+
+    assert optimizer.param_groups[0]["weight_decay"] == 0.3
+    assert optimizer.param_groups[1]["weight_decay"] == 0.0
+    assert optimizer.param_groups[2]["weight_decay"] == 0.6
+
+
+def test_update_param_groups__default_no_add_entry() -> None:
+    """Test that update_param_groups does not add new entries to param groups."""
+    optimizer = SGD([{"name": "model", "params": Linear(1, 1).parameters()}], lr=0.1)
+    optim.update_param_groups(
+        optimizer=optimizer,
+        default_update={"unknown": 1.0},
+    )
+    assert "unknown" not in optimizer.param_groups[0]
+
+
+@pytest.mark.parametrize(
+    "updates, match",
+    [
+        ([{"name": "unknown"}], "No param group with name 'unknown' in optimizer."),
+        (
+            [{"name": "model", "unknown": 1.0}],
+            "Key 'unknown' not found in param group with name 'model'.",
+        ),
+    ],
+)
+def test_update_param_groups__error(updates: List[Dict[str, Any]], match: str) -> None:
+    optimizer = SGD([{"name": "model", "params": Linear(1, 1).parameters()}], lr=0.1)
+    with pytest.raises(ValueError, match=match):
+        optim.update_param_groups(optimizer=optimizer, updates=updates)


### PR DESCRIPTION
### Changes

* Add `update_param_groups` to `lightly/utils/optim`
 
This is useful for updating values in parameter groups when following training schedules.

### How was it tested?

* Added unit tests
