### PR TITLE
Correct README since Python 3.12 is now supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Community and partner projects:
 
 ## Quick Start
 
-Lightly requires **Python 3.7+**. We recommend installing Lightly in a **Linux** or **OSX** environment. Python 3.12 is not yet supported, as PyTorch itself lacks Python 3.12 compatibility.
+Lightly requires **Python 3.7+**. We recommend installing Lightly in a **Linux** or **OSX** environment. Python 3.13 is not yet supported, as PyTorch itself lacks Python 3.13 compatibility.
 
 ### Dependencies
 


### PR DESCRIPTION
## Changes
 - README stated that Python 3.12 is not supported yet due to PyTorch not supporting 3.12. This is outdated and instead now true for Python 3.13
 - Issue tracking for PyTorch's Python 3.13 support: [https://github.com/pytorch/pytorch/issues/130249](https://github.com/pytorch/pytorch/issues/130249)