### PR TITLE
Fix typo:  Dict() instead of dict() return class instanciation error

### DIFF
--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -121,7 +121,7 @@ def main(
                 precision=precision,
                 ckpt_path=ckpt_path,
             )
-        eval_metrics: Dict[str, Dict[str, float]] = Dict()
+        eval_metrics: Dict[str, Dict[str, float]] = dict()
         if skip_knn_eval:
             print_rank_zero("Skipping KNN eval.")
         else:

--- a/benchmarks/imagenet/vitb16/main.py
+++ b/benchmarks/imagenet/vitb16/main.py
@@ -100,7 +100,7 @@ def main(
                 strategy=strategy,
             )
 
-        eval_metrics: Dict[str, Dict[str, float]] = Dict()
+        eval_metrics: Dict[str, Dict[str, float]] = dict()
         if skip_knn_eval:
             print("Skipping KNN eval.")
         else:


### PR DESCRIPTION
Dict is the type and dict is the class, python return an error when trying to create an instance of Dict()