### PR TITLE
allow to check v2 transforms availability from anywhere

### DIFF
--- a/lightly/transforms/torchvision_v2_compatibility.py
+++ b/lightly/transforms/torchvision_v2_compatibility.py
@@ -12,12 +12,13 @@ from PIL.Image import Image
 from torch import Tensor
 from torchvision.transforms import ToTensor as ToTensorV1
 
-try:
+from lightly.utils import dependency as _dependency
+
+if _dependency.torchvision_transforms_v2_available():
     from torchvision.transforms import v2 as torchvision_transforms
 
     _TRANSFORMS_V2 = True
-
-except ImportError:
+else:
     from torchvision import transforms as torchvision_transforms
 
     _TRANSFORMS_V2 = False

--- a/lightly/utils/dependency.py
+++ b/lightly/utils/dependency.py
@@ -42,3 +42,19 @@ def timm_vit_available() -> bool:
     except ImportError:
         return False
     return True
+
+
+@functools.lru_cache(maxsize=1)
+def torchvision_transforms_v2_available() -> bool:
+    """Checks if torchvision supports the transforms.v2 API.
+
+    Returns:
+        True if transforms.v2 are available, False otherwise
+    """
+    try:
+        from torchvision.transforms import v2 as torchvision_transforms
+    except ImportError:
+        from torchvision import transforms as torchvision_transforms
+
+        return False
+    return True

--- a/lightly/utils/dependency.py
+++ b/lightly/utils/dependency.py
@@ -52,9 +52,8 @@ def torchvision_transforms_v2_available() -> bool:
         True if transforms.v2 are available, False otherwise
     """
     try:
-        from torchvision.transforms import v2 as torchvision_transforms
+        from torchvision.transforms import v2
     except ImportError:
-        from torchvision import transforms as torchvision_transforms
 
         return False
     return True

--- a/lightly/utils/dependency.py
+++ b/lightly/utils/dependency.py
@@ -54,6 +54,5 @@ def torchvision_transforms_v2_available() -> bool:
     try:
         from torchvision.transforms import v2
     except ImportError:
-
         return False
     return True


### PR DESCRIPTION
## Changes & Explanation
 - the availability of the `torchvision.transforms.v2` was so far only checked on module level
 - now the dependency check is implemented at the same level as other dependency checks and can also be accessed from other modules
 - change is necessary for future implementation of DetCon