### PR TITLE
Update NNCLR model example in docs

### DIFF
--- a/docs/source/examples/nnclr.rst
+++ b/docs/source/examples/nnclr.rst
@@ -10,6 +10,7 @@ NNCLR is a self-supervised framework for visual representation learning that bui
 3. Architectural Adjustments: NNCLR employs different sizes for projection and prediction head layers compared to SimCLR.
 
 These improvements result in significantly better performance across multiple self-supervised learning benchmarks. Compared to SimCLR and other self-supervised methods, NNCLR achieves:
+
 - Higher ImageNet linear evaluation accuracy.
 - Improved semi-supervised learning results.
 - Superior performance on transfer learning tasks, outperforming BYOL, SimCLR, and even supervised ImageNet pretraining in 8 out of 12 benchmarked cases.

--- a/docs/source/examples/nnclr.rst
+++ b/docs/source/examples/nnclr.rst
@@ -3,7 +3,32 @@
 NNCLR
 =====
 
-Example implementation of the NNCLR architecture.
+NNCLR is a self-supervised framework for visual representation learning using contrastive methods.
+It is similar to SimCLR by using two augmented views of the same image, prediction and projection heads and a contrastive loss.
+It differs from SimCLR by replacing each sample with its nearest neightbour in a support set or memory bank.
+Furthermore, it makes the loss symmetric and uses other sizes of the projection and prediction head layers.
+
+NNCLR shows a significant improvement on all use cases of self-supervised learning:
+Compared to both SimCLR and other self-supervised learning methods,
+it has a better ImageNet linear evaluation performance, and also shows better semi-supervised learning results. 
+On transfer learning tasks, NNCLR is the best performing method compared to all of BYOL, SimCLR and supervised pretraining on ImageNet in 8 out of 12 cases.
+
+
+Key Components
+--------------
+
+- **Data Augmentations**: Exactly like SimCLR, NNCLR uses random cropping, resizing, color jittering, and Gaussian blur to create diverse views of the same image.
+- **Backbone**: Convolutional neural networks, such as ResNet, are employed to encode augmented images into feature representations.
+- **Projection Head**: A multilayer perceptron (MLP) maps features into a space where contrastive loss is applied, enhancing representation quality.
+- **Memory Bank**: NNCLR uses a first-in first-out memory bank to store the features of previous samples. The features of each batch are stored in the memory bank and the oldest features are then discarded. The size of the memory bank is kept large enough to approximate the full dataset.
+- **Nearest Neighbour Sampling**: The features of each view are replaced by the features of their nearest neighbour in the memory bank. This provides more semantic variations than pre-defined data augmentations.
+- **Contrastive Loss**: The normalized temperature-scaled cross-entropy loss (NT-Xent) encourages similar pairs to align and dissimilar pairs to diverge.
+
+Good to Know
+----------------
+
+- **Backbone Networks**: NNCLR is specifically optimized for convolutional neural networks, with a focus on ResNet architectures. We do not recommend using it with transformer-based models.
+- **Learning Paradigm**: NNCLR is less dependent on good augmentations than SimCLR, as the nearest neighbour sampling provides more semantic variations. However, the method still benefits from a good choice of augmentations and larger batch sizes.
 
 Reference:
     `With a Little Help from My Friends: Nearest-Neighbor Contrastive Learning of Visual Representations, 2021 <https://arxiv.org/abs/2104.14548>`_

--- a/docs/source/examples/nnclr.rst
+++ b/docs/source/examples/nnclr.rst
@@ -3,32 +3,33 @@
 NNCLR
 =====
 
-NNCLR is a self-supervised framework for visual representation learning using contrastive methods.
-It is similar to SimCLR by using two augmented views of the same image, prediction and projection heads and a contrastive loss.
-It differs from SimCLR by replacing each sample with its nearest neightbour in a support set or memory bank.
-Furthermore, it makes the loss symmetric and uses other sizes of the projection and prediction head layers.
+NNCLR is a self-supervised framework for visual representation learning that builds upon contrastive methods. It shares similarities with SimCLR, such as using two augmented views of the same image, projection and prediction heads, and a contrastive loss. However, it introduces key modifications:
 
-NNCLR shows a significant improvement on all use cases of self-supervised learning:
-Compared to both SimCLR and other self-supervised learning methods,
-it has a better ImageNet linear evaluation performance, and also shows better semi-supervised learning results. 
-On transfer learning tasks, NNCLR is the best performing method compared to all of BYOL, SimCLR and supervised pretraining on ImageNet in 8 out of 12 cases.
+1. Nearest Neighbor Replacement: Instead of directly comparing two augmented views of the same sample, NNCLR replaces each sample with its nearest neighbor in a support set (or memory bank). This increases semantic variation in the learned representations.
+2. Symmetric Loss: The contrastive loss is made symmetric to improve training stability.
+3. Architectural Adjustments: NNCLR employs different sizes for projection and prediction head layers compared to SimCLR.
 
+These improvements result in significantly better performance across multiple self-supervised learning benchmarks. Compared to SimCLR and other self-supervised methods, NNCLR achieves:
+- Higher ImageNet linear evaluation accuracy.
+- Improved semi-supervised learning results.
+- Superior performance on transfer learning tasks, outperforming BYOL, SimCLR, and even supervised ImageNet pretraining in 8 out of 12 benchmarked cases.
 
 Key Components
 --------------
 
-- **Data Augmentations**: Exactly like SimCLR, NNCLR uses random cropping, resizing, color jittering, and Gaussian blur to create diverse views of the same image.
-- **Backbone**: Convolutional neural networks, such as ResNet, are employed to encode augmented images into feature representations.
-- **Projection Head**: A multilayer perceptron (MLP) maps features into a space where contrastive loss is applied, enhancing representation quality.
-- **Memory Bank**: NNCLR uses a first-in first-out memory bank to store the features of previous samples. The features of each batch are stored in the memory bank and the oldest features are then discarded. The size of the memory bank is kept large enough to approximate the full dataset.
-- **Nearest Neighbour Sampling**: The features of each view are replaced by the features of their nearest neighbour in the memory bank. This provides more semantic variations than pre-defined data augmentations.
-- **Contrastive Loss**: The normalized temperature-scaled cross-entropy loss (NT-Xent) encourages similar pairs to align and dissimilar pairs to diverge.
+- **Data Augmentations**: NNCLR applies the same transformations as SimCLR, including random cropping, resizing, color jittering, and Gaussian blur, to create diverse views of the same image.
+- **Backbone**: A convolutional neural network (typically ResNet) encodes augmented images into feature representations.
+- **Projection Head**: A multilayer perceptron (MLP) maps features into a contrastive space, improving representation learning.
+- **Memory Bank**: NNCLR maintains a first-in, first-out (FIFO) memory bank, storing past feature representations. Older features are gradually discarded, ensuring a large and diverse set approximating the full dataset.
+- **Nearest Neighbor Sampling**: Each feature representation is replaced by its nearest neighbor from the memory bank, introducing additional semantic variation beyond standard augmentations.
+- **Contrastive Loss**: NNCLR employs normalized temperature-scaled cross-entropy loss (NT-Xent), encouraging alignment between positive pairs and separation from negative pairs.
 
 Good to Know
 ----------------
 
-- **Backbone Networks**: NNCLR is specifically optimized for convolutional neural networks, with a focus on ResNet architectures. We do not recommend using it with transformer-based models.
-- **Learning Paradigm**: NNCLR is less dependent on good augmentations than SimCLR, as the nearest neighbour sampling provides more semantic variations. However, the method still benefits from a good choice of augmentations and larger batch sizes.
+- **Optimized for CNNs**: NNCLR is specifically designed for convolutional neural networks (CNNs), particularly ResNet. It is not recommended for transformer-based architectures.
+- **Augmentation Robustness**: Compared to SimCLR, NNCLR is less dependent on strong augmentations since nearest neighbor sampling introduces natural semantic variation. However, performance still benefits from well-chosen augmentations and larger batch sizes.
+
 
 Reference:
     `With a Little Help from My Friends: Nearest-Neighbor Contrastive Learning of Visual Representations, 2021 <https://arxiv.org/abs/2104.14548>`_


### PR DESCRIPTION
## Description

## Changes

- Adds more info to the NNCLR model example here: https://docs.lightly.ai/self-supervised-learning/examples/nnclr.html
- Structure is similar to the one for SimCLR, see https://github.com/lightly-ai/lightly/pull/1782
- Example of the updated version is attached 
![image](https://github.com/user-attachments/assets/d7bc708a-c933-46f2-8c0b-0a3958b15e03)









