### PR TITLE
fix torchvision dependency test

### DIFF
--- a/lightly/utils/dependency.py
+++ b/lightly/utils/dependency.py
@@ -52,7 +52,7 @@ def torchvision_transforms_v2_available() -> bool:
         True if transforms.v2 are available, False otherwise
     """
     try:
-        from torchvision.transforms import v2
+        from torchvision.tv_tensors import Mask
     except ImportError:
         return False
     return True

--- a/lightly/utils/dependency.py
+++ b/lightly/utils/dependency.py
@@ -46,13 +46,16 @@ def timm_vit_available() -> bool:
 
 @functools.lru_cache(maxsize=1)
 def torchvision_transforms_v2_available() -> bool:
-    """Checks if torchvision supports the transforms.v2 API.
+    """Checks if torchvision supports the v2 transforms API with the `tv_tensors`
+    module. Checking for the availability of the `transforms.v2` is not sufficient
+    since it is available in torchvision >= 0.15.1, but the `tv_tensors` module is
+    only available in torchvision >= 0.16.0.
 
     Returns:
         True if transforms.v2 are available, False otherwise
     """
     try:
-        from torchvision.tv_tensors import Mask
+        from torchvision import tv_tensors
     except ImportError:
         return False
     return True


### PR DESCRIPTION
## Changes
 - changes how we test if the `torchvision.transforms.v2` is available

## Necessity
 - Testing if we can import `torchvision.transforms.v2` is not enough since we need to make sure that we install a version that also has a stable version of the API. Trying to mport `Mask` should be safer.