### PR TITLE
replaces google tracked badges with shields.io

### DIFF
--- a/docs/source/examples/aim.rst
+++ b/docs/source/examples/aim.rst
@@ -19,7 +19,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/aim.ipynb
 
         This example can be run from the command line with::
@@ -30,7 +30,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/aim.ipynb
 
         This example can be run from the command line with::
@@ -41,7 +41,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/aim.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/barlowtwins.rst
+++ b/docs/source/examples/barlowtwins.rst
@@ -14,7 +14,7 @@ Reference:
 
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/barlowtwins.ipynb
 
         This example can be run from the command line with::
@@ -25,7 +25,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/barlowtwins.ipynb
 
         This example can be run from the command line with::
@@ -36,7 +36,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/barlowtwins.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/byol.rst
+++ b/docs/source/examples/byol.rst
@@ -13,7 +13,7 @@ Reference:
 
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/byol.ipynb
 
         This example can be run from the command line with::
@@ -24,7 +24,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/byol.ipynb
 
         This example can be run from the command line with::
@@ -35,7 +35,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/byol.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/dcl.rst
+++ b/docs/source/examples/dcl.rst
@@ -34,7 +34,7 @@ with DCL loss.
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/dcl.ipynb
 
         This example can be run from the command line with::
@@ -45,7 +45,7 @@ with DCL loss.
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/dcl.ipynb
 
         This example can be run from the command line with::
@@ -56,7 +56,7 @@ with DCL loss.
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/dcl.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/densecl.rst
+++ b/docs/source/examples/densecl.rst
@@ -16,7 +16,7 @@ Reference:
 
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/densecl.ipynb
 
         This example can be run from the command line with::
@@ -27,7 +27,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/densecl.ipynb
 
         This example can be run from the command line with::
@@ -38,7 +38,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/densecl.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/dino.rst
+++ b/docs/source/examples/dino.rst
@@ -12,7 +12,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/dino.ipynb
 
         This example can be run from the command line with::
@@ -23,7 +23,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/dino.ipynb
 
         This example can be run from the command line with::
@@ -34,7 +34,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/dino.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/fastsiam.rst
+++ b/docs/source/examples/fastsiam.rst
@@ -14,7 +14,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/fastsiam.ipynb
 
         This example can be run from the command line with::
@@ -25,7 +25,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/fastsiam.ipynb
 
         This example can be run from the command line with::
@@ -36,7 +36,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/fastsiam.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/mae.rst
+++ b/docs/source/examples/mae.rst
@@ -27,7 +27,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/mae.ipynb
 
         This example can be run from the command line with::
@@ -38,7 +38,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/mae.ipynb
 
         This example can be run from the command line with::
@@ -49,7 +49,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/mae.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/mmcr.rst
+++ b/docs/source/examples/mmcr.rst
@@ -13,7 +13,7 @@ Reference:
 
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/mmcr.ipynb
 
         This example can be run from the command line with::
@@ -24,7 +24,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/mmcr.ipynb
 
         This example can be run from the command line with::
@@ -35,7 +35,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/mmcr.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/moco.rst
+++ b/docs/source/examples/moco.rst
@@ -20,7 +20,7 @@ Tutorials:
 
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/moco.ipynb
 
         This example can be run from the command line with::
@@ -31,7 +31,7 @@ Tutorials:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/moco.ipynb
 
         This example can be run from the command line with::
@@ -42,7 +42,7 @@ Tutorials:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/moco.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/msn.rst
+++ b/docs/source/examples/msn.rst
@@ -20,7 +20,7 @@ See :ref:`PMSN` for a version of MSN for datasets with non-uniform class distrib
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/msn.ipynb
 
         This example can be run from the command line with::
@@ -31,7 +31,7 @@ See :ref:`PMSN` for a version of MSN for datasets with non-uniform class distrib
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/msn.ipynb
 
         This example can be run from the command line with::
@@ -42,7 +42,7 @@ See :ref:`PMSN` for a version of MSN for datasets with non-uniform class distrib
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/msn.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/nnclr.rst
+++ b/docs/source/examples/nnclr.rst
@@ -11,7 +11,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/nnclr.ipynb
 
         This example can be run from the command line with::
@@ -22,7 +22,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/nnclr.ipynb
 
         This example can be run from the command line with::
@@ -33,7 +33,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/nnclr.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/pmsn.rst
+++ b/docs/source/examples/pmsn.rst
@@ -37,7 +37,7 @@ For PMSN, you can use the exact same code as for :ref:`msn` but change
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/pmsn.ipynb
 
         This example can be run from the command line with::
@@ -48,7 +48,7 @@ For PMSN, you can use the exact same code as for :ref:`msn` but change
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/pmsn.ipynb
 
         This example can be run from the command line with::
@@ -59,7 +59,7 @@ For PMSN, you can use the exact same code as for :ref:`msn` but change
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/pmsn.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/simclr.rst
+++ b/docs/source/examples/simclr.rst
@@ -15,7 +15,7 @@ Tutorials:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/simclr.ipynb
 
         This example can be run from the command line with::
@@ -26,7 +26,7 @@ Tutorials:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/simclr.ipynb
 
         This example can be run from the command line with::
@@ -37,7 +37,7 @@ Tutorials:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/simclr.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/simmim.rst
+++ b/docs/source/examples/simmim.rst
@@ -15,7 +15,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/simmim.ipynb
 
         This example can be run from the command line with::
@@ -26,7 +26,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/simmim.ipynb
 
         This example can be run from the command line with::
@@ -37,7 +37,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/simmim.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/simsiam.rst
+++ b/docs/source/examples/simsiam.rst
@@ -15,7 +15,7 @@ Tutorials:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/simsiam.ipynb
 
         This example can be run from the command line with::
@@ -26,7 +26,7 @@ Tutorials:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/simsiam.ipynb
 
         This example can be run from the command line with::
@@ -37,7 +37,7 @@ Tutorials:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/simsiam.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/smog.rst
+++ b/docs/source/examples/smog.rst
@@ -16,7 +16,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/smog.ipynb
 
         This example can be run from the command line with::
@@ -27,7 +27,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/smog.ipynb
 
         This example can be run from the command line with::

--- a/docs/source/examples/swav.rst
+++ b/docs/source/examples/swav.rst
@@ -14,7 +14,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/swav.ipynb
 
         This example can be run from the command line with::
@@ -25,7 +25,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/swav.ipynb
 
         This example can be run from the command line with::
@@ -36,7 +36,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/swav.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/tico.rst
+++ b/docs/source/examples/tico.rst
@@ -16,7 +16,7 @@ Reference:
 
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/tico.ipynb
 
         This example can be run from the command line with::
@@ -27,7 +27,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/tico.ipynb
 
         This example can be run from the command line with::
@@ -38,7 +38,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/tico.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/vicreg.rst
+++ b/docs/source/examples/vicreg.rst
@@ -15,7 +15,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/vicreg.ipynb
 
         This example can be run from the command line with::
@@ -26,7 +26,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/vicreg.ipynb
 
         This example can be run from the command line with::
@@ -37,7 +37,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/vicreg.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)

--- a/docs/source/examples/vicregl.rst
+++ b/docs/source/examples/vicregl.rst
@@ -14,7 +14,7 @@ Reference:
 .. tabs::
     .. tab:: PyTorch
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch/vicregl.ipynb
 
         This example can be run from the command line with::
@@ -25,7 +25,7 @@ Reference:
 
     .. tab:: Lightning
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning/vicregl.ipynb
 
         This example can be run from the command line with::
@@ -36,7 +36,7 @@ Reference:
 
     .. tab:: Lightning Distributed
 
-        .. image:: https://colab.research.google.com/assets/colab-badge.svg
+        .. image:: https://img.shields.io/badge/Open%20in%20Colab-blue?logo=googlecolab&label=%20&labelColor=5c5c5c
             :target: https://colab.research.google.com/github/lightly-ai/lightly/blob/master/examples/notebooks/pytorch_lightning_distributed/vicregl.ipynb
 
         This example runs on multiple gpus using Distributed Data Parallel (DDP)


### PR DESCRIPTION
closes lig-5584
- replace google colab badges (which get blocked by most ad/tracking blockers) with img.shields

previously;
![colab-badge (1)](https://github.com/user-attachments/assets/2c8eef44-0a1f-4eb9-a9cd-ad47399050b8)

after;
![after-badge](https://github.com/user-attachments/assets/9187cc5e-bf38-46a1-a12c-1becc1c5a3fe)
