### PR TITLE
docs: add coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Downloads](https://static.pepy.tech/badge/lightly)](https://pepy.tech/project/lightly)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Discord](https://img.shields.io/discord/752876370337726585?logo=discord&logoColor=white&label=discord&color=7289da)](https://discord.gg/xvNJW94)
+![codecov.io](https://codecov.io/github/lightly-ai/lightly/coverage.svg?branch=master)
+
 
 Lightly**SSL** is a computer vision framework for self-supervised learning.
 


### PR DESCRIPTION
Adds Coverage Badge from [codecov.io/lightly-ai/lightly](https://app.codecov.io/gh/lightly-ai/lightly)