### PR TITLE
fix(BTLoss): ensure invariance to affine transformations

### DIFF
--- a/lightly/loss/barlow_twins_loss.py
+++ b/lightly/loss/barlow_twins_loss.py
@@ -65,7 +65,7 @@ class BarlowTwinsLoss(torch.nn.Module):
         """
 
         # Normalize repr. along the batch dimension
-        z_a_norm, z_b_norm = _normalize(z_a, z_b)
+        z_a_norm, z_b_norm = _normalize(z_a), _normalize(z_b)
 
         N = z_a.size(0)
 
@@ -87,24 +87,16 @@ class BarlowTwinsLoss(torch.nn.Module):
         return loss
 
 
-def _normalize(
-    z_a: torch.Tensor, z_b: torch.Tensor
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Helper function to normalize tensors along the batch dimension."""
-    # Stack tensors along a new dimension
-    combined = torch.stack([z_a, z_b], dim=0)  # Shape: 2 x N x D
-
-    # Normalize the stacked tensors along the batch dimension
-    normalized = F.batch_norm(
-        combined.flatten(0, 1),
+def _normalize(z: torch.Tensor) -> torch.Tensor:
+    """Helper function to normalize tensor along the batch dimension."""
+    return F.batch_norm(
+        z,
         running_mean=None,
         running_var=None,
         weight=None,
         bias=None,
         training=True,
-    ).view_as(combined)
-
-    return normalized[0], normalized[1]
+    )
 
 
 def _off_diagonal(x: Tensor) -> Tensor:

--- a/lightly/loss/barlow_twins_loss.py
+++ b/lightly/loss/barlow_twins_loss.py
@@ -88,7 +88,7 @@ class BarlowTwinsLoss(torch.nn.Module):
 
 
 def _normalize(z: torch.Tensor) -> torch.Tensor:
-    """Helper function to normalize tensor along the batch dimension."""
+    """Helper function to create batches of mean 0 and std 1."""
     return F.batch_norm(
         z,
         running_mean=None,

--- a/tests/loss/test_barlow_twins_loss.py
+++ b/tests/loss/test_barlow_twins_loss.py
@@ -91,4 +91,4 @@ class TestBarlowTwinsLoss:
         x = torch.randn(32, 1024)
 
         # Loss should be invariant to affine transformations.
-        assert torch.allclose(loss(x, x), loss(x, 2*x + 4))
+        assert torch.allclose(loss(x, x), loss(x, 2 * x + 4))

--- a/tests/loss/test_barlow_twins_loss.py
+++ b/tests/loss/test_barlow_twins_loss.py
@@ -91,4 +91,4 @@ class TestBarlowTwinsLoss:
         x = torch.randn(32, 1024)
 
         # Loss should be invariant to affine transformations.
-        assert torch.allclose(loss(x, x), loss(x, 2 * x + 4))
+        assert torch.allclose(loss(x, x), loss(x, 2*x + 4))

--- a/tests/loss/test_barlow_twins_loss.py
+++ b/tests/loss/test_barlow_twins_loss.py
@@ -85,3 +85,10 @@ class TestBarlowTwinsLoss:
         loss_ref_out = loss_ref(z_a, z_b)
 
         assert torch.allclose(loss_out, loss_ref_out, rtol=1e-3, atol=1e-3)
+
+    def test__loss_is_affine_invariant(self) -> None:
+        loss = BarlowTwinsLoss()
+        x = torch.randn(32, 1024)
+
+        # Loss should be invariant to affine transformations.
+        assert torch.allclose(loss(x, x), loss(x, 2 * x + 4))


### PR DESCRIPTION
The Barlow Twins loss must be invariant to affine transformations since ``corr(X, X) = corr(X, a*X + b)``.

Previously, the loss was not invariant to such transformations since during normalization the statistics from ``z_a`` and ``z_b`` were mixed up:

```python
combined = torch.stack([z_a, z_b], dim=0)  # Shape: 2 x N x D

normalized = F.batch_norm(
    combined.flatten(0, 1),  # Embeddings are not normalized independently.
    ...
)
```

You can check that the loss was not scale invariant with this snippet:
```python
import torch
from lightly.loss import BarlowTwinsLoss

torch.manual_seed(42)

loss = BarlowTwinsLoss()
x = torch.randn(32, 128)

print(loss(x, x))
print(loss(x, 2*x + 4))
```

Additional changes:
* Add unit test

See also:
* https://www.alphaxiv.org/abs/2103.03230v3?cid=677730ab31430e4d1bbf0f8a
* https://www.reddit.com/r/MachineLearning/comments/1htpuuv/r_how_barlow_twins_avoid_embeddings_that_differ/