### PR TITLE
Lambda functions removed from examples

### DIFF
--- a/examples/notebooks/pytorch/aim.ipynb
+++ b/examples/notebooks/pytorch/aim.ipynb
@@ -129,16 +129,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = AIMTransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -147,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/dino.ipynb
+++ b/examples/notebooks/pytorch/dino.ipynb
@@ -139,13 +139,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = DINOTransform()\n",
+    "transform = DINOTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -154,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/ijepa.ipynb
+++ b/examples/notebooks/pytorch/ijepa.ipynb
@@ -129,20 +129,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "we ignore object detection annotations by setting target_transform to return 0\n",
+    "or create a dataset from a folder containing images or videos:\n",
+    "dataset = LightlyDataset(\"path/to/folder\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
-    "# or create a dataset from a folder containing images or videos:\n",
-    "# dataset = LightlyDataset(\"path/to/folder\")\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "data_loader = torch.utils.data.DataLoader(\n",
     "    dataset, collate_fn=collator, batch_size=10, persistent_workers=False\n",
@@ -152,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/mae.ipynb
+++ b/examples/notebooks/pytorch/mae.ipynb
@@ -141,16 +141,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = MAETransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -159,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/msn.ipynb
+++ b/examples/notebooks/pytorch/msn.ipynb
@@ -134,16 +134,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = MSNTransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -152,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/pmsn.ipynb
+++ b/examples/notebooks/pytorch/pmsn.ipynb
@@ -134,16 +134,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = MSNTransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -152,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/simmim.ipynb
+++ b/examples/notebooks/pytorch/simmim.ipynb
@@ -123,16 +123,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = MAETransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -141,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/swav.ipynb
+++ b/examples/notebooks/pytorch/swav.ipynb
@@ -102,16 +102,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = SwaVTransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -120,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/swav_queue.ipynb
+++ b/examples/notebooks/pytorch/swav_queue.ipynb
@@ -149,16 +149,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = SwaVTransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -167,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch/vicregl.ipynb
+++ b/examples/notebooks/pytorch/vicregl.ipynb
@@ -105,16 +105,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = VICRegLTransform(n_local_views=0)\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -123,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/aim.ipynb
+++ b/examples/notebooks/pytorch_lightning/aim.ipynb
@@ -131,13 +131,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = AIMTransform()\n",
+    "transform = AIMTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -146,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/dino.ipynb
+++ b/examples/notebooks/pytorch_lightning/dino.ipynb
@@ -139,16 +139,38 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
    "outputs": [],
    "source": [
     "transform = DINOTransform()\n",
-    "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "# we ignore object detection annotations by setting target_transform to return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -157,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/mae.ipynb
+++ b/examples/notebooks/pytorch_lightning/mae.ipynb
@@ -142,13 +142,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MAETransform()\n",
+    "transform = MAETransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -157,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/msn.ipynb
+++ b/examples/notebooks/pytorch_lightning/msn.ipynb
@@ -153,13 +153,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MSNTransform()\n",
+    "transform = MSNTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -168,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/pmsn.ipynb
+++ b/examples/notebooks/pytorch_lightning/pmsn.ipynb
@@ -152,13 +152,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MSNTransform()\n",
+    "transform = MSNTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -167,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/simmim.ipynb
+++ b/examples/notebooks/pytorch_lightning/simmim.ipynb
@@ -136,13 +136,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MAETransform()\n",
+    "transform = MAETransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -151,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/swav.ipynb
+++ b/examples/notebooks/pytorch_lightning/swav.ipynb
@@ -108,13 +108,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = SwaVTransform()\n",
+    "transform = SwaVTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -123,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/swav_queue.ipynb
+++ b/examples/notebooks/pytorch_lightning/swav_queue.ipynb
@@ -154,13 +154,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = SwaVTransform()\n",
+    "transform = SwaVTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -169,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning/vicregl.ipynb
+++ b/examples/notebooks/pytorch_lightning/vicregl.ipynb
@@ -125,13 +125,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = VICRegLTransform(n_local_views=0)\n",
+    "transform = VICRegLTransform(n_local_views=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -140,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/aim.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/aim.ipynb
@@ -131,13 +131,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = AIMTransform()\n",
+    "transform = AIMTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -146,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/dino.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/dino.ipynb
@@ -142,13 +142,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = DINOTransform()\n",
+    "transform = DINOTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -157,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/mae.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/mae.ipynb
@@ -142,13 +142,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MAETransform()\n",
+    "transform = MAETransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -157,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/msn.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/msn.ipynb
@@ -155,13 +155,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MSNTransform()\n",
+    "transform = MSNTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -170,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/pmsn.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/pmsn.ipynb
@@ -154,13 +154,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MSNTransform()\n",
+    "transform = MSNTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -169,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/simmim.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/simmim.ipynb
@@ -135,13 +135,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = MAETransform()\n",
+    "transform = MAETransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -150,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/swav.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/swav.ipynb
@@ -111,13 +111,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = SwaVTransform()\n",
+    "transform = SwaVTransform()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -126,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/pytorch_lightning_distributed/vicregl.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/vicregl.ipynb
@@ -125,13 +125,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = VICRegLTransform(n_local_views=0)\n",
+    "transform = VICRegLTransform(n_local_views=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# we ignore object detection annotations by setting target_transform to return 0\n",
+    "def target_transform(t):\n",
+    "    return 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataset = torchvision.datasets.VOCDetection(\n",
     "    \"datasets/pascal_voc\",\n",
     "    download=True,\n",
     "    transform=transform,\n",
-    "    target_transform=lambda t: 0,\n",
+    "    target_transform=target_transform,\n",
     ")\n",
     "# or create a dataset from a folder containing images or videos:\n",
     "# dataset = LightlyDataset(\"path/to/folder\")"
@@ -140,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/pytorch/aim.py
+++ b/examples/pytorch/aim.py
@@ -67,7 +67,7 @@ transform = AIMTransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -75,7 +75,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/aim.py
+++ b/examples/pytorch/aim.py
@@ -65,11 +65,17 @@ model.to(device)
 
 transform = AIMTransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/dino.py
+++ b/examples/pytorch/dino.py
@@ -55,12 +55,18 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = DINOTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/dino.py
+++ b/examples/pytorch/dino.py
@@ -58,7 +58,7 @@ transform = DINOTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -66,7 +66,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/ijepa.py
+++ b/examples/pytorch/ijepa.py
@@ -69,7 +69,7 @@ transform = IJEPATransform()
 # dataset = LightlyDataset("path/to/folder")
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -77,7 +77,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 data_loader = torch.utils.data.DataLoader(
     dataset, collate_fn=collator, batch_size=10, persistent_workers=False

--- a/examples/pytorch/ijepa.py
+++ b/examples/pytorch/ijepa.py
@@ -67,11 +67,17 @@ transform = IJEPATransform()
 # we ignore object detection annotations by setting target_transform to return 0
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 data_loader = torch.utils.data.DataLoader(
     dataset, collate_fn=collator, batch_size=10, persistent_workers=False

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -83,11 +83,17 @@ model.to(device)
 
 transform = MAETransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -85,7 +85,7 @@ transform = MAETransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -93,7 +93,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/msn.py
+++ b/examples/pytorch/msn.py
@@ -70,7 +70,7 @@ transform = MSNTransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -78,7 +78,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/msn.py
+++ b/examples/pytorch/msn.py
@@ -68,11 +68,17 @@ model.to(device)
 
 transform = MSNTransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/pmsn.py
+++ b/examples/pytorch/pmsn.py
@@ -70,7 +70,7 @@ transform = MSNTransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -78,7 +78,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/pmsn.py
+++ b/examples/pytorch/pmsn.py
@@ -68,11 +68,17 @@ model.to(device)
 
 transform = MSNTransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/simmim.py
+++ b/examples/pytorch/simmim.py
@@ -65,11 +65,17 @@ model.to(device)
 
 transform = MAETransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/simmim.py
+++ b/examples/pytorch/simmim.py
@@ -67,7 +67,7 @@ transform = MAETransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -75,7 +75,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/swav.py
+++ b/examples/pytorch/swav.py
@@ -40,7 +40,7 @@ transform = SwaVTransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -48,7 +48,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/swav.py
+++ b/examples/pytorch/swav.py
@@ -38,11 +38,17 @@ model.to(device)
 
 transform = SwaVTransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -87,7 +87,7 @@ transform = SwaVTransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -95,7 +95,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/swav_queue.py
+++ b/examples/pytorch/swav_queue.py
@@ -85,11 +85,17 @@ model.to(device)
 
 transform = SwaVTransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/vicregl.py
+++ b/examples/pytorch/vicregl.py
@@ -41,7 +41,7 @@ transform = VICRegLTransform(n_local_views=0)
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -49,7 +49,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch/vicregl.py
+++ b/examples/pytorch/vicregl.py
@@ -39,11 +39,17 @@ model.to(device)
 
 transform = VICRegLTransform(n_local_views=0)
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/aim.py
+++ b/examples/pytorch_lightning/aim.py
@@ -71,12 +71,18 @@ class AIM(pl.LightningModule):
 model = AIM()
 
 transform = AIMTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/aim.py
+++ b/examples/pytorch_lightning/aim.py
@@ -74,7 +74,7 @@ transform = AIMTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -82,7 +82,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/dino.py
+++ b/examples/pytorch_lightning/dino.py
@@ -77,7 +77,7 @@ transform = DINOTransform()
 # we ignore object detection annotations by setting target_transform to return 0
 
 
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -85,7 +85,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/dino.py
+++ b/examples/pytorch_lightning/dino.py
@@ -75,11 +75,17 @@ model = DINO()
 
 transform = DINOTransform()
 # we ignore object detection annotations by setting target_transform to return 0
+
+
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -91,7 +91,7 @@ transform = MAETransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -99,7 +99,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -88,12 +88,18 @@ class MAE(pl.LightningModule):
 model = MAE()
 
 transform = MAETransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/msn.py
+++ b/examples/pytorch_lightning/msn.py
@@ -94,7 +94,7 @@ transform = MSNTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -102,7 +102,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/msn.py
+++ b/examples/pytorch_lightning/msn.py
@@ -91,12 +91,18 @@ class MSN(pl.LightningModule):
 model = MSN()
 
 transform = MSNTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/pmsn.py
+++ b/examples/pytorch_lightning/pmsn.py
@@ -93,7 +93,7 @@ transform = MSNTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -101,7 +101,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/pmsn.py
+++ b/examples/pytorch_lightning/pmsn.py
@@ -90,12 +90,18 @@ class PMSN(pl.LightningModule):
 model = PMSN()
 
 transform = MSNTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/simmim.py
+++ b/examples/pytorch_lightning/simmim.py
@@ -74,12 +74,18 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MAETransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/simmim.py
+++ b/examples/pytorch_lightning/simmim.py
@@ -77,7 +77,7 @@ transform = MAETransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -85,7 +85,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/swav.py
+++ b/examples/pytorch_lightning/swav.py
@@ -48,12 +48,18 @@ class SwaV(pl.LightningModule):
 model = SwaV()
 
 transform = SwaVTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/swav.py
+++ b/examples/pytorch_lightning/swav.py
@@ -51,7 +51,7 @@ transform = SwaVTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -59,7 +59,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -94,12 +94,18 @@ class SwaV(pl.LightningModule):
 model = SwaV()
 
 transform = SwaVTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/swav_queue.py
+++ b/examples/pytorch_lightning/swav_queue.py
@@ -97,7 +97,7 @@ transform = SwaVTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -105,7 +105,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -57,12 +57,18 @@ class VICRegL(pl.LightningModule):
 model = VICRegL()
 
 transform = VICRegLTransform(n_local_views=0)
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning/vicregl.py
+++ b/examples/pytorch_lightning/vicregl.py
@@ -60,7 +60,7 @@ transform = VICRegLTransform(n_local_views=0)
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -68,7 +68,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/aim.py
+++ b/examples/pytorch_lightning_distributed/aim.py
@@ -71,12 +71,18 @@ class AIM(pl.LightningModule):
 model = AIM()
 
 transform = AIMTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/aim.py
+++ b/examples/pytorch_lightning_distributed/aim.py
@@ -74,7 +74,7 @@ transform = AIMTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -82,7 +82,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/dino.py
+++ b/examples/pytorch_lightning_distributed/dino.py
@@ -77,7 +77,7 @@ transform = DINOTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -85,7 +85,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/dino.py
+++ b/examples/pytorch_lightning_distributed/dino.py
@@ -74,12 +74,18 @@ class DINO(pl.LightningModule):
 model = DINO()
 
 transform = DINOTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -91,7 +91,7 @@ transform = MAETransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -99,7 +99,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -88,12 +88,18 @@ class MAE(pl.LightningModule):
 model = MAE()
 
 transform = MAETransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/msn.py
+++ b/examples/pytorch_lightning_distributed/msn.py
@@ -93,12 +93,18 @@ class MSN(pl.LightningModule):
 model = MSN()
 
 transform = MSNTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/msn.py
+++ b/examples/pytorch_lightning_distributed/msn.py
@@ -96,7 +96,7 @@ transform = MSNTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -104,7 +104,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/pmsn.py
+++ b/examples/pytorch_lightning_distributed/pmsn.py
@@ -92,12 +92,18 @@ class PMSN(pl.LightningModule):
 model = PMSN()
 
 transform = MSNTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/pmsn.py
+++ b/examples/pytorch_lightning_distributed/pmsn.py
@@ -95,7 +95,7 @@ transform = MSNTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -103,7 +103,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/simmim.py
+++ b/examples/pytorch_lightning_distributed/simmim.py
@@ -76,7 +76,7 @@ transform = MAETransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -84,7 +84,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/simmim.py
+++ b/examples/pytorch_lightning_distributed/simmim.py
@@ -73,12 +73,18 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
 
 transform = MAETransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/swav.py
+++ b/examples/pytorch_lightning_distributed/swav.py
@@ -51,12 +51,18 @@ class SwaV(pl.LightningModule):
 model = SwaV()
 
 transform = SwaVTransform()
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/swav.py
+++ b/examples/pytorch_lightning_distributed/swav.py
@@ -54,7 +54,7 @@ transform = SwaVTransform()
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -62,7 +62,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -57,12 +57,18 @@ class VICRegL(pl.LightningModule):
 model = VICRegL()
 
 transform = VICRegLTransform(n_local_views=0)
+
+
 # we ignore object detection annotations by setting target_transform to return 0
+def target_transform_function(t):
+    return 0
+
+
 dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=lambda t: 0,
+    target_transform=target_transform_function,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")

--- a/examples/pytorch_lightning_distributed/vicregl.py
+++ b/examples/pytorch_lightning_distributed/vicregl.py
@@ -60,7 +60,7 @@ transform = VICRegLTransform(n_local_views=0)
 
 
 # we ignore object detection annotations by setting target_transform to return 0
-def target_transform_function(t):
+def target_transform(t):
     return 0
 
 
@@ -68,7 +68,7 @@ dataset = torchvision.datasets.VOCDetection(
     "datasets/pascal_voc",
     download=True,
     transform=transform,
-    target_transform=target_transform_function,
+    target_transform=target_transform,
 )
 # or create a dataset from a folder containing images or videos:
 # dataset = LightlyDataset("path/to/folder")


### PR DESCRIPTION
**Enhancement:**
- Replaced lambda functions with named functions in the examples.

**Fixes Issue:**
- Closes #1512.

**Approach:**
- I created a bash script to list all files containing lambda functions. After identifying the files, I manually replaced the lambda functions with named functions.