### PR TITLE
BYOL: transition from torchvision.transforms v1 to version indep

### DIFF
--- a/lightly/transforms/byol_transform.py
+++ b/lightly/transforms/byol_transform.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
@@ -8,6 +7,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 


### PR DESCRIPTION
## Changes
- use version independent `torchvision.transforms` instead of using only v1