### PR TITLE
ApiWorkflowClient: Include auto_tasks in selection_config_from_dict

### DIFF
--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -9,6 +9,8 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Type, TypeVar,
 from lightly.api import utils
 from lightly.openapi_generated.swagger_client.api_client import ApiClient
 from lightly.openapi_generated.swagger_client.models import (
+    AutoTask,
+    AutoTaskTiling,
     CreateDockerWorkerRegistryEntryRequest,
     DockerRunData,
     DockerRunScheduledCreateRequest,
@@ -27,8 +29,6 @@ from lightly.openapi_generated.swagger_client.models import (
     SelectionConfigV4EntryInput,
     SelectionConfigV4EntryStrategy,
     TagData,
-    AutoTask,
-    AutoTaskTiling,
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
 
@@ -637,21 +637,23 @@ def selection_config_from_dict(cfg: Dict[str, Any]) -> SelectionConfigV4:
     new_cfg["auto_tasks"] = auto_tasks
     return SelectionConfigV4(**new_cfg)
 
+
 def selection_config_entry_from_dict(entry: Dict[str, Any]) -> AutoTask:
     new_entry = copy.deepcopy(entry)
     new_entry["input"] = SelectionConfigV4EntryInput(**new_entry["input"])
     new_entry["strategy"] = SelectionConfigV4EntryStrategy(**new_entry["strategy"])
     return SelectionConfigV4Entry(**new_entry)
 
+
 def auto_task_from_dict(entry: Dict[str, Any]) -> AutoTask:
-    auto_task_type_to_class =  {
+    auto_task_type_to_class = {
         "TILING": AutoTaskTiling,
     }
     if entry["type"] not in auto_task_type_to_class:
         raise ValueError(
             f"AutoTask type '{entry['type']}' not supported. "
             f"Supported types are: {list(auto_task_type_to_class.keys())}"
-    )
+        )
     auto_task_class = auto_task_type_to_class[entry["type"]]
     auto_task_instance = auto_task_class(**entry)
     return AutoTask(actual_instance=auto_task_instance)

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -27,6 +27,8 @@ from lightly.openapi_generated.swagger_client.models import (
     SelectionConfigV4EntryInput,
     SelectionConfigV4EntryStrategy,
     TagData,
+    AutoTask,
+    AutoTaskTiling,
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
 
@@ -624,15 +626,35 @@ class _ComputeWorkerMixin:
 
 def selection_config_from_dict(cfg: Dict[str, Any]) -> SelectionConfigV4:
     """Recursively converts selection config from dict to a SelectionConfigV4 instance."""
-    strategies = []
-    for entry in cfg.get("strategies", []):
-        new_entry = copy.deepcopy(entry)
-        new_entry["input"] = SelectionConfigV4EntryInput(**entry["input"])
-        new_entry["strategy"] = SelectionConfigV4EntryStrategy(**entry["strategy"])
-        strategies.append(SelectionConfigV4Entry(**new_entry))
     new_cfg = copy.deepcopy(cfg)
+    strategies = []
+    for entry in new_cfg.get("strategies", []):
+        strategies.append(selection_config_entry_from_dict(entry=entry))
     new_cfg["strategies"] = strategies
+    auto_tasks = []
+    for entry in new_cfg.get("auto_tasks", []):
+        auto_tasks.append(auto_task_from_dict(entry=entry))
+    new_cfg["auto_tasks"] = auto_tasks
     return SelectionConfigV4(**new_cfg)
+
+def selection_config_entry_from_dict(entry: Dict[str, Any]) -> AutoTask:
+    new_entry = copy.deepcopy(entry)
+    new_entry["input"] = SelectionConfigV4EntryInput(**new_entry["input"])
+    new_entry["strategy"] = SelectionConfigV4EntryStrategy(**new_entry["strategy"])
+    return SelectionConfigV4Entry(**new_entry)
+
+def auto_task_from_dict(entry: Dict[str, Any]) -> AutoTask:
+    auto_task_type_to_class =  {
+        "TILING": AutoTaskTiling,
+    }
+    if entry["type"] not in auto_task_type_to_class:
+        raise ValueError(
+            f"AutoTask type '{entry['type']}' not supported. "
+            f"Supported types are: {list(auto_task_type_to_class.keys())}"
+    )
+    auto_task_class = auto_task_type_to_class[entry["type"]]
+    auto_task_instance = auto_task_class(**entry)
+    return AutoTask(actual_instance=auto_task_instance)
 
 
 _T = TypeVar("_T")

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -1,5 +1,6 @@
 import json
 import random
+import re
 from typing import Any, List
 from unittest import mock
 from unittest.mock import MagicMock
@@ -49,6 +50,8 @@ from lightly.openapi_generated.swagger_client.models import (
     SelectionStrategyThresholdOperation,
     SelectionStrategyTypeV3,
     TagData,
+    AutoTask,
+    AutoTaskTiling
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
 from tests.api_workflow import utils
@@ -288,6 +291,15 @@ def test_selection_config_from_dict() -> None:
                 },
             },
         ],
+        "auto_tasks": [
+            {
+                "type": "TILING",
+                "name": "tiling-task",
+                "num_rows": 10,
+                "num_cols": 10,
+                "overlap": 0.1,
+            },
+        ]
     }
     selection_cfg = api_workflow_compute_worker.selection_config_from_dict(cfg)
     assert selection_cfg.n_samples == 10
@@ -303,6 +315,15 @@ def test_selection_config_from_dict() -> None:
     assert selection_cfg.strategies[1].strategy.type == "THRESHOLD"
     assert selection_cfg.strategies[1].strategy.threshold == 20
     assert selection_cfg.strategies[1].strategy.operation == "BIGGER"
+    assert selection_cfg.auto_tasks is not None
+    assert len(selection_cfg.auto_tasks) == 1
+    assert isinstance(selection_cfg.auto_tasks[0], AutoTask)
+    assert isinstance(selection_cfg.auto_tasks[0].actual_instance, AutoTaskTiling)
+    assert selection_cfg.auto_tasks[0].actual_instance.type == "TILING"
+    assert selection_cfg.auto_tasks[0].actual_instance.name == "tiling-task"
+    assert selection_cfg.auto_tasks[0].actual_instance.num_rows == 10
+    assert selection_cfg.auto_tasks[0].actual_instance.num_cols == 10
+    assert selection_cfg.auto_tasks[0].actual_instance.overlap == 0.1
     # verify that original dict was not mutated
     assert isinstance(cfg["strategies"][0]["input"], dict)
 
@@ -325,7 +346,7 @@ def test_selection_config_from_dict__extra_key() -> None:
         api_workflow_compute_worker.selection_config_from_dict(cfg)
 
 
-def test_selection_config_from_dict__extra_stratey_key() -> None:
+def test_selection_config_from_dict__extra_strategy_key() -> None:
     cfg = {
         "strategies": [
             {
@@ -338,6 +359,50 @@ def test_selection_config_from_dict__extra_stratey_key() -> None:
     with pytest.raises(
         ValidationError,
         match=r"invalid-key\n  extra fields not permitted",
+    ):
+        api_workflow_compute_worker.selection_config_from_dict(cfg)
+
+def test_selection_config_from_dict__auto_tasks__invalid_type() -> None:
+    cfg = {
+        "strategies": [
+            {
+                "input": {"type": "EMBEDDINGS"},
+                "strategy": {"type": "DIVERSITY"},
+            },
+        ],
+        "auto_tasks": [
+            {
+                "type": "INVALID",
+            },
+        ],
+    }
+    with pytest.raises(
+        ValueError,
+        match=re.escape("AutoTask type 'INVALID' not supported. Supported types are: ['TILING']"),
+    ):
+        api_workflow_compute_worker.selection_config_from_dict(cfg)
+
+def test_selection_config_from_dict__auto_tasks__invalid_args() -> None:
+    cfg = {
+        "strategies": [
+            {
+                "input": {"type": "EMBEDDINGS"},
+                "strategy": {"type": "DIVERSITY"},
+            },
+        ],
+        "auto_tasks": [
+            {
+                "type": "TILING",
+                "name": "tiling-task",
+                "n_rows": 10,
+                "num_cols": 10,
+                "overlap": 0.1,
+            },
+        ],
+    }
+    with pytest.raises(
+        ValueError,
+        match=re.escape("2 validation errors for AutoTaskTiling\nnumRows\n  field required (type=value_error.missing)\nn_rows\n  extra fields not permitted (type=value_error.extra)"),
     ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
 

--- a/tests/api_workflow/test_api_workflow_compute_worker.py
+++ b/tests/api_workflow/test_api_workflow_compute_worker.py
@@ -28,6 +28,8 @@ from lightly.api.api_workflow_compute_worker import (
 from lightly.openapi_generated.swagger_client.api import DockerApi
 from lightly.openapi_generated.swagger_client.api_client import ApiClient
 from lightly.openapi_generated.swagger_client.models import (
+    AutoTask,
+    AutoTaskTiling,
     DockerRunData,
     DockerRunScheduledData,
     DockerRunScheduledPriority,
@@ -50,8 +52,6 @@ from lightly.openapi_generated.swagger_client.models import (
     SelectionStrategyThresholdOperation,
     SelectionStrategyTypeV3,
     TagData,
-    AutoTask,
-    AutoTaskTiling
 )
 from lightly.openapi_generated.swagger_client.rest import ApiException
 from tests.api_workflow import utils
@@ -299,7 +299,7 @@ def test_selection_config_from_dict() -> None:
                 "num_cols": 10,
                 "overlap": 0.1,
             },
-        ]
+        ],
     }
     selection_cfg = api_workflow_compute_worker.selection_config_from_dict(cfg)
     assert selection_cfg.n_samples == 10
@@ -362,6 +362,7 @@ def test_selection_config_from_dict__extra_strategy_key() -> None:
     ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
 
+
 def test_selection_config_from_dict__auto_tasks__invalid_type() -> None:
     cfg = {
         "strategies": [
@@ -378,9 +379,12 @@ def test_selection_config_from_dict__auto_tasks__invalid_type() -> None:
     }
     with pytest.raises(
         ValueError,
-        match=re.escape("AutoTask type 'INVALID' not supported. Supported types are: ['TILING']"),
+        match=re.escape(
+            "AutoTask type 'INVALID' not supported. Supported types are: ['TILING']"
+        ),
     ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
+
 
 def test_selection_config_from_dict__auto_tasks__invalid_args() -> None:
     cfg = {
@@ -402,7 +406,9 @@ def test_selection_config_from_dict__auto_tasks__invalid_args() -> None:
     }
     with pytest.raises(
         ValueError,
-        match=re.escape("2 validation errors for AutoTaskTiling\nnumRows\n  field required (type=value_error.missing)\nn_rows\n  extra fields not permitted (type=value_error.extra)"),
+        match=re.escape(
+            "2 validation errors for AutoTaskTiling\nnumRows\n  field required (type=value_error.missing)\nn_rows\n  extra fields not permitted (type=value_error.extra)"
+        ),
     ):
         api_workflow_compute_worker.selection_config_from_dict(cfg)
 


### PR DESCRIPTION
## Description

Includes `auto_tasks` in the `selection_config_from_dict()` function so that passing them as dict is very simple.

## Tests

Adapted and new unittests