### PR TITLE
Run Format Check on Multiple Python Versions

### DIFF
--- a/.github/workflows/test_code_format.yml
+++ b/.github/workflows/test_code_format.yml
@@ -11,6 +11,9 @@ jobs:
   test:
     name: Check
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.7", "3.12"]
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -22,7 +25,7 @@ jobs:
     - name: Set Up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.7"
+        python-version: ${{ matrix.python }}
     - name: Set Up Environment
       run: |
         make install-uv reset-venv


### PR DESCRIPTION
### Changes

* Run format checks on Python 3.7 and 3.12

Follow-up from #1654 to avoid having local format checks fail with different Python versions.