### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -21,10 +21,10 @@ jobs:
         LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
         git checkout $LATEST_TAG
         echo "tag_name=$LATEST_TAG" >> $GITHUB_OUTPUT;
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Build and release
       id: build_and_release
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.10"]
+        python: ["3.7", "3.12"]
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,15 +59,15 @@ jobs:
           source .venv/bin/activate
           export LIGHTLY_SERVER_LOCATION="localhost:-1"
           python -m pytest -s -v --runslow --ignore=./lightly/openapi_generated/
-      - name: Run Pytest with Coverage (Python 3.10)
-        if: matrix.python == '3.10'
+      - name: Run Pytest with Coverage (Python 3.12)
+        if: matrix.python == '3.12'
         run: |
           source .venv/bin/activate
           export LIGHTLY_SERVER_LOCATION="localhost:-1"
           uv pip install pytest-cov==5.0.0
           python -m pytest -s -v --runslow --cov=./lightly --cov-report=xml --ignore=./lightly/openapi_generated/
       - name: Upload Coverage to Codecov
-        if: matrix.python == '3.10'
+        if: matrix.python == '3.12'
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false

--- a/.github/workflows/test_api_deps_only.yml
+++ b/.github/workflows/test_api_deps_only.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Set Up Environment
         run: |
           make install-uv reset-venv

--- a/.github/workflows/weekly_dependency_test.yml
+++ b/.github/workflows/weekly_dependency_test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set Up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Set Up Environment
       run: |
         make install-uv reset-venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [

--- a/tests/api/test_download.py
+++ b/tests/api/test_download.py
@@ -188,7 +188,7 @@ class TestDownload(unittest.TestCase):
     def test_download_all_video_frames_timeout(self):
         with tempfile.NamedTemporaryFile(suffix=".avi") as file:
             _generate_video(file.name)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 RuntimeError,
                 "Maximum retries exceeded.*av.error.ExitError.*Immediate exit requested.*",
             ):
@@ -237,7 +237,7 @@ class TestDownload(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix=".avi") as file:
             n_frames = 5
             _generate_video(file.name, n_frames)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 RuntimeError,
                 "Maximum retries exceeded.*av.error.ExitError.*Immediate exit requested.*",
             ):
@@ -436,7 +436,7 @@ class TestDownload(unittest.TestCase):
     def test_download_video_Frame_count_timeout(self):
         with tempfile.NamedTemporaryFile(suffix=".avi") as file:
             _generate_video(file.name)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 RuntimeError,
                 "Maximum retries exceeded.*av.error.ExitError.*Immediate exit requested.*",
             ):

--- a/tests/loss/test_DINOLoss.py
+++ b/tests/loss/test_DINOLoss.py
@@ -221,11 +221,11 @@ class TestDINOLoss(unittest.TestCase):
                 for param, orig_param in zip(
                     student.parameters(), orig_student.parameters()
                 ):
-                    self.assertTrue(torch.allclose(param, orig_param))
+                    torch.testing.assert_close(param, orig_param)
                 for param, orig_param in zip(
                     teacher.parameters(), orig_teacher.parameters()
                 ):
-                    self.assertTrue(torch.allclose(param, orig_param))
+                    torch.testing.assert_close(param, orig_param)
 
         def test_all(**kwargs):
             """Tests all combinations of the input parameters"""

--- a/tests/loss/test_VICRegLoss.py
+++ b/tests/loss/test_VICRegLoss.py
@@ -81,7 +81,7 @@ class TestVICRegLossUnitTest(unittest.TestCase):
         loss = VICRegLoss(nu_param=0.5)
         x0 = torch.randn((2, 10, 32))
         x1 = torch.randn((2, 10, 32))
-        assert loss(x0, x1).item() == _reference_vicregl_vicreg_loss(x0, x1).item()
+        torch.testing.assert_close(loss(x0, x1), _reference_vicregl_vicreg_loss(x0, x1))
 
 
 def _reference_vicreg_loss(


### PR DESCRIPTION
closes #1473

## Description

### CI Updates

Updates the  tests to use python 3.12 instead of 3.10. 

### Testing updates

These were necessary because local tests with python 3.12 were failing (on Mac).

Replaces `self.assertRaisesRegexp` with `self.assertRaisesRegex`, as the former was deprecated in python 3.2, see [here](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaisesRegex) and removed in python 3.12.

Replaces `self.assertTrue(torch.allclose(a, b))` with `torch.testing.assert_close(a,b)`, as the latter has better debugging support and more stability under other python / pytorch versions. `torch.testing.assert_close` was added in April 2021 and is thus available for our oldest supported torch version (1.10 was released in late 2021).
Also uses it for one more test.

## Testing

CI changes test themselves ;)
