### PR TITLE
Remove-docs-build-warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -35,6 +35,11 @@ help:
 	make download
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -v
 
+# Clean up everything and build from scratch
+clean-html-noplot:
+	$(MAKE) clean-all
+	$(MAKE) html-noplot
+
 # Build the docs without running the python tutorials
 html-noplot:
 	$(SPHINXBUILD) -D plot_gallery=0 -b html $(SPHINXOPTS) "$(SOURCEDIR)" "$(BUILDDIR)/html"

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,12 @@ To build docs without running python files (tutorials) use
 make html-noplot
 ```
 
+Since above command uses caching to speed up the build, some warnings may not appear after
+the initial build. It is therefore advisable to do a clean build from time to time
+```
+make clean-html-noplot
+```
+
 To create a shortcut for building the documentation with environment variables for the active-learning tutorial, use:
 ```
 LIGHTLY_SERVER_LOCATION='https://api.lightly.ai' LIGHTLY_TOKEN='YOUR_TOKEN' AL_TUTORIAL_DATASET_ID='YOUR_DATASET_ID' make html && python -m http.server 1234 -d build/html

--- a/docs/source/getting_started/benchmarks.rst
+++ b/docs/source/getting_started/benchmarks.rst
@@ -14,7 +14,7 @@ List of available benchmarks:
 ImageNet1k
 ----------
 
-- `Dataset <https://image-net.org/download.php>`_
+- `ImageNet1k Dataset <https://image-net.org/download.php>`_
 - `Code <https://github.com/lightly-ai/lightly/tree/master/benchmarks/imagenet/resnet50>`_
 
 The following experiments have been conducted on a system with 2x4090 GPUs.
@@ -30,17 +30,17 @@ Evaluation settings are based on the following papers:
   :header: "Model", "Backbone", "Batch Size", "Epochs", "Linear Top1", "Linear Top5", "Finetune Top1", "Finetune Top5", "kNN Top1", "kNN Top5", "Tensorboard", "Checkpoint"
   :widths: 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20
 
-  "BarlowTwins", "Res50", "256", "100", "62.9", "84.3", "72.6", "90.9", "45.6", "73.9", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_barlowtwins_2023-08-18_00-11-03/pretrain/version_0/events.out.tfevents.1692310273.Machine2.569794.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_barlowtwins_2023-08-18_00-11-03/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "BYOL", "Res50", "256", "100", "62.5", "85.0", "74.5", "92.0", "46.0", "74.8", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_byol_2024-02-14_16-10-09/pretrain/version_0/events.out.tfevents.1707923418.Machine2.3205.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_byol_2024-02-14_16-10-09/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "DINO", "Res50", "128", "100", "68.2", "87.9", "72.5", "90.8", "49.9", "78.7", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dino_2023-06-06_13-59-48/pretrain/version_0/events.out.tfevents.1686052799.Machine2.482599.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dino_2023-06-06_13-59-48/pretrain/version_0/checkpoints/epoch%3D99-step%3D1000900.ckpt>`_"
-  "MAE", "ViT-B/16", "256", "100", "46.0", "70.2", "81.3", "95.5", "11.2", "24.5", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_vitb16_mae_2024-02-25_19-57-30/pretrain/version_0/events.out.tfevents.1708887459.Machine2.1092409.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_vitb16_mae_2024-02-25_19-57-30/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "MoCoV2", "Res50", "256", "100", "61.5", "84.1", "74.3", "91.9", "41.8", "72.2", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_mocov2_2024-02-18_10-29-14/pretrain/version_0/events.out.tfevents.1708248562.Machine2.439033.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_mocov2_2024-02-18_10-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "SimCLR*", "Res50", "256", "100", "63.2", "85.2", "73.9", "91.9", "44.8", "73.9", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-06-22_09-11-13/pretrain/version_0/events.out.tfevents.1687417883.Machine2.33270.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-06-22_09-11-13/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "SimCLR* + DCL", "Res50", "256", "100", "65.1", "86.2", "73.5", "91.7", "49.6", "77.5", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dcl_2023-07-04_16-51-40/pretrain/version_0/events.out.tfevents.1688482310.Machine2.247807.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dcl_2023-07-04_16-51-40/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "SimCLR* + DCLW", "Res50", "256", "100", "64.5", "86.0", "73.2", "91.5", "48.5", "76.8", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dclw_2023-07-07_14-57-13/pretrain/version_0/events.out.tfevents.1688734645.Machine2.3176.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dclw_2023-07-07_14-57-13/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "SwAV", "Res50", "256", "100", "67.2", "88.1", "75.4", "92.7", "49.5", "78.6", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/events.out.tfevents.1684996168.Machine2.1445108.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
-  "TiCo", "Res50", "256", "100", "49.7", "74.4", "72.7", "90.9", "26.6", "53.6", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_tico_2024-01-07_18-40-57/pretrain/version_0/events.out.tfevents.1704649265.Machine2.1604956.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_tico_2024-01-07_18-40-57/pretrain/version_0/checkpoints/epoch%3D99-step%3D250200.ckpt>`_"
-  "VICReg", "Res50", "256", "100", "63.0", "85.4", "73.7", "91.9", "46.3", "75.2", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_vicreg_2023-09-11_10-53-08/pretrain/version_0/events.out.tfevents.1694422401.Machine2.556563.0>`_", "`link <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_vicreg_2023-09-11_10-53-08/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "BarlowTwins", "Res50", "256", "100", "62.9", "84.3", "72.6", "90.9", "45.6", "73.9", "`tensorboard BarlowTwins <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_barlowtwins_2023-08-18_00-11-03/pretrain/version_0/events.out.tfevents.1692310273.Machine2.569794.0>`_", "`checkpoint BarlowTwins <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_barlowtwins_2023-08-18_00-11-03/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "BYOL", "Res50", "256", "100", "62.5", "85.0", "74.5", "92.0", "46.0", "74.8", "`tensorboard BYOL <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_byol_2024-02-14_16-10-09/pretrain/version_0/events.out.tfevents.1707923418.Machine2.3205.0>`_", "`checkpoint BYOL <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_byol_2024-02-14_16-10-09/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "DINO", "Res50", "128", "100", "68.2", "87.9", "72.5", "90.8", "49.9", "78.7", "`tensorboard DINO <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dino_2023-06-06_13-59-48/pretrain/version_0/events.out.tfevents.1686052799.Machine2.482599.0>`_", "`checkpoint DINO <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dino_2023-06-06_13-59-48/pretrain/version_0/checkpoints/epoch%3D99-step%3D1000900.ckpt>`_"
+  "MAE", "ViT-B/16", "256", "100", "46.0", "70.2", "81.3", "95.5", "11.2", "24.5", "`tensorboard MAE <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_vitb16_mae_2024-02-25_19-57-30/pretrain/version_0/events.out.tfevents.1708887459.Machine2.1092409.0>`_", "`checkpoint MAE <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_vitb16_mae_2024-02-25_19-57-30/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "MoCoV2", "Res50", "256", "100", "61.5", "84.1", "74.3", "91.9", "41.8", "72.2", "`tensorboard MoCoV2 <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_mocov2_2024-02-18_10-29-14/pretrain/version_0/events.out.tfevents.1708248562.Machine2.439033.0>`_", "`checkpoint MoCoV2 <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_mocov2_2024-02-18_10-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "SimCLR*", "Res50", "256", "100", "63.2", "85.2", "73.9", "91.9", "44.8", "73.9", "`tensorboard SimCLR <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-06-22_09-11-13/pretrain/version_0/events.out.tfevents.1687417883.Machine2.33270.0>`_", "`checkpoint SimCLR <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_simclr_2023-06-22_09-11-13/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "SimCLR* + DCL", "Res50", "256", "100", "65.1", "86.2", "73.5", "91.7", "49.6", "77.5", "`tensorboard SimCLR + DCL <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dcl_2023-07-04_16-51-40/pretrain/version_0/events.out.tfevents.1688482310.Machine2.247807.0>`_", "`checkpoint SimCLR + DCL <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dcl_2023-07-04_16-51-40/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "SimCLR* + DCLW", "Res50", "256", "100", "64.5", "86.0", "73.2", "91.5", "48.5", "76.8", "`tensorboard SimCLR + DCLW <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dclw_2023-07-07_14-57-13/pretrain/version_0/events.out.tfevents.1688734645.Machine2.3176.0>`_", "`checkpoint SimCLR + DCLW <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_dclw_2023-07-07_14-57-13/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "SwAV", "Res50", "256", "100", "67.2", "88.1", "75.4", "92.7", "49.5", "78.6", "`tensorboard SwAV <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/events.out.tfevents.1684996168.Machine2.1445108.0>`_", "`checkpoint SwAV <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_swav_2023-05-25_08-29-14/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
+  "TiCo", "Res50", "256", "100", "49.7", "74.4", "72.7", "90.9", "26.6", "53.6", "`tensorboard TiCo <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_tico_2024-01-07_18-40-57/pretrain/version_0/events.out.tfevents.1704649265.Machine2.1604956.0>`_", "`checkpoint TiCo <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_tico_2024-01-07_18-40-57/pretrain/version_0/checkpoints/epoch%3D99-step%3D250200.ckpt>`_"
+  "VICReg", "Res50", "256", "100", "63.0", "85.4", "73.7", "91.9", "46.3", "75.2", "`tensorboard VICReg <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_vicreg_2023-09-11_10-53-08/pretrain/version_0/events.out.tfevents.1694422401.Machine2.556563.0>`_", "`checkpoint VICReg <https://lightly-ssl-checkpoints.s3.amazonaws.com/imagenet_resnet50_vicreg_2023-09-11_10-53-08/pretrain/version_0/checkpoints/epoch%3D99-step%3D500400.ckpt>`_"
 
 *\*We use square root learning rate scaling instead of linear scaling as it yields better results for smaller batch sizes. See Appendix B.1 in the SimCLR paper.*
 
@@ -49,7 +49,7 @@ Found a missing model? Track the progress of our planned benchmarks on `GitHub <
 ImageNet100
 -----------
 
-- `Dataset <https://image-net.org/download.php>`_
+- `ImageNet100 Dataset <https://image-net.org/download.php>`_
 - :download:`Code <benchmarks/imagenet100_benchmark.py>`
 
 Imagenet100 is a subset of the popular ImageNet1k dataset. It consists of 100 classes
@@ -81,7 +81,7 @@ Training a model takes between 20 and 30 hours, including kNN evaluation.
 Imagenette
 ----------
 
-- `Dataset <https://github.com/fastai/imagenette>`_
+- `Imagenette Dataset <https://github.com/fastai/imagenette>`_
 - :download:`Code <benchmarks/imagenette_benchmark.py>`
 
 Imagenette is a subset of 10 easily classified classes from ImageNet.
@@ -127,7 +127,7 @@ Training a model takes three to five hours, including kNN evaluation.
 CIFAR-10
 --------
 
-- `Dataset <https://www.cs.toronto.edu/~kriz/cifar.html>`_
+- `CIFAR-10 Dataset <https://www.cs.toronto.edu/~kriz/cifar.html>`_
 - :download:`Code <benchmarks/cifar10_benchmark.py>` 
 
 CIFAR-10 consists of 50k training images and 10k testing images. We train the

--- a/docs/source/lightly.utils.rst
+++ b/docs/source/lightly.utils.rst
@@ -34,7 +34,7 @@ lightly.utils
    :members:
 
 .version_compare
----------------
+-----------------
 .. automodule:: lightly.utils.version_compare
    :members:
 

--- a/docs/source/tutorials/structure_your_input.rst
+++ b/docs/source/tutorials/structure_your_input.rst
@@ -130,7 +130,7 @@ The dataset assigns each video frame its video as label.
 PyTorch Datasets
 ----------------
 
-You can also use native `torchvision <https://pytorch.org/vision/main/datasets.html>`_ datasets with Lightly\ **SSL** directly.
+You can also use native `torchvision datasets <https://pytorch.org/vision/main/datasets.html>`_ with Lightly\ **SSL** directly.
 Just create a dataset as you normally would and apply transforms for greater control over the dataloader. For example, the
 :ref:`simclr` self-supervised learning method expects two views of an input image. To achieve this, we can use the `SimCLRTransform`
 while creating the dataset instance, which will lead to the dataloader returning two views per batch.
@@ -147,7 +147,7 @@ while creating the dataset instance, which will lead to the dataloader returning
 
 
 Hugging Face Datasets
---------------------
+----------------------
 
 To use a dataset from the Hugging Face Hub 🤗, we can simply apply the desired transformations using the
 `set_transform <https://huggingface.co/docs/datasets/v2.20.0/en/package_reference/main_classes#datasets.Dataset.set_transform>`_

--- a/lightly/loss/mmcr_loss.py
+++ b/lightly/loss/mmcr_loss.py
@@ -8,7 +8,7 @@ class MMCRLoss(nn.Module):
     All hyperparameters are set to the default values from the paper for ImageNet.
 
     - [0]: Efficient Coding of Natural Images using Maximum Manifold Capacity
-    Representations, 2023, https://arxiv.org/pdf/2303.03307.pdf
+        Representations, 2023, https://arxiv.org/pdf/2303.03307.pdf
 
     Examples:
         >>> # initialize loss function

--- a/lightly/transforms/add_grid_transform.py
+++ b/lightly/transforms/add_grid_transform.py
@@ -17,24 +17,26 @@ class AddGridTransform(Transform):  # type: ignore[misc]
     Input to this transform:
         Any datastructure containing one or several `torchvision.tv_tensor.BoundingBoxes`
         and/or `torchvision.tv_tensor.Mask`, such as tuples or arbitrarily nested dictionaries.
-        For all supported data structures check [1]_. Masks should be of size (*, H, W) and
+        For all supported data structures check [1]_. Masks should be of size `(*, H, W)` and
         BoundingBoxes can be of arbitrary shape.
 
     Output of this transform:
         Leaves any images in the data structure untouched, but overwrites any bounding
-        boxes and masks by a regular grid. Bounding boxes will take shape (num_rows*num_cols, 4)
-        and masks will be of shape (1, H, W) with integer values in the range [0, num_rows*num_cols-1].
+        boxes and masks by a regular grid. Bounding boxes will take shape `(num_rows*num_cols, 4)`
+        and masks will be of shape `(1, H, W)` with integer values in the range `[0, num_rows*num_cols-1]`.
 
-    Example::
+    Example:
 
-        img = torch.randn((3, 16, 16))
-        bboxes = BoundingBoxes(torch.randn((1, 4)), format="XYXY", canvas_size=img.shape[-2:])
-        mask = Mask(torch.randn((16, 16)).to(torch.int64))
-        tr = AddGridTransform(num_rows=4, num_cols=4)
-        # the image will be untouched the bounding boxes will be a regular grid
-        img, bboxes, mask = tr(img, bboxes, mask)
-        # bboxes of shape (num_rows*num_cols, 4)
-        # mask with value range [0, num_rows*num_cols-1]
+        .. code-block:: python
+
+            img = torch.randn((3, 16, 16))
+            bboxes = BoundingBoxes(torch.randn((1, 4)), format="XYXY", canvas_size=img.shape[-2:])
+            mask = Mask(torch.randn((16, 16)).to(torch.int64))
+            tr = AddGridTransform(num_rows=4, num_cols=4)
+            # the image will be untouched the bounding boxes will be a regular grid
+            img, bboxes, mask = tr(img, bboxes, mask)
+            # bboxes of shape (num_rows*num_cols, 4)
+            # mask with value range [0, num_rows*num_cols-1]
 
     References:
         .. [0] DetCon, 2021, https://arxiv.org/abs/2103.10957

--- a/lightly/transforms/image_grid_transform.py
+++ b/lightly/transforms/image_grid_transform.py
@@ -12,8 +12,7 @@ class ImageGridTransform:
     Used for VICRegL.
 
     Attributes:
-        transforms:
-            A sequence of (image_grid_transform, view_transform) tuples.
+        transforms: A sequence of (image_grid_transform, view_transform) tuples.
             The image_grid_transform creates a new view and grid from the image.
             The view_transform further augments the view. Every transform tuple
             is applied once to the image, creating len(transforms) views and
@@ -35,12 +34,15 @@ class ImageGridTransform:
         Returns:
             List of views and grids tensors or PIL images. In the VICRegL implementation
             it has size:
-            [
-                [3, global_crop_size, global_crop_size],
-                [3, local_crop_size, local_crop_size],
-                [global_grid_size, global_grid_size, 2],
-                [local_grid_size, local_grid_size, 2]
-            ]
+
+            .. code-block:: python
+
+                [
+                    [3, global_crop_size, global_crop_size],
+                    [3, local_crop_size, local_crop_size],
+                    [global_grid_size, global_grid_size, 2],
+                    [local_grid_size, local_grid_size, 2]
+                ]
 
         """
         views, grids = [], []

--- a/lightly/transforms/multi_view_transform_v2.py
+++ b/lightly/transforms/multi_view_transform_v2.py
@@ -9,7 +9,6 @@ class MultiViewTransformV2:
     Args:
         transforms:
             A sequence of v2 transforms. Every transform creates a new view.
-
     """
 
     def __init__(self, transforms: Sequence[T.Compose]):
@@ -27,7 +26,7 @@ class MultiViewTransformV2:
                 containing images, bounding boxes and masks.
 
         Returns:
-            A list of views, where each view is a transformed version of *args.
+            A list of views, where each view is a transformed version of `*args`.
 
         """
         return [transform(*args) for transform in self.transforms]


### PR DESCRIPTION
## Description
- reduces warnings from 46 to 13
- all remaining warnings are in the `api` subpackage
- additionally adds another make command for a clean docs build – otherwise some warnings will not be shown due to cache-ing

