### PR TITLE
Run weekly tests the same way as unit tests

### DIFF
--- a/.github/workflows/weekly_dependency_test.yml
+++ b/.github/workflows/weekly_dependency_test.yml
@@ -29,7 +29,7 @@ jobs:
       id: run_tests
       run: |
         source .venv/bin/activate
-        pytest -n auto
+        python -m pytest -s -v --runslow
     - name: Slack Notification
       if: always()
       uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## Changes

* Use same command for weekly tests as for unit tests

The only difference is that weekly tests don't run codecov. 

## How was it tested?

* https://github.com/lightly-ai/lightly/actions/runs/15411745822