### PR TITLE
Allow v1/v2 independent import of torchvision.transforms

### DIFF
--- a/lightly/transforms/__init__.py
+++ b/lightly/transforms/__init__.py
@@ -46,6 +46,7 @@ from lightly.transforms.tico_transform import (
     TiCoView1Transform,
     TiCoView2Transform,
 )
+from lightly.transforms.torchvision_transforms import torchvision_transforms
 from lightly.transforms.vicreg_transform import VICRegTransform, VICRegViewTransform
 from lightly.transforms.vicregl_transform import VICRegLTransform, VICRegLViewTransform
 from lightly.transforms.wmse_transform import WMSETransform

--- a/lightly/transforms/torchvision_transforms.py
+++ b/lightly/transforms/torchvision_transforms.py
@@ -21,15 +21,3 @@ except ImportError:
     from torchvision import transforms as torchvision_transforms
 
     _TRANSFORMS_V2 = False
-
-
-def ToTensor() -> Union[torchvision_transforms.Compose, ToTensorV1]:
-    T = torchvision_transforms
-    if _TRANSFORMS_V2 and hasattr(T, "ToImage") and hasattr(T, "ToDtype"):
-        # v2.transforms.ToTensor is deprecated and will be removed in the future.
-        # This is the new recommended way to convert a PIL Image to a tensor since
-        # torchvision v0.16.
-        # See also https://github.com/pytorch/vision/blame/33e47d88265b2d57c2644aad1425be4fccd64605/torchvision/transforms/v2/_deprecated.py#L19
-        return T.Compose([T.ToImage(), T.ToDtype(dtype=torch.float32, scale=True)])
-    else:
-        return T.ToTensor()

--- a/lightly/transforms/torchvision_transforms.py
+++ b/lightly/transforms/torchvision_transforms.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) Lightly AG and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from typing import Callable, Generic, Protocol, TypeVar, Union
+
+import torch
+from PIL.Image import Image
+from torch import Tensor
+from torchvision.transforms import ToTensor as ToTensorV1
+
+try:
+    from torchvision.transforms import v2 as torchvision_transforms
+
+    _TRANSFORMS_V2 = True
+
+except ImportError:
+    from torchvision import transforms as torchvision_transforms
+
+    _TRANSFORMS_V2 = False
+
+
+def ToTensor() -> Union[torchvision_transforms.Compose, ToTensorV1]:
+    T = torchvision_transforms
+    if _TRANSFORMS_V2 and hasattr(T, "ToImage") and hasattr(T, "ToDtype"):
+        # v2.transforms.ToTensor is deprecated and will be removed in the future.
+        # This is the new recommended way to convert a PIL Image to a tensor since
+        # torchvision v0.16.
+        # See also https://github.com/pytorch/vision/blame/33e47d88265b2d57c2644aad1425be4fccd64605/torchvision/transforms/v2/_deprecated.py#L19
+        return T.Compose([T.ToImage(), T.ToDtype(dtype=torch.float32, scale=True)])
+    else:
+        return T.ToTensor()

--- a/lightly/transforms/torchvision_transforms.py
+++ b/lightly/transforms/torchvision_transforms.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 #
-from typing import Callable, Generic, Protocol, TypeVar, Union
+from typing import Union
 
 import torch
 from PIL.Image import Image

--- a/lightly/transforms/torchvision_transforms.py
+++ b/lightly/transforms/torchvision_transforms.py
@@ -10,7 +10,6 @@ from typing import Union
 import torch
 from PIL.Image import Image
 from torch import Tensor
-from torchvision.transforms import ToTensor as ToTensorV1
 
 try:
     from torchvision.transforms import v2 as torchvision_transforms


### PR DESCRIPTION
## Changes
- adds file `lightly/transforms/torchvision_transforms.py` with:
  - import v2 of `torchvision.transforms` if available, else keep using v1
  - add `ToTensor()` transform that is compatible with v2
- make transforms (irrespective of v1 or v2) available in module `lightly.transforms` as `lightly.transforms.torchvision_transforms`