### PR TITLE
Remaining Transforms: Import version independent torchvision instead of defaulting to v1

### DIFF
--- a/lightly/transforms/image_grid_transform.py
+++ b/lightly/transforms/image_grid_transform.py
@@ -1,8 +1,9 @@
 from typing import List, Sequence, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
+
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 
 
 class ImageGridTransform:

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -8,7 +8,8 @@ import torch
 from PIL import Image as Image
 from PIL.Image import Image as PILImage
 from torch import Tensor
-from torchvision import transforms as T
+
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray

--- a/lightly/transforms/mae_transform.py
+++ b/lightly/transforms/mae_transform.py
@@ -1,9 +1,9 @@
 from typing import Dict, List, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/msn_transform.py
+++ b/lightly/transforms/msn_transform.py
@@ -1,11 +1,11 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/multi_crop_transform.py
+++ b/lightly/transforms/multi_crop_transform.py
@@ -1,8 +1,7 @@
 from typing import Tuple
 
-import torchvision.transforms as T
-
 from lightly.transforms.multi_view_transform import MultiViewTransform
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 
 
 class MultiCropTranform(MultiViewTransform):

--- a/lightly/transforms/multi_view_transform.py
+++ b/lightly/transforms/multi_view_transform.py
@@ -2,7 +2,8 @@ from typing import List, Sequence, Union
 
 from PIL.Image import Image
 from torch import Tensor
-from torchvision import transforms as T
+
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 
 
 class MultiViewTransform:

--- a/lightly/transforms/pirl_transform.py
+++ b/lightly/transforms/pirl_transform.py
@@ -1,10 +1,9 @@
 from typing import Dict, List, Tuple, Union
 
-import torchvision.transforms as T
-
 from lightly.transforms.jigsaw import Jigsaw
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/random_crop_and_flip_with_grid.py
+++ b/lightly/transforms/random_crop_and_flip_with_grid.py
@@ -2,10 +2,11 @@ from dataclasses import dataclass
 from typing import Tuple
 
 import torch
-import torchvision.transforms as T
 import torchvision.transforms.functional as F
 from PIL import Image
 from torch import nn
+
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 
 
 @dataclass

--- a/lightly/transforms/rotation.py
+++ b/lightly/transforms/rotation.py
@@ -66,9 +66,9 @@ class RandomRotateDegrees:
     """
 
     def __init__(self, prob: float, degrees: Union[float, Tuple[float, float]]):
-        self.transform: Callable[[Union[Image, Tensor]], Union[Image, Tensor]] = (
-            T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
-        )
+        self.transform: Callable[
+            [Union[Image, Tensor]], Union[Image, Tensor]
+        ] = T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
 
     def __call__(self, image: Union[Image, Tensor]) -> Union[Image, Tensor]:
         """Rotates the images with a given probability.

--- a/lightly/transforms/rotation.py
+++ b/lightly/transforms/rotation.py
@@ -4,10 +4,11 @@
 from typing import Callable, Tuple, Union
 
 import numpy as np
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 from torchvision.transforms import functional as TF
+
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 
 
 class RandomRotate:
@@ -65,9 +66,9 @@ class RandomRotateDegrees:
     """
 
     def __init__(self, prob: float, degrees: Union[float, Tuple[float, float]]):
-        self.transform: Callable[
-            [Union[Image, Tensor]], Union[Image, Tensor]
-        ] = T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
+        self.transform: Callable[[Union[Image, Tensor]], Union[Image, Tensor]] = (
+            T.RandomApply([T.RandomRotation(degrees=degrees)], p=prob)
+        )
 
     def __call__(self, image: Union[Image, Tensor]) -> Union[Image, Tensor]:
         """Rotates the images with a given probability.

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/simsiam_transform.py
+++ b/lightly/transforms/simsiam_transform.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/smog_transform.py
+++ b/lightly/transforms/smog_transform.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.solarize import RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/swav_transform.py
+++ b/lightly/transforms/swav_transform.py
@@ -1,12 +1,12 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_crop_transform import MultiCropTranform
 from lightly.transforms.rotation import random_rotation_transform
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/vicreg_transform.py
+++ b/lightly/transforms/vicreg_transform.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
@@ -8,6 +7,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import torchvision.transforms as T
 from PIL.Image import Image
 from torch import Tensor
 
@@ -8,6 +7,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.image_grid_transform import ImageGridTransform
 from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropAndFlip
 from lightly.transforms.solarize import RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/wmse_transform.py
+++ b/lightly/transforms/wmse_transform.py
@@ -1,9 +1,8 @@
 from typing import Dict, List, Optional, Tuple
 
-import torchvision.transforms as T
-
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 


### PR DESCRIPTION
## Changes
- change import from `import torchvision.transforms as T` to `from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms` as T **in all files**