### PR TITLE
Rename `lightly-train` Command to `lightly-ssl-train`.

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -51,7 +51,7 @@ jobs:
           source .venv/bin/activate
           LIGHTLY_SERVER_LOCATION="localhost:-1"
           lightly-crop --help
-          lightly-train --help
+          lightly-ssl-train --help
           lightly-embed --help
           lightly-magic --help
           lightly-download --help
@@ -62,5 +62,5 @@ jobs:
           LIGHTLY_SERVER_LOCATION="localhost:-1"
           git clone https://github.com/alexeygrigorev/clothing-dataset-small clothing_dataset_small
           INPUT_DIR_1="clothing_dataset_small/test/dress"
-          lightly-train input_dir=$INPUT_DIR_1 trainer.max_epochs=1 loader.num_workers=6
+          lightly-ssl-train input_dir=$INPUT_DIR_1 trainer.max_epochs=1 loader.num_workers=6
           lightly-embed input_dir=$INPUT_DIR_1

--- a/docs/source/getting_started/command_line_tool.rst
+++ b/docs/source/getting_started/command_line_tool.rst
@@ -79,7 +79,7 @@ An example for the label names .yaml file:
     names: [cat, dog]
 
 You can use the output of the lightly-crop command as the *input_dir* for your
-lightly-train command.
+lightly-ssl-train command.
 
 Training and Embedding in a Go – Magic
 ---------------------------------------------------
@@ -118,23 +118,23 @@ You can use the following command to train a model and save the checkpoint:
 .. code-block:: bash
 
     # train a model using default parameters
-    lightly-train input_dir=cat
+    lightly-ssl-train input_dir=cat
 
     # train a model for 5 epochs
-    lightly-train input_dir=cat trainer.max_epochs=5
+    lightly-ssl-train input_dir=cat trainer.max_epochs=5
 
     # continue training from a checkpoint for another 10 epochs
-    lightly-train input_dir=cat trainer.max_epochs=10 checkpoint=mycheckpoint.ckpt
+    lightly-ssl-train input_dir=cat trainer.max_epochs=10 checkpoint=mycheckpoint.ckpt
 
     # continue training from the last checkpoint
-    lightly-train input_dir=cat trainer.max_epochs=10 \
+    lightly-ssl-train input_dir=cat trainer.max_epochs=10 \
                   checkpoint=$LIGHTLY_LAST_CHECKPOINT_PATH
 
     # train with multiple gpus
     # the total batch size will be trainer.gpus * loader.batch_size
-    lightly-train input_dir=data_dir trainer.gpus=2
+    lightly-ssl-train input_dir=data_dir trainer.gpus=2
 
-The path to the latest checkpoint you created using the `lightly-train` command
+The path to the latest checkpoint you created using the `lightly-ssl-train` command
 will be saved under an environment variable named LIGHTLY_LAST_CHECKPOINT_PATH.
 This can be useful for continuing training or for creating embeddings from
 a checkpoint.
@@ -143,7 +143,7 @@ For a full list of supported arguments run
 
 .. code-block:: bash
     
-    lightly-train --help
+    lightly-ssl-train --help
 
 
 You can get an overview of the various CLI parameters you can set in 
@@ -222,14 +222,14 @@ you can use the following:
     # equivalent breakdown into single commands
 
     # train the embedding model
-    lightly-train input_dir=data_dir
+    lightly-ssl-train input_dir=data_dir
     # embed the images with the embedding model just trained
     lightly-embed input_dir=data_dir checkpoint=$LIGHTLY_LAST_CHECKPOINT_PATH
 
 
 
 
-    
+
 
 
 

--- a/docs/source/lightly.cli.rst
+++ b/docs/source/lightly.cli.rst
@@ -50,7 +50,7 @@ and empty string so it must be overwritten:
 .. code-block:: bash
 
    # train the default model on my data
-   lightly-train input_dir='path/to/my/data'
+   lightly-ssl-train input_dir='path/to/my/data'
 
 An argument which is grouped under a certain namespace can be accessed by specifying the namespace and the argument,
 separated by a dot. For example the argument "name" in the namespace "model" can be accessed like so:
@@ -58,7 +58,7 @@ separated by a dot. For example the argument "name" in the namespace "model" can
 .. code-block:: bash
 
    # train a ResNet-34 on my data
-   lightly-train input_dir='path/to/my/data' model.name='resnet-34'
+   lightly-ssl-train input_dir='path/to/my/data' model.name='resnet-34'
 
 Additional Arguments
 ^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ This can be done by adding a + right before the argument:
 .. code-block:: bash
 
    # train a ResNet-34 with momentum on my data
-   lightly-train input_dir='path/to/my/data' model.name='resnet-34' +optimizer.momentum=0.9
+   lightly-ssl-train input_dir='path/to/my/data' model.name='resnet-34' +optimizer.momentum=0.9
 
 .. _ref-cli-config-default:
 

--- a/lightly/cli/config/config.yaml
+++ b/lightly/cli/config/config.yaml
@@ -131,16 +131,16 @@ hydra:
       > lightly-embed input_dir='path/to/image/folder' collate.input_size=224 checkpoint='path/to/checkpoint.ckpt'
 
       Train a self-supervised model on your image dataset from scratch
-      > lightly-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 pre_trained=False
+      > lightly-ssl-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 pre_trained=False
 
       Train a self-supervised model starting from the pre-trained checkpoint
-      > lightly-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224
+      > lightly-ssl-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224
 
       Train a self-supervised model starting from a custom checkpoint
-      > lightly-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 checkpoint='path/to/checkpoint.ckpt'
+      > lightly-ssl-train input_dir='path/to/image/folder' loader.batch_size=128 collate.input_size=224 checkpoint='path/to/checkpoint.ckpt'
 
       Train using half-precision
-      > lightly-train input_dir='path/to/image/folder' trainer.precision=16
+      > lightly-ssl-train input_dir='path/to/image/folder' trainer.precision=16
       
       Download a list of files in a given tag from the Lightly Platform
       > lightly-download tag_name='my-tag' dataset_id='your_dataset_id' token='your_access_token'

--- a/lightly/cli/crop_cli.py
+++ b/lightly/cli/crop_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """**Lightly Train:** Train a self-supervised model from the command-line.
 
-This module contains the entrypoint for the **lightly-train**
+This module contains the entrypoint for the **lightly-crop**
 command-line interface.
 """
 

--- a/lightly/cli/train_cli.py
+++ b/lightly/cli/train_cli.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-"""**Lightly Train:** Train a self-supervised model from the command-line.
+"""**Lightly SSL Train:** Train a self-supervised model from the command-line.
 
-This module contains the entrypoint for the **lightly-train**
+This module contains the entrypoint for the **lightly-ssl-train**
 command-line interface.
 """
 
@@ -167,17 +167,17 @@ def train_cli(cfg):
             Path to the input directory where images are stored.
 
     Examples:
-        >>> # train model with default settings
-        >>> lightly-train input_dir=data/
+        >>> # train model with default settings
+        >>> lightly-ssl-train input_dir=data/
         >>>
         >>> # train model with batches of size 128
-        >>> lightly-train input_dir=data/ loader.batch_size=128
+        >>> lightly-ssl-train input_dir=data/ loader.batch_size=128
         >>>
         >>> # train model for 10 epochs
-        >>> lightly-train input_dir=data/ trainer.max_epochs=10
+        >>> lightly-ssl-train input_dir=data/ trainer.max_epochs=10
         >>>
         >>> # print a full summary of the model
-        >>> lightly-train input_dir=data/ trainer.weights_summary=full
+        >>> lightly-ssl-train input_dir=data/ trainer.weights_summary=full
 
     """
     return _train_cli(cfg)

--- a/lightly/core.py
+++ b/lightly/core.py
@@ -127,8 +127,8 @@ def train_model_and_embed_images(
 def train_embedding_model(config_path: str = None, **kwargs):
     """Train a self-supervised model.
 
-    Calls the same function as lightly-train. All arguments passed to
-    lightly-train can also be passed to this function (see below for an
+    Calls the same function as lightly-ssl-train. All arguments passed to
+    lightly-ssl-train can also be passed to this function (see below for an
     example).
 
     Args:
@@ -162,7 +162,7 @@ def train_embedding_model(config_path: str = None, **kwargs):
         >>> checkpoint_path = lightly.train_embedding_model(
         >>>     input_dir='path/to/data', loader=my_loader)
         >>> # the command above is equivalent to:
-        >>> # lightly-train input_dir='path/to/data' loader.batch_size=100 loader.num_workers=8
+        >>> # lightly-ssl-train input_dir='path/to/data' loader.batch_size=100 loader.num_workers=8
     """
     config_path = _get_config_path(config_path)
     config_args = _load_config_file(config_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ lightly-download = "lightly.cli.download_cli:entry"
 lightly-embed = "lightly.cli.embed_cli:entry"
 lightly-magic = "lightly.cli.lightly_cli:entry"
 lightly-serve = "lightly.cli.serve_cli:entry"
-lightly-train = "lightly.cli.train_cli:entry"
+lightly-ssl-train = "lightly.cli.train_cli:entry"
 lightly-version = "lightly.cli.version_cli:entry"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
- [x] Rename the `lightly-train` command to `lightly-ssl-train` so as to avoid the bug of using `lightly-train` command in LightlyTrain:

```
Error parsing override 'train'
missing EQUAL at '<EOF>'
See https://hydra.cc/docs/1.2/advanced/override_grammar/basic for details
Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

- [x] Update the corresponding docs and docstrings.

[Command-line tool — lightly 1.5.19 documentation.pdf](https://github.com/user-attachments/files/19790445/Command-line.tool.lightly.1.5.19.documentation.pdf)
[lightly.cli — lightly 1.5.19 documentation.pdf](https://github.com/user-attachments/files/19790446/lightly.cli.lightly.1.5.19.documentation.pdf)