### PR TITLE
Add seed_everything import for reproducibility in benchmarks

### DIFF
--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -89,7 +89,7 @@ def main(
     ckpt_path: Union[Path, None],
     float32_matmul_precision: str,
     strategy: str,
-    seed: int | None = None
+    seed: int | None = None,
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
     seed_everything(seed, workers=True, verbose=True)

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -17,7 +17,7 @@ import swav
 import tico
 import torch
 import vicreg
-from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning import LightningModule, Trainer, seed_everything
 from pytorch_lightning.callbacks import (
     DeviceStatsMonitor,
     EarlyStopping,
@@ -90,6 +90,8 @@ def main(
     strategy: str,
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
+    seed_everything(42, workers=True, verbose=True)
+
     torch.set_float32_matmul_precision(float32_matmul_precision)
 
     method_names = methods or METHODS.keys()

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -51,6 +51,7 @@ parser.add_argument("--skip-linear-eval", action="store_true")
 parser.add_argument("--skip-finetune-eval", action="store_true")
 parser.add_argument("--float32-matmul-precision", type=str, default="high")
 parser.add_argument("--strategy", default="ddp_find_unused_parameters_true")
+parser.add_argument("--seed", type=int, default=None)
 
 METHODS = {
     "barlowtwins": {
@@ -88,9 +89,10 @@ def main(
     ckpt_path: Union[Path, None],
     float32_matmul_precision: str,
     strategy: str,
+    seed: int | None = None
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
-    seed_everything(42, workers=True, verbose=True)
+    seed_everything(seed, workers=True, verbose=True)
 
     torch.set_float32_matmul_precision(float32_matmul_precision)
 

--- a/benchmarks/imagenet/vitb16/main.py
+++ b/benchmarks/imagenet/vitb16/main.py
@@ -76,7 +76,7 @@ def main(
     ckpt_path: Union[Path, None],
     float32_matmul_precision: str,
     strategy: str,
-    seed: int | None = None
+    seed: int | None = None,
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
     seed_everything(seed, workers=True, verbose=True)

--- a/benchmarks/imagenet/vitb16/main.py
+++ b/benchmarks/imagenet/vitb16/main.py
@@ -10,7 +10,7 @@ import knn_eval
 import linear_eval
 import mae
 import torch
-from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning import LightningModule, Trainer, seed_everything
 from pytorch_lightning.callbacks import (
     DeviceStatsMonitor,
     EarlyStopping,
@@ -78,6 +78,7 @@ def main(
     strategy: str,
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
+    seed_everything(42, workers=True, verbose=True)
     torch.set_float32_matmul_precision(float32_matmul_precision)
 
     method_names = methods or METHODS.keys()

--- a/benchmarks/imagenet/vitb16/main.py
+++ b/benchmarks/imagenet/vitb16/main.py
@@ -47,7 +47,7 @@ parser.add_argument("--skip-linear-eval", action="store_true")
 parser.add_argument("--skip-finetune-eval", action="store_true")
 parser.add_argument("--float32-matmul-precision", type=str, default="high")
 parser.add_argument("--strategy", default="ddp_find_unused_parameters_true")
-
+parser.add_argument("--seed", type=int, default=None)
 METHODS = {
     "dino": {"model": dino.DINO, "transform": dino.transform},
     "mae": {"model": mae.MAE, "transform": mae.transform},
@@ -76,9 +76,10 @@ def main(
     ckpt_path: Union[Path, None],
     float32_matmul_precision: str,
     strategy: str,
+    seed: int | None = None
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
-    seed_everything(42, workers=True, verbose=True)
+    seed_everything(seed, workers=True, verbose=True)
     torch.set_float32_matmul_precision(float32_matmul_precision)
 
     method_names = methods or METHODS.keys()


### PR DESCRIPTION
This PR imports `seed_everything` from PyTorch Lightning and invokes it at the start for 'main.py'  of both the ResNet50 and ViT-B/16 benchmark scripts. 
