### PR TITLE
Format & format-check: only target python directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,16 +31,19 @@ clean-out:
 	rm -fr last.ckpt
 
 
+# Python directories to format and lint
+PYTHON_DIRS = benchmarks docs examples lightly tests
+
 # format code with isort and black
 format:
-	isort .
-	black .
+	isort $(PYTHON_DIRS)
+	black $(PYTHON_DIRS)
 
 # check if code is formatted with isort and black
 format-check:
 	@echo "⚫ Checking code format..."
-	isort --check-only --diff .
-	black --check .
+	isort --check-only --diff $(PYTHON_DIRS)
+	black --check $(PYTHON_DIRS)
 
 # check style with flake8
 lint: lint-lightly lint-tests


### PR DESCRIPTION
## Description:

Makes the format & format-check only target python directories. This is relevant for users having other python directories which should not be formatted.

E.g. it prevents problems like this one:

```bash
.venv_3p7__minimalmalteebnerlightly@Maltes-MacBook-Pro lightly % make format
isort .
Fixing /Users/malteebnerlightly/Documents/GitHub/lightly/.venv_3p10/bin/f2py
Fixing /Users/malteebnerlightly/Documents/GitHub/lightly/.venv_3p10/bin/numpy-config
```