### PR TITLE
DINO: transition from torchvision.transforms v1 to version indep

### DIFF
--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -1,7 +1,6 @@
 from typing import Dict, List, Optional, Tuple, Union
 
 import PIL
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
@@ -9,6 +8,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 


### PR DESCRIPTION
## Changes
- instead of defaulting to v1 of `torchvision.transforms`, allow using v2 if available