### PR TITLE
docs: fix mismatch between forward method and docstring of `NTXentLoss`

### DIFF
--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -53,11 +53,10 @@ class NTXentLoss(nn.Module):
         >>> t1 = transforms(images)
         >>>
         >>> # feed through SimCLR or MoCo model
-        >>> batch = torch.cat((t0, t1), dim=0)
-        >>> output = model(batch)
+        >>> out0, out1 = model(t0), model(t1)
         >>>
         >>> # calculate loss
-        >>> loss = loss_fn(output)
+        >>> loss = loss_fn(out0, out1)
 
     """
 


### PR DESCRIPTION
Under the `Examples` section of [NTXentLoss](https://docs.lightly.ai/self-supervised-learning/lightly.loss.html#lightly.loss.ntx_ent_loss.NTXentLoss), the calculation of loss:

```python
>>> # initialize loss function without memory bank
>>> loss_fn = NTXentLoss(memory_bank_size=0)
>>>
>>> # generate two random transforms of images
>>> t0 = transforms(images)
>>> t1 = transforms(images)
>>>
>>> # feed through SimCLR or MoCo model
>>> batch = torch.cat((t0, t1), dim=0)
>>> output = model(batch)
>>>
>>> # calculate loss
>>> loss = loss_fn(output)   # Correct: loss_fn(out0, out1)
```
 doesn't match the function signature of `forward`, which requires two input tensors:

```python
def forward(self, out0: Tensor, out1: Tensor) -> Tensor:
```

Suggested change:


```python
>>> # initialize loss function without memory bank
>>> loss_fn = NTXentLoss(memory_bank_size=0)
>>>
>>> # generate two random transforms of images
>>> t0 = transforms(images)
>>> t1 = transforms(images)
>>>
>>> # feed through SimCLR or MoCo model
>>> out0, out1 = model(t0), model(t1)
>>>
>>> # calculate loss
>>> loss = loss_fn(out0, out1)
```