### PR TITLE
IJEPA: transition from torchvision.transforms v1 to version indep

### DIFF
--- a/lightly/transforms/ijepa_transform.py
+++ b/lightly/transforms/ijepa_transform.py
@@ -1,9 +1,9 @@
 from typing import Dict, List, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 


### PR DESCRIPTION
## Changes
- instead of defaulting to v1 of torchvision.transforms, allow using v2 if available