### PR TITLE
Guarin lig 5512 fix local type check

### DIFF
--- a/lightly/models/batchnorm.py
+++ b/lightly/models/batchnorm.py
@@ -56,29 +56,30 @@ class SplitBatchNorm(nn.BatchNorm2d):
 
         # during training, use different stats for each split and otherwise
         # use the stats from the first split
+        momentum = 0.0 if self.momentum is None else self.momentum
         if self.training or not self.track_running_stats:
             result = nn.functional.batch_norm(
-                input.view(-1, C * self.num_splits, H, W),
-                self.running_mean,
-                self.running_var,
-                self.weight.repeat(self.num_splits),
-                self.bias.repeat(self.num_splits),
-                True,
-                self.momentum,
-                self.eps,
+                input=input.view(-1, C * self.num_splits, H, W),
+                running_mean=self.running_mean,
+                running_var=self.running_var,
+                weight=self.weight.repeat(self.num_splits),
+                bias=self.bias.repeat(self.num_splits),
+                training=True,
+                momentum=momentum,
+                eps=self.eps,
             ).view(N, C, H, W)
         else:
             # We have to ignore the type errors here, because we know that running_mean
             # and running_var are not None, but the type checker does not.
             result = nn.functional.batch_norm(
-                input,
-                self.running_mean[: self.num_features],  # type: ignore[index]
-                self.running_var[: self.num_features],  # type: ignore[index]
-                self.weight,
-                self.bias,
-                False,
-                self.momentum,
-                self.eps,
+                input=input,
+                running_mean=self.running_mean[: self.num_features],  # type: ignore[index]
+                running_var=self.running_var[: self.num_features],  # type: ignore[index]
+                weight=self.weight,
+                bias=self.bias,
+                training=False,
+                momentum=momentum,
+                eps=self.eps,
             )
 
         return result

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -219,6 +219,7 @@ class DINOViewTransform:
             T.RandomResizedCrop(
                 size=crop_size,
                 scale=crop_scale,
+                # Type ignore needed because BICUBIC is not recognized as an attribute.
                 interpolation=PIL.Image.BICUBIC,  # type: ignore[attr-defined]
             ),
             T.RandomHorizontalFlip(p=hf_prob),

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -219,7 +219,7 @@ class DINOViewTransform:
             T.RandomResizedCrop(
                 size=crop_size,
                 scale=crop_scale,
-                interpolation=PIL.Image.BICUBIC,
+                interpolation=PIL.Image.BICUBIC, # type: ignore[attr-defined]
             ),
             T.RandomHorizontalFlip(p=hf_prob),
             T.RandomVerticalFlip(p=vf_prob),

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -219,7 +219,7 @@ class DINOViewTransform:
             T.RandomResizedCrop(
                 size=crop_size,
                 scale=crop_scale,
-                interpolation=PIL.Image.BICUBIC, # type: ignore[attr-defined]
+                interpolation=PIL.Image.BICUBIC,  # type: ignore[attr-defined]
             ),
             T.RandomHorizontalFlip(p=hf_prob),
             T.RandomVerticalFlip(p=vf_prob),

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -10,7 +10,6 @@ from PIL.Image import Image as PILImage
 from torch import Tensor
 from torchvision import transforms as T
 
-
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from typing import List
+from typing import TYPE_CHECKING, Callable, List
 
 import numpy as np
 import torch
@@ -9,6 +9,10 @@ from PIL import Image as Image
 from PIL.Image import Image as PILImage
 from torch import Tensor
 from torchvision import transforms as T
+
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 class Jigsaw(object):
@@ -49,7 +53,7 @@ class Jigsaw(object):
         self.crop_size = crop_size
         self.grid_size = int(img_size / self.n_grid)
         self.side = self.grid_size - self.crop_size
-        self.transform = transform
+        self.transform: Callable[[PILImage], Tensor] = transform
 
         yy, xx = np.meshgrid(np.arange(n_grid), np.arange(n_grid))
         self.yy = np.reshape(yy * self.grid_size, (n_grid * n_grid,))
@@ -66,11 +70,11 @@ class Jigsaw(object):
         """
         r_x = np.random.randint(0, self.side + 1, self.n_grid * self.n_grid)
         r_y = np.random.randint(0, self.side + 1, self.n_grid * self.n_grid)
-        img = np.asarray(img, np.uint8)
-        crops: List[PILImage] = []
+        img_arr = np.asarray(img, np.uint8)
+        crops: List[NDArray[np.uint8]] = []
         for i in range(self.n_grid * self.n_grid):
             crops.append(
-                img[
+                img_arr[
                     self.xx[i] + r_x[i] : self.xx[i] + r_x[i] + self.crop_size,
                     self.yy[i] + r_y[i] : self.yy[i] + r_y[i] + self.crop_size,
                     :,

--- a/lightly/transforms/rotation.py
+++ b/lightly/transforms/rotation.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-from typing import Tuple, Union
+from typing import Callable, Tuple, Union
 
 import numpy as np
 import torchvision.transforms as T
@@ -65,7 +65,7 @@ class RandomRotateDegrees:
     """
 
     def __init__(self, prob: float, degrees: Union[float, Tuple[float, float]]):
-        self.transform = T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
+        self.transform: Callable[[Union[Image, Tensor]], Union[Image, Tensor]] = T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
 
     def __call__(self, image: Union[Image, Tensor]) -> Union[Image, Tensor]:
         """Rotates the images with a given probability.
@@ -78,8 +78,7 @@ class RandomRotateDegrees:
             Rotated image or original image.
 
         """
-        rot_image: Union[Image, Tensor] = self.transform(image)
-        return rot_image
+        return self.transform(image)
 
 
 def random_rotation_transform(

--- a/lightly/transforms/rotation.py
+++ b/lightly/transforms/rotation.py
@@ -78,7 +78,8 @@ class RandomRotateDegrees:
             Rotated image or original image.
 
         """
-        return self.transform(image)
+        rot_image: Union[Image, Tensor] = self.transform(image)
+        return rot_image
 
 
 def random_rotation_transform(

--- a/lightly/transforms/rotation.py
+++ b/lightly/transforms/rotation.py
@@ -65,7 +65,9 @@ class RandomRotateDegrees:
     """
 
     def __init__(self, prob: float, degrees: Union[float, Tuple[float, float]]):
-        self.transform: Callable[[Union[Image, Tensor]], Union[Image, Tensor]] = T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
+        self.transform: Callable[
+            [Union[Image, Tensor]], Union[Image, Tensor]
+        ] = T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
 
     def __call__(self, image: Union[Image, Tensor]) -> Union[Image, Tensor]:
         """Rotates the images with a given probability.

--- a/lightly/utils/benchmarking/linear_classifier.py
+++ b/lightly/utils/benchmarking/linear_classifier.py
@@ -131,9 +131,9 @@ class LinearClassifier(LightningModule):
 
     # Type ignore is needed because return type of LightningModule.configure_optimizers
     # is complicated and typing changes between versions.
-    def configure_optimizers( # type: ignore[override]
+    def configure_optimizers(  # type: ignore[override]
         self,
-    ) -> Tuple[List[Optimizer], List[Dict[str, Union[Any, str]]]]: 
+    ) -> Tuple[List[Optimizer], List[Dict[str, Union[Any, str]]]]:
         parameters = list(self.classification_head.parameters())
         if not self.freeze_model:
             parameters += self.model.parameters()

--- a/lightly/utils/benchmarking/linear_classifier.py
+++ b/lightly/utils/benchmarking/linear_classifier.py
@@ -129,9 +129,11 @@ class LinearClassifier(LightningModule):
         self.log_dict(log_dict, prog_bar=True, sync_dist=True, batch_size=batch_size)
         return loss
 
-    def configure_optimizers(
+    # Type ignore is needed because return type of LightningModule.configure_optimizers
+    # is complicated and typing changes between versions.
+    def configure_optimizers( # type: ignore[override]
         self,
-    ) -> Tuple[List[Optimizer], List[Dict[str, Union[Any, str]]]]:
+    ) -> Tuple[List[Optimizer], List[Dict[str, Union[Any, str]]]]: 
         parameters = list(self.classification_head.parameters())
         if not self.freeze_model:
             parameters += self.model.parameters()

--- a/lightly/utils/lars.py
+++ b/lightly/utils/lars.py
@@ -1,8 +1,7 @@
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, overload
 
 import torch
-from torch import Tensor
-from torch.optim.optimizer import Optimizer, required  # type: ignore[attr-defined]
+from torch.optim.optimizer import Optimizer
 
 
 class LARS(Optimizer):
@@ -69,7 +68,7 @@ class LARS(Optimizer):
     def __init__(
         self,
         params: Any,
-        lr: float = required,
+        lr: float,
         momentum: float = 0,
         dampening: float = 0,
         weight_decay: float = 0,
@@ -77,7 +76,7 @@ class LARS(Optimizer):
         trust_coefficient: float = 0.001,
         eps: float = 1e-8,
     ):
-        if lr is not required and lr < 0.0:
+        if lr < 0.0:
             raise ValueError(f"Invalid learning rate: {lr}")
         if momentum < 0.0:
             raise ValueError(f"Invalid momentum value: {momentum}")
@@ -103,6 +102,15 @@ class LARS(Optimizer):
 
         for group in self.param_groups:
             group.setdefault("nesterov", False)
+    
+    # Type ignore for overloads is required for Python 3.7
+    @overload # type: ignore[override]
+    def step(self, closure: None = None) -> None: 
+        ...
+
+    @overload # type: ignore[override]
+    def step(self, closure: Callable[[], float]) -> float: 
+        ...
 
     @torch.no_grad()
     def step(self, closure: Optional[Callable[[], float]] = None) -> Optional[float]:

--- a/lightly/utils/lars.py
+++ b/lightly/utils/lars.py
@@ -102,14 +102,14 @@ class LARS(Optimizer):
 
         for group in self.param_groups:
             group.setdefault("nesterov", False)
-    
+
     # Type ignore for overloads is required for Python 3.7
-    @overload # type: ignore[override]
-    def step(self, closure: None = None) -> None: 
+    @overload  # type: ignore[override]
+    def step(self, closure: None = None) -> None:
         ...
 
-    @overload # type: ignore[override]
-    def step(self, closure: Callable[[], float]) -> float: 
+    @overload  # type: ignore[override]
+    def step(self, closure: Callable[[], float]) -> float:
         ...
 
     @torch.no_grad()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ omit = ["lightly/openapi_generated/*"]
 
 [tool.mypy]
 ignore_missing_imports = true
-python_version = "3.10"
 warn_unused_configs = true
 strict_equality = true
 
@@ -167,7 +166,7 @@ no_implicit_optional = true
 strict_optional = true
 
 # Configuring warnings
-warn_unused_ignores = true
+warn_unused_ignores = false   # Different ignores are required for different Python versions
 warn_no_return = true
 warn_return_any = true
 warn_redundant_casts = true

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,17 @@
+from torch import Tensor
+from typing import Any, List
+
+def assert_list_tensor(items: Any) -> List[Tensor]:
+    """Makes sure that the input is a list of tensors.
+    
+    Should be used in tests where functions return Union[List[Tensor], List[Image]] and
+    we want to make sure that the output is a list of tensors.
+
+    Example:
+        >>> output: Union[List[Tensor], List[Image]] = transform(images)
+        >>> tensors: List[Tensor] = assert_list_tensor(output)
+
+    """
+    assert isinstance(items, list)
+    assert all(isinstance(item, Tensor) for item in items)
+    return items

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,9 +1,11 @@
-from torch import Tensor
 from typing import Any, List
+
+from torch import Tensor
+
 
 def assert_list_tensor(items: Any) -> List[Tensor]:
     """Makes sure that the input is a list of tensors.
-    
+
     Should be used in tests where functions return Union[List[Tensor], List[Image]] and
     we want to make sure that the output is a list of tensors.
 

--- a/tests/transforms/test_byol_transform.py
+++ b/tests/transforms/test_byol_transform.py
@@ -5,6 +5,7 @@ from lightly.transforms.byol_transform import (
     BYOLView1Transform,
     BYOLView2Transform,
 )
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -20,7 +21,7 @@ def test_multi_view_on_pil_image() -> None:
         view_2_transform=BYOLView2Transform(input_size=32),
     )
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)

--- a/tests/transforms/test_byol_transform.py
+++ b/tests/transforms/test_byol_transform.py
@@ -5,6 +5,7 @@ from lightly.transforms.byol_transform import (
     BYOLView1Transform,
     BYOLView2Transform,
 )
+
 from .. import helpers
 
 

--- a/tests/transforms/test_densecl_transform.py
+++ b/tests/transforms/test_densecl_transform.py
@@ -1,12 +1,13 @@
 from PIL import Image
 
 from lightly.transforms import DenseCLTransform
+from .. import helpers
 
 
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = DenseCLTransform(input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)

--- a/tests/transforms/test_densecl_transform.py
+++ b/tests/transforms/test_densecl_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms import DenseCLTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_dino_transform.py
+++ b/tests/transforms/test_dino_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.dino_transform import DINOTransform, DINOViewTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_dino_transform.py
+++ b/tests/transforms/test_dino_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.dino_transform import DINOTransform, DINOViewTransform
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -13,7 +14,7 @@ def test_view_on_pil_image() -> None:
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = DINOTransform(global_crop_size=32, local_crop_size=8)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 8
     # global views
     assert all(out.shape == (3, 32, 32) for out in output[:2])

--- a/tests/transforms/test_fastsiam_transform.py
+++ b/tests/transforms/test_fastsiam_transform.py
@@ -1,12 +1,12 @@
 from PIL import Image
 
 from lightly.transforms.fast_siam_transform import FastSiamTransform
-
+from .. import helpers
 
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = FastSiamTransform(num_views=3, input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 3
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)

--- a/tests/transforms/test_fastsiam_transform.py
+++ b/tests/transforms/test_fastsiam_transform.py
@@ -1,7 +1,9 @@
 from PIL import Image
 
 from lightly.transforms.fast_siam_transform import FastSiamTransform
+
 from .. import helpers
+
 
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = FastSiamTransform(num_views=3, input_size=32)

--- a/tests/transforms/test_moco_transform.py
+++ b/tests/transforms/test_moco_transform.py
@@ -1,12 +1,13 @@
 from PIL import Image
 
 from lightly.transforms.moco_transform import MoCoV1Transform, MoCoV2Transform
+from .. import helpers
 
 
 def test_moco_v1_multi_view_on_pil_image() -> None:
     multi_view_transform = MoCoV1Transform(input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)
@@ -15,7 +16,7 @@ def test_moco_v1_multi_view_on_pil_image() -> None:
 def test_moco_v2_multi_view_on_pil_image() -> None:
     multi_view_transform = MoCoV2Transform(input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)

--- a/tests/transforms/test_moco_transform.py
+++ b/tests/transforms/test_moco_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.moco_transform import MoCoV1Transform, MoCoV2Transform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_msn_transform.py
+++ b/tests/transforms/test_msn_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.msn_transform import MSNTransform, MSNViewTransform
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -13,7 +14,7 @@ def test_view_on_pil_image() -> None:
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = MSNTransform(random_size=32, focal_size=8)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 12
     # global views
     assert all(out.shape == (3, 32, 32) for out in output[:2])

--- a/tests/transforms/test_msn_transform.py
+++ b/tests/transforms/test_msn_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.msn_transform import MSNTransform, MSNViewTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_pirl_transform.py
+++ b/tests/transforms/test_pirl_transform.py
@@ -1,12 +1,13 @@
 from PIL import Image
 
 from lightly.transforms.pirl_transform import PIRLTransform
+from .. import helpers
 
 
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = PIRLTransform(input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (9, 3, 10, 10)

--- a/tests/transforms/test_pirl_transform.py
+++ b/tests/transforms/test_pirl_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.pirl_transform import PIRLTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_simclr_transform.py
+++ b/tests/transforms/test_simclr_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.simclr_transform import SimCLRTransform, SimCLRViewTransform
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -13,7 +14,7 @@ def test_view_on_pil_image() -> None:
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = SimCLRTransform(input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)

--- a/tests/transforms/test_simclr_transform.py
+++ b/tests/transforms/test_simclr_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.simclr_transform import SimCLRTransform, SimCLRViewTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_simsiam_transform.py
+++ b/tests/transforms/test_simsiam_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.simsiam_transform import SimSiamTransform, SimSiamViewTransform
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -13,7 +14,7 @@ def test_view_on_pil_image() -> None:
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = SimSiamTransform(input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)

--- a/tests/transforms/test_simsiam_transform.py
+++ b/tests/transforms/test_simsiam_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.simsiam_transform import SimSiamTransform, SimSiamViewTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_smog_transform.py
+++ b/tests/transforms/test_smog_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.smog_transform import SMoGTransform, SmoGViewTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_smog_transform.py
+++ b/tests/transforms/test_smog_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.smog_transform import SMoGTransform, SmoGViewTransform
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -13,7 +14,7 @@ def test_view_on_pil_image() -> None:
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = SMoGTransform(crop_sizes=(32, 8))
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 8
     assert all(out.shape == (3, 32, 32) for out in output[:4])
     assert all(out.shape == (3, 8, 8) for out in output[4:])

--- a/tests/transforms/test_swav_transform.py
+++ b/tests/transforms/test_swav_transform.py
@@ -1,7 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.swav_transform import SwaVTransform, SwaVViewTransform
-
+from .. import helpers
 
 def test_view_on_pil_image() -> None:
     single_view_transform = SwaVViewTransform()
@@ -13,7 +13,7 @@ def test_view_on_pil_image() -> None:
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = SwaVTransform(crop_sizes=(32, 8))
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 8
     assert all(out.shape == (3, 32, 32) for out in output[:2])
     assert all(out.shape == (3, 8, 8) for out in output[2:])

--- a/tests/transforms/test_swav_transform.py
+++ b/tests/transforms/test_swav_transform.py
@@ -1,7 +1,9 @@
 from PIL import Image
 
 from lightly.transforms.swav_transform import SwaVTransform, SwaVViewTransform
+
 from .. import helpers
+
 
 def test_view_on_pil_image() -> None:
     single_view_transform = SwaVViewTransform()

--- a/tests/transforms/test_vicreg_transform.py
+++ b/tests/transforms/test_vicreg_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.vicreg_transform import VICRegTransform, VICRegViewTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_vicreg_transform.py
+++ b/tests/transforms/test_vicreg_transform.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from lightly.transforms.vicreg_transform import VICRegTransform, VICRegViewTransform
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -13,7 +14,7 @@ def test_view_on_pil_image() -> None:
 def test_multi_view_on_pil_image() -> None:
     multi_view_transform = VICRegTransform(input_size=32)
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 2
     assert output[0].shape == (3, 32, 32)
     assert output[1].shape == (3, 32, 32)

--- a/tests/transforms/test_vicregl_transform.py
+++ b/tests/transforms/test_vicregl_transform.py
@@ -1,8 +1,10 @@
 from typing import List
+
 from PIL import Image
 from torch import Tensor
 
 from lightly.transforms.vicregl_transform import VICRegLTransform, VICRegLViewTransform
+
 from .. import helpers
 
 

--- a/tests/transforms/test_vicregl_transform.py
+++ b/tests/transforms/test_vicregl_transform.py
@@ -1,6 +1,9 @@
+from typing import List
 from PIL import Image
+from torch import Tensor
 
 from lightly.transforms.vicregl_transform import VICRegLTransform, VICRegLViewTransform
+from .. import helpers
 
 
 def test_view_on_pil_image() -> None:
@@ -19,7 +22,7 @@ def test_multi_view_on_pil_image() -> None:
         local_grid_size=2,
     )
     sample = Image.new("RGB", (100, 100))
-    output = multi_view_transform(sample)
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
     assert len(output) == 16  # (2 global crops * 2) + (6 local crops * 2)
     global_views = output[:2]
     local_views = output[2:8]


### PR DESCRIPTION
### Changes

* Fix typing inconsistencies between Python version
* Remove `python_version` mypy flag

This fixes all [typing issues](https://github.com/lightly-ai/lightly/issues/1635#issuecomment-2364651925) with mypy 1.4.1 on Python 3.7, 3.8, and 3.10. I removed the `python_version` mypy setting in `pyproject.toml` because it is not needed anymore. Mypy automatically uses the installed python version. This should make type checking more robust.


