### PR TITLE
Update cosine warmup tests

### DIFF
--- a/lightly/utils/scheduler.py
+++ b/lightly/utils/scheduler.py
@@ -144,13 +144,17 @@ class CosineWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):
         max_epochs:
             Total number of training epochs or steps.
         last_epoch:
-            The index of last epoch or step. Default: -1
+            The index of last epoch or step.
         start_value:
-            Starting learning rate scale. Default: 1.0
+            Starting learning rate.
         end_value:
-            Target learning rate scale. Default: 0.001
+            Target learning rate.
         verbose:
-            If True, prints a message to stdout for each update. Default: False.
+            If True, prints a message to stdout for each update.
+        warmup_start_value:
+            Starting learning rate for warmup.
+        warmup_end_value:
+            Target learning rate for warmup. Defaults to start_value.
 
     Note: The `epoch` arguments do not necessarily have to be epochs. Any step or index
     can be used. The naming follows the Pytorch convention to use `epoch` for the steps
@@ -167,12 +171,16 @@ class CosineWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):
         end_value: float = 0.001,
         period: Optional[int] = None,
         verbose: bool = False,
+        warmup_start_value: float = 0.0,
+        warmup_end_value: Optional[float] = None,
     ) -> None:
         self.warmup_epochs = warmup_epochs
         self.max_epochs = max_epochs
         self.start_value = start_value
         self.end_value = end_value
         self.period = period
+        self.warmup_start_value = warmup_start_value
+        self.warmup_end_value = warmup_end_value
         super().__init__(
             optimizer=optimizer,
             lr_lambda=self.scale_lr,
@@ -198,7 +206,7 @@ class CosineWarmupScheduler(torch.optim.lr_scheduler.LambdaLR):
             start_value=self.start_value,
             end_value=self.end_value,
             warmup_steps=self.warmup_epochs,
-            warmup_start_value=0.0,
-            warmup_end_value=self.start_value,
+            warmup_start_value=self.warmup_start_value,
+            warmup_end_value=self.warmup_end_value,
             period=self.period,
         )

--- a/tests/utils/test_scheduler.py
+++ b/tests/utils/test_scheduler.py
@@ -1,35 +1,251 @@
 import unittest
+from typing import Optional
 
+import pytest
 import torch
 from torch import nn
+from torch.nn import Linear
+from torch.optim import SGD
 
-from lightly.utils.scheduler import CosineWarmupScheduler, cosine_schedule
+from lightly.utils import scheduler
+from lightly.utils.scheduler import CosineWarmupScheduler
 
 
+@pytest.mark.parametrize(
+    "step, max_steps, start_value, end_value, period, expected",
+    [
+        # No period
+        (0, 10, 1.0, 0.0, None, 1.0),
+        (1, 10, 1.0, 0.0, None, 0.96984631),
+        (2, 10, 1.0, 0.0, None, 0.88302222),
+        (10, 10, 1.0, 0.0, None, 0.0),
+        # Period
+        (0, 20, 1.0, 0.0, 10, 1.0),
+        (1, 20, 1.0, 0.0, 10, 0.90450849),
+        (5, 20, 1.0, 0.0, 10, 0.0),
+        (10, 20, 1.0, 0.0, 10, 1.0),
+        (11, 20, 1.0, 0.0, 10, 0.90450849),
+        (15, 20, 1.0, 0.0, 10, 0.0),
+        (20, 20, 1.0, 0.0, 10, 1.0),
+    ],
+)
+def test_cosine_schedule(
+    step: int,
+    max_steps: int,
+    start_value: float,
+    end_value: float,
+    period: Optional[int],
+    expected: float,
+) -> None:
+    assert scheduler.cosine_schedule(
+        step=step,
+        max_steps=max_steps,
+        start_value=start_value,
+        end_value=end_value,
+        period=period,
+    ) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "step, max_steps, start_value, end_value, period, expected_message",
+    [
+        (-1, 1, 0.0, 1.0, None, "Current step number -1 can't be negative"),
+        (0, 0, 0.0, 1.0, None, "Total step number 0 must be >= 1"),
+        (1, 0, 0.0, 1.0, None, "Total step number 0 must be >= 1"),
+        (0, 1, 0.0, 1.0, -1, "Period -1 must be >= 1"),
+    ],
+)
+def test_cosine_schedule__error(
+    step: int,
+    max_steps: int,
+    start_value: float,
+    end_value: float,
+    period: Optional[int],
+    expected_message: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        scheduler.cosine_schedule(
+            step=step,
+            max_steps=max_steps,
+            start_value=start_value,
+            end_value=end_value,
+            period=period,
+        )
+
+
+def test_cosine_schedule__warn_step_exceeds_max_steps() -> None:
+    with pytest.warns(
+        RuntimeWarning, match="Current step number 11 exceeds max_steps 10."
+    ):
+        scheduler.cosine_schedule(step=11, max_steps=10, start_value=0.0, end_value=1.0)
+
+
+COSINE_WARMUP_VALUES = [
+    # No warmup, no period
+    (0, 10, 1.0, 0.0, 0, 0.0, None, None, 1.0),
+    (1, 10, 1.0, 0.0, 0, 0.0, None, None, 0.96984631),
+    (2, 10, 1.0, 0.0, 0, 0.0, None, None, 0.88302222),
+    (10, 10, 1.0, 0.0, 0, 0.0, None, None, 0.0),
+    # Warmup, no period
+    (0, 20, 1.0, 0.0, 10, 0.0, 0.5, None, 0.05),
+    (1, 20, 1.0, 0.0, 10, 0.0, 0.5, None, 0.1),
+    (2, 20, 1.0, 0.0, 10, 0.0, 0.5, None, 0.15),
+    (10, 20, 1.0, 0.0, 10, 0.0, 0.5, None, 1.0),
+    (11, 20, 1.0, 0.0, 10, 0.0, 0.5, None, 0.96984631),
+    (20, 20, 1.0, 0.0, 10, 0.0, 0.5, None, 0.0),
+    # No warmup, period
+    (0, 20, 1.0, 0.0, 0, 0.0, None, 10, 1.0),
+    (1, 20, 1.0, 0.0, 0, 0.0, None, 10, 0.90450849),
+    (5, 20, 1.0, 0.0, 0, 0.0, None, 10, 0.0),
+    (10, 20, 1.0, 0.0, 0, 0.0, None, 10, 1.0),
+    (11, 20, 1.0, 0.0, 0, 0.0, None, 10, 0.90450849),
+    (15, 20, 1.0, 0.0, 0, 0.0, None, 10, 0.0),
+    (20, 20, 1.0, 0.0, 0, 0.0, None, 10, 1.0),
+    # Warmup and period
+    (0, 20, 1.0, 0.0, 10, 0.0, 0.5, 10, 0.05),
+    (1, 20, 1.0, 0.0, 10, 0.0, 0.5, 10, 0.1),
+    (2, 20, 1.0, 0.0, 10, 0.0, 0.5, 10, 0.15),
+    (10, 20, 1.0, 0.0, 10, 0.0, 0.5, 10, 1.0),
+    (11, 20, 1.0, 0.0, 0, 0.0, 0.5, 10, 0.90450849),
+    (15, 20, 1.0, 0.0, 0, 0.0, 0.5, 10, 0.0),
+    (20, 20, 1.0, 0.0, 0, 0.0, 0.5, 10, 1.0),
+]
+
+
+@pytest.mark.parametrize(
+    "step, max_steps, start_value, end_value, warmup_steps, warmup_start_value, warmup_end_value, period, expected",
+    COSINE_WARMUP_VALUES,
+)
+def test_cosine_warmup_schedule(
+    step: int,
+    max_steps: int,
+    start_value: float,
+    end_value: float,
+    warmup_steps: int,
+    warmup_start_value: float,
+    warmup_end_value: Optional[float],
+    period: Optional[int],
+    expected: float,
+) -> None:
+    assert scheduler.cosine_warmup_schedule(
+        step=step,
+        max_steps=max_steps,
+        start_value=start_value,
+        end_value=end_value,
+        warmup_steps=warmup_steps,
+        warmup_start_value=warmup_start_value,
+        warmup_end_value=warmup_end_value,
+        period=period,
+    ) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "warmup_steps, expected_message",
+    [
+        (-1, "Warmup steps -1 can't be negative"),
+        (2, "Warmup steps 2 must be <= max_steps"),
+    ],
+)
+def test_cosine_warmup_schedule__error_warmup_steps(
+    warmup_steps: int,
+    expected_message: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        scheduler.cosine_warmup_schedule(
+            step=0,
+            max_steps=1,
+            start_value=0.0,
+            end_value=1.0,
+            warmup_steps=warmup_steps,
+            warmup_start_value=0.0,
+        )
+
+
+def test_cosine_warmup_schedule__warn_step_exceeds_max_steps() -> None:
+    with pytest.warns(
+        RuntimeWarning, match="Current step number 11 exceeds max_steps 10."
+    ):
+        scheduler.cosine_warmup_schedule(
+            step=11,
+            max_steps=10,
+            start_value=0.0,
+            end_value=1.0,
+            warmup_steps=0,
+            warmup_start_value=0.0,
+        )
+
+
+class TestCosineWarmupScheduler:
+    @pytest.mark.parametrize(
+        "step, max_steps, start_value, end_value, warmup_steps, warmup_start_value, warmup_end_value, period, expected",
+        COSINE_WARMUP_VALUES,
+    )
+    def test_get_value(
+        self,
+        step: int,
+        max_steps: int,
+        start_value: float,
+        end_value: float,
+        warmup_steps: int,
+        warmup_start_value: float,
+        warmup_end_value: float,
+        period: Optional[int],
+        expected: float,
+    ) -> None:
+        optimizer = SGD(Linear(1, 1).parameters(), lr=1.0)
+        scheduler = CosineWarmupScheduler(
+            optimizer=optimizer,
+            max_epochs=max_steps,
+            start_value=start_value,
+            end_value=end_value,
+            warmup_epochs=warmup_steps,
+            warmup_start_value=warmup_start_value,
+            warmup_end_value=warmup_end_value,
+            period=period,
+        )
+        for _ in range(step):
+            scheduler.step()
+        assert scheduler.get_last_lr()[0] == pytest.approx(expected)
+
+
+# TODO(Guarin, 09/24): Remove these tests as they have been replaced by
+# TestCosineWarmupScheduler.
 class TestScheduler(unittest.TestCase):
     def test_cosine_schedule(self) -> None:
-        self.assertAlmostEqual(cosine_schedule(1, 10, 0.99, 1.0), 0.99030154, 6)
-        self.assertAlmostEqual(cosine_schedule(95, 100, 0.7, 2.0), 1.99477063, 6)
-        self.assertAlmostEqual(cosine_schedule(0, 1, 0.996, 1.0), 1.0, 6)
-        self.assertAlmostEqual(cosine_schedule(10, 10, 0.0, 1.0), 1.0, 6)
+        self.assertAlmostEqual(
+            scheduler.cosine_schedule(1, 10, 0.99, 1.0), 0.99030154, 6
+        )
+        self.assertAlmostEqual(
+            scheduler.cosine_schedule(95, 100, 0.7, 2.0), 1.99477063, 6
+        )
+        self.assertAlmostEqual(scheduler.cosine_schedule(0, 1, 0.996, 1.0), 1.0, 6)
+        self.assertAlmostEqual(scheduler.cosine_schedule(10, 10, 0.0, 1.0), 1.0, 6)
         with self.assertRaises(ValueError):
-            cosine_schedule(-1, 1, 0.0, 1.0)
+            scheduler.cosine_schedule(-1, 1, 0.0, 1.0)
         with self.assertRaises(ValueError):
-            cosine_schedule(0, 0, 0.0, 1.0)
+            scheduler.cosine_schedule(0, 0, 0.0, 1.0)
         with self.assertRaises(ValueError):
-            cosine_schedule(1, 0, 0.0, 1.0)
+            scheduler.cosine_schedule(1, 0, 0.0, 1.0)
         with self.assertWarns(
             RuntimeWarning, msg="Current step number 11 exceeds max_steps 10."
         ):
-            cosine_schedule(11, 10, 0.0, 1.0)
+            scheduler.cosine_schedule(11, 10, 0.0, 1.0)
 
     def test_cosine_schedule__period(self) -> None:
-        self.assertAlmostEqual(cosine_schedule(0, 1, 0, 1.0, period=10), 0.0, 6)
-        self.assertAlmostEqual(cosine_schedule(3, 1, 0, 2.0, period=10), 1.30901706, 6)
-        self.assertAlmostEqual(cosine_schedule(10, 1, 0, 1.0, period=10), 0.0, 6)
-        self.assertAlmostEqual(cosine_schedule(15, 1, 0, 1.0, period=10), 1.0, 6)
+        self.assertAlmostEqual(
+            scheduler.cosine_schedule(0, 1, 0, 1.0, period=10), 0.0, 6
+        )
+        self.assertAlmostEqual(
+            scheduler.cosine_schedule(3, 1, 0, 2.0, period=10), 1.30901706, 6
+        )
+        self.assertAlmostEqual(
+            scheduler.cosine_schedule(10, 1, 0, 1.0, period=10), 0.0, 6
+        )
+        self.assertAlmostEqual(
+            scheduler.cosine_schedule(15, 1, 0, 1.0, period=10), 1.0, 6
+        )
         with self.assertRaises(ValueError):
-            cosine_schedule(1, 10, 0.0, 1.0, period=-1)
+            scheduler.cosine_schedule(1, 10, 0.0, 1.0, period=-1)
 
     def test_CosineWarmupScheduler(self) -> None:
         model = nn.Linear(10, 1)


### PR DESCRIPTION
### Changes

* Update cosine warmup tests
* Add `warmup_start_value` and `warmup_end_value` arguments to CosineWarmupScheduler

Follow-up from #1644 

### How was it tested?

* Added new tests while keeping the old tests

Will remove the old tests in a follow-up.