### PR TITLE
lionel-lig-5887 remove heuristics in masked pooling

### DIFF
--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -40,8 +40,8 @@ def pool_masked(
             integer indices.
         num_cls: The number of classes in the possible masks.
 
-    Returns: 
-        A tensor of shape :math:`(B, C, N)` or :math:`(C, N)` where :math:`N` 
+    Returns:
+        A tensor of shape :math:`(B, C, N)` or :math:`(C, N)` where :math:`N`
         corresponds to `num_cls`.
     """
     if source.dim() == 3:

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -28,23 +28,21 @@ if TYPE_CHECKING:
 
 
 def pool_masked(
-    source: Tensor, mask: Tensor, reduce: str = "mean", num_cls: Optional[int] = None
+    source: Tensor, mask: Tensor, num_cls: int, reduce: str = "mean"
 ) -> Tensor:
-    """Reduce image feature maps (B, C, H, W) or (C, H, W) according to an integer
-    index given by `mask` (B, H, W) or (H, W).
+    """Reduce image feature maps :math:`(B, C, H, W)` or :math:`(C, H, W)` according to
+    an integer index given by `mask` :math:`(B, H, W)` or :math:`(H, W)`.
 
     Args:
-        source: Float tensor of shape (B, C, H, W) or (C, H, W) to be reduced.
-        mask: Integer tensor of shape (B, H, W) or (H, W) containing the integer indices.
-        reduce: The reduction operation to be applied, one of 'prod', 'mean', 'amax' or
-            'amin'. Defaults to 'mean'.
-        num_cls: The number of classes in the possible masks. If None, the number of classes
-            is inferred from the unique elements in `mask`. This is useful when not all
-            classes are present in the mask.
+        source: Float tensor of shape :math:`(B, C, H, W)` or :math:`(C, H, W)` to be
+            reduced.
+        mask: Integer tensor of shape :math:`(B, H, W)` or :math:`(H, W)` containing the
+            integer indices.
+        num_cls: The number of classes in the possible masks.
 
     Returns:
-        A tensor of shape (B, C, N) or (C, N) where N is the number of unique elements
-        in `mask` or `num_cls` if specified.
+        A tensor of shape :math:`(B, C, N)` or :math:`(C, N)` where :math:`N`
+            corresponds to `num_cls`.
     """
     if source.dim() == 3:
         return _mask_reduce(source, mask, reduce, num_cls)
@@ -55,29 +53,26 @@ def pool_masked(
 
 
 def _mask_reduce(
-    source: Tensor, mask: Tensor, reduce: str = "mean", num_cls: Optional[int] = None
+    source: Tensor, mask: Tensor, num_cls: int, reduce: str = "mean"
 ) -> Tensor:
     output = _mask_reduce_batched(
-        source.unsqueeze(0), mask.unsqueeze(0), num_cls=num_cls
+        source.unsqueeze(0), mask.unsqueeze(0), num_cls=num_cls, reduce=reduce
     )
     return output.squeeze(0)
 
 
 def _mask_reduce_batched(
-    source: Tensor, mask: Tensor, num_cls: Optional[int] = None
+    source: Tensor, mask: Tensor, num_cls: int, reduce: str = "mean"
 ) -> Tensor:
     b, c, h, w = source.shape
-    if num_cls is None:
-        cls = mask.unique(sorted=True)
-    else:
-        cls = torch.arange(num_cls, device=mask.device)
+    cls = torch.arange(num_cls, device=mask.device)
     num_cls = cls.size(0)
     # create output tensor
     output = source.new_zeros((b, c, num_cls))  # (B C N)
     mask = mask.unsqueeze(1).expand(-1, c, -1, -1).view(b, c, -1)  # (B C HW)
     source = source.view(b, c, -1)  # (B C HW)
     output.scatter_reduce_(
-        dim=2, index=mask, src=source, reduce="mean", include_self=False
+        dim=2, index=mask, src=source, reduce=reduce, include_self=False
     )  # (B C N)
     # scatter_reduce_ produces NaNs if the count is zero
     output = torch.nan_to_num(output, nan=0.0)

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -40,9 +40,9 @@ def pool_masked(
             integer indices.
         num_cls: The number of classes in the possible masks.
 
-    Returns:
-        A tensor of shape :math:`(B, C, N)` or :math:`(C, N)` where :math:`N`
-            corresponds to `num_cls`.
+    Returns: 
+        A tensor of shape :math:`(B, C, N)` or :math:`(C, N)` where :math:`N` 
+        corresponds to `num_cls`.
     """
     if source.dim() == 3:
         return _mask_reduce(source, mask, reduce, num_cls)

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -41,8 +41,7 @@ def pool_masked(
         num_cls: The number of classes in the possible masks.
 
     Returns:
-        A tensor of shape :math:`(B, C, N)` or :math:`(C, N)` where :math:`N`
-        corresponds to `num_cls`.
+        A tensor of shape :math:`(B, C, num_cls)` or :math:`(C, num_cls)`.
     """
     if source.dim() == 3:
         return _mask_reduce(source, mask, reduce, num_cls)

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -104,15 +104,6 @@ class TestMaskReduce:
         assert out_manual.shape == (1, 3, 2)
         assert (out_manual == expected_result2[:, :2]).all()
 
-    def test_masked_pooling_auto(
-        self, feature_map2: Tensor, mask2: Tensor, expected_result2: Tensor
-    ) -> None:
-        out_auto = pool_masked(
-            feature_map2.unsqueeze(0), mask2.unsqueeze(0), num_cls=None
-        )
-        assert out_auto.shape == (1, 3, 2)
-        assert (out_auto == expected_result2[:, :2]).all()
-
     # Type ignore because untyped decorator makes function untyped.
     @pytest.mark.parametrize(
         "feature_map, mask, expected_result",


### PR DESCRIPTION
## Changes
- removes automatic detection of `num_cls` and makes this argument non-optionable
- removes the test for automatic inference of `num_cls`
- fixes an issue with the argument `reduce`, which was not actually propagated
- brush up the docstring while at it

## Necessity
- using the heuristics was bad practice and could lead to issue when calling the function several times with different masks (e.g. different tensor output shapes from the two calls)
- user of function should be aware of the classes in the dataset anyway