### PR TITLE
fix: ijepa example

### DIFF
--- a/lightly/models/modules/ijepa_timm.py
+++ b/lightly/models/modules/ijepa_timm.py
@@ -6,6 +6,7 @@ from typing import Callable
 import torch
 import torch.nn as nn
 from timm.models.vision_transformer import Block
+from torch import Tensor
 
 from lightly.models import utils
 
@@ -58,7 +59,7 @@ class IJEPAPredictorTIMM(nn.Module):
         drop_path_rate: float = 0.0,
         proj_drop_rate: float = 0.0,
         attn_drop_rate: float = 0.0,
-        norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
+        norm_layer: Callable[..., nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
         """Initializes the IJEPAPredictorTIMM with the specified dimensions."""
 
@@ -97,10 +98,10 @@ class IJEPAPredictorTIMM(nn.Module):
 
     def forward(
         self,
-        x: torch.Tensor,
-        masks_x: list[torch.Tensor] | torch.Tensor,
-        masks: list[torch.Tensor] | torch.Tensor,
-    ) -> torch.Tensor:
+        x: Tensor,
+        masks_x: list[Tensor] | Tensor,
+        masks: list[Tensor] | Tensor,
+    ) -> Tensor:
         """Forward pass of the IJEPAPredictorTIMM.
 
         Args:

--- a/lightly/models/modules/ijepa_timm.py
+++ b/lightly/models/modules/ijepa_timm.py
@@ -11,7 +11,8 @@ from torch import Tensor
 from lightly.models import utils
 
 
-class IJEPAPredictorTIMM(nn.Module):
+# Type ignore because superclass has Any types.
+class IJEPAPredictorTIMM(nn.Module):  # type: ignore[misc]
     """Predictor for the I-JEPA model [0].
 
     Experimental: Support for I-JEPA is experimental, there might be breaking changes
@@ -127,12 +128,12 @@ class IJEPAPredictorTIMM(nn.Module):
         x = self.predictor_embed(x)
         x_pos_embed = self.predictor_pos_embed.repeat(B, 1, 1)
 
-        x += self.apply_masks(x_pos_embed, masks_x)
+        x += utils.apply_masks(x_pos_embed, masks_x)
         _, N_ctxt, _ = x.shape
 
         pos_embs = self.predictor_pos_embed.repeat(B, 1, 1)
-        pos_embs = self.apply_masks(pos_embs, masks)
-        pos_embs = self.repeat_interleave_batch(pos_embs, B, repeat=len_masks_x)
+        pos_embs = utils.apply_masks(pos_embs, masks)
+        pos_embs = utils.repeat_interleave_batch(pos_embs, B, repeat=len_masks_x)
         pred_tokens = self.mask_token.repeat(pos_embs.size(0), pos_embs.size(1), 1)
 
         pred_tokens += pos_embs

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -1263,7 +1263,7 @@ def update_drop_path_rate(
             block.drop_path2 = Identity()
 
 
-def repeat_interleave_batch(x: torch.Tensor, B: int, repeat: int) -> torch.Tensor:
+def repeat_interleave_batch(x: Tensor, B: int, repeat: int) -> Tensor:
     """Repeat and interleave the input tensor."""
     N = len(x) // B
     x = torch.cat(
@@ -1277,8 +1277,8 @@ def repeat_interleave_batch(x: torch.Tensor, B: int, repeat: int) -> torch.Tenso
 
 
 def apply_masks(
-    x: torch.Tensor, masks: torch.Tensor | list[torch.Tensor]
-) -> torch.Tensor:
+    x: Tensor, masks: Tensor | list[Tensor]
+) -> Tensor:
     """Apply masks to the input tensor.
 
     From https://github.com/facebookresearch/ijepa/blob/main/src/masks/utils.py

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -1264,7 +1264,21 @@ def update_drop_path_rate(
 
 
 def repeat_interleave_batch(x: Tensor, B: int, repeat: int) -> Tensor:
-    """Repeat and interleave the input tensor."""
+    """Repeat and interleave the input tensor.
+
+    Args:
+        x:
+            Tensor with shape (B * N, ...) where B is the batch size and N the number of
+            batches.
+        B:
+            Batch size.
+        repeat:
+            Number of times to repeat each batch.
+
+    Returns:
+        Tensor with shape (B * repeat * N, ...) where each batch is repeated `repeat`
+        times.
+    """
     N = len(x) // B
     x = torch.cat(
         [
@@ -1283,12 +1297,14 @@ def apply_masks(x: Tensor, masks: Tensor | list[Tensor]) -> Tensor:
 
     Args:
         x:
-            tensor of shape [B (batch-size), N (num-patches), D (feature-dim)].
+            Tensor of shape (B, N, D) where N is the number of patches.
         masks:
-            tensor or list of tensors containing indices of patches in [N] to keep.
+            Tensor or list of tensors containing indices of patches in
+            [0, N-1] to keep. Each tensor musth have shape (B, K) where K is the number
+            of patches to keep. All masks must have the same K.
 
     Returns:
-        Tensor of shape [B, N', D] where N' is the number of patches to keep.
+        Tensor of shape (B * num_masks, K, D) where K is the number of patches to keep.
     """
 
     if not isinstance(masks, list):

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -1276,9 +1276,7 @@ def repeat_interleave_batch(x: Tensor, B: int, repeat: int) -> Tensor:
     return x
 
 
-def apply_masks(
-    x: Tensor, masks: Tensor | list[Tensor]
-) -> Tensor:
+def apply_masks(x: Tensor, masks: Tensor | list[Tensor]) -> Tensor:
     """Apply masks to the input tensor.
 
     From https://github.com/facebookresearch/ijepa/blob/main/src/masks/utils.py


### PR DESCRIPTION
Resolves #1712

Moved `apply_masks` together with `repeat_interleave_batch` to `utils.py` from `lightly/models/modules/ijepa_timm.py`.