### PR TITLE
Fix DINOLoss tensor warning

### DIFF
--- a/lightly/loss/dino_loss.py
+++ b/lightly/loss/dino_loss.py
@@ -133,7 +133,7 @@ class DINOLoss(Module):
             teacher_temperature = torch.tensor(teacher_temp)
         elif epoch is not None:  # for backward compatibility
             if epoch < self.warmup_teacher_temp_epochs:
-                teacher_temperature = torch.tensor(self.teacher_temp_schedule[epoch])
+                teacher_temperature = self.teacher_temp_schedule[epoch]
             else:
                 teacher_temperature = torch.tensor(self.teacher_temp)
         else:


### PR DESCRIPTION
## What has changed and why?

* Fix DINOLoss tensor warning

This change removes the following warning:
```
UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  teacher_temperature = torch.tensor(self.teacher_temp_schedule[epoch])
```

This happened because `self.teacher_temp_schedule` already returns a tensor. 