### PR TITLE
Add `models.utils` to Docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -89,6 +89,7 @@ Lightly AI
    lightly.data
    lightly.loss
    lightly.models
+   lightly.models.utils
    lightly.transforms
    lightly.utils
 

--- a/docs/source/lightly.models.utils.rst
+++ b/docs/source/lightly.models.utils.rst
@@ -1,0 +1,5 @@
+lightly.models.utils
+=====================
+
+.. automodule:: lightly.models.utils
+    :members:


### PR DESCRIPTION
## Changes
 - add the module `lightly.models.utils` to the docs where it has been missing so far

## Screenshot
![Screenshot 2024-11-19 at 14 40 55](https://github.com/user-attachments/assets/d2d642c8-48ca-43f7-83aa-3a2b09969aa0)
