### PR TITLE
Fix Benchmark Evaluation

### DIFF
--- a/benchmarks/imagenet/resnet50/knn_eval.py
+++ b/benchmarks/imagenet/resnet50/knn_eval.py
@@ -25,6 +25,8 @@ def knn_eval(
     devices: int,
     strategy: str,
     num_classes: int,
+    knn_k: int,
+    knn_t: float,
 ) -> Dict[str, float]:
     """Runs KNN evaluation on the given model.
 
@@ -70,6 +72,8 @@ def knn_eval(
         model=model,
         num_classes=num_classes,
         feature_dtype=torch.float16,
+        knn_k=knn_k,
+        knn_t=knn_t,
     )
 
     # Run KNN evaluation.

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -47,6 +47,8 @@ parser.add_argument("--compile-model", action="store_true")
 parser.add_argument("--methods", type=str, nargs="+")
 parser.add_argument("--num-classes", type=int, default=1000)
 parser.add_argument("--skip-knn-eval", action="store_true")
+parser.add_argument("--knn-k", type=int, default=200)
+parser.add_argument("--knn-t", type=float, default=0.1)
 parser.add_argument("--skip-linear-eval", action="store_true")
 parser.add_argument("--skip-finetune-eval", action="store_true")
 parser.add_argument("--float32-matmul-precision", type=str, default="high")
@@ -83,6 +85,8 @@ def main(
     compile_model: bool,
     methods: Union[Sequence[str], None],
     num_classes: int,
+    knn_k: int,
+    knn_t: float,
     skip_knn_eval: bool,
     skip_linear_eval: bool,
     skip_finetune_eval: bool,
@@ -147,6 +151,8 @@ def main(
                 accelerator=accelerator,
                 devices=devices,
                 strategy=strategy,
+                knn_k=knn_k,
+                knn_t=knn_t,
             )
 
         if skip_linear_eval:

--- a/benchmarks/imagenet/vitb16/knn_eval.py
+++ b/benchmarks/imagenet/vitb16/knn_eval.py
@@ -25,7 +25,8 @@ def knn_eval(
     devices: int,
     strategy: str,
     num_classes: int,
-    knn_k: int = 200,
+    knn_k: int,
+    knn_t: float,
 ) -> Dict[str, float]:
     """Runs KNN evaluation on the given model.
 
@@ -71,6 +72,7 @@ def knn_eval(
         model=model,
         num_classes=num_classes,
         knn_k=knn_k,
+        knn_t=knn_t,
     )
 
     # Run KNN evaluation.

--- a/benchmarks/imagenet/vitb16/main.py
+++ b/benchmarks/imagenet/vitb16/main.py
@@ -42,8 +42,9 @@ parser.add_argument("--compile-model", action="store_true")
 parser.add_argument("--methods", type=str, nargs="+")
 parser.add_argument("--eval-method", type=str, default="mae", choices=["mae", "simclr"])
 parser.add_argument("--num-classes", type=int, default=1000)
-parser.add_argument("--knn-k", type=int, default=200)
 parser.add_argument("--skip-knn-eval", action="store_true")
+parser.add_argument("--knn-k", type=int, default=200)
+parser.add_argument("--knn-t", type=float, default=0.07)
 parser.add_argument("--skip-linear-eval", action="store_true")
 parser.add_argument("--skip-finetune-eval", action="store_true")
 parser.add_argument("--float32-matmul-precision", type=str, default="high")
@@ -72,6 +73,7 @@ def main(
     eval_method: str,
     num_classes: int,
     knn_k: int,
+    knn_t: float,
     skip_knn_eval: bool,
     skip_linear_eval: bool,
     skip_finetune_eval: bool,
@@ -139,6 +141,7 @@ def main(
                 devices=devices,
                 strategy=strategy,
                 knn_k=knn_k,
+                knn_t=knn_t,
             )
 
         if skip_linear_eval:

--- a/lightly/utils/benchmarking/knn_classifier.py
+++ b/lightly/utils/benchmarking/knn_classifier.py
@@ -134,8 +134,6 @@ class KNNClassifier(LightningModule):
         pass
 
     def validation_step(self, batch, batch_idx: int, dataloader_idx: int) -> None:
-        # Set model to eval mode to disable norm layer updates.
-        self.model.eval()
         images, targets = batch[0], batch[1]
         features = self(images)
 

--- a/lightly/utils/benchmarking/knn_classifier.py
+++ b/lightly/utils/benchmarking/knn_classifier.py
@@ -15,8 +15,8 @@ class KNNClassifier(LightningModule):
         self,
         model: Module,
         num_classes: int,
-        knn_k: int = 200,
-        knn_t: float = 0.07,
+        knn_k: int,
+        knn_t: float,
         topk: Tuple[int, ...] = (1, 5),
         feature_dtype: torch.dtype = torch.float32,
         normalize: bool = True,
@@ -134,6 +134,8 @@ class KNNClassifier(LightningModule):
         pass
 
     def validation_step(self, batch, batch_idx: int, dataloader_idx: int) -> None:
+        # Set model to eval mode to disable norm layer updates.
+        self.model.eval()
         images, targets = batch[0], batch[1]
         features = self(images)
 
@@ -162,16 +164,6 @@ class KNNClassifier(LightningModule):
             self.log_dict(
                 log_dict, prog_bar=True, sync_dist=True, batch_size=len(targets)
             )
-
-    def on_train_epoch_start(self) -> None:
-        # Set model to eval mode to disable norm layer updates.
-        self.model.eval()
-
-        # Reset features and targets.
-        self._train_features = []
-        self._train_targets = []
-        self._train_features_tensor = None
-        self._train_targets_tensor = None
 
     def configure_optimizers(self) -> None:
         # configure_optimizers must be implemented for PyTorch Lightning. Returning None

--- a/tests/utils/benchmarking/test_knn_classifier.py
+++ b/tests/utils/benchmarking/test_knn_classifier.py
@@ -42,7 +42,9 @@ class TestKNNClassifier:
 
         # Run KNN classifier.
         model = nn.Identity()
-        classifier = KNNClassifier(model, num_classes=4, knn_k=3, topk=(1, 2, 3, 4))
+        classifier = KNNClassifier(
+            model, num_classes=4, knn_k=3, knn_t=0.1, topk=(1, 2, 3, 4)
+        )
         trainer = Trainer(max_epochs=1, accelerator="cpu", devices=1)
         trainer.validate(
             model=classifier,
@@ -78,7 +80,7 @@ class TestKNNClassifier:
         model = nn.Sequential(linear, batch_norm)
         initial_weights = linear.weight.clone()
         initial_bn_weights = batch_norm.weight.clone()
-        classifier = KNNClassifier(model, num_classes=10, knn_k=20)
+        classifier = KNNClassifier(model, num_classes=10, knn_k=20, knn_t=0.1)
         trainer = Trainer(max_epochs=1, accelerator=accelerator, devices=1)
         train_features = torch.randn(40, 3)
         train_targets = torch.randint(0, 10, (40,))
@@ -126,7 +128,7 @@ class TestKNNClassifier:
         # Set feature_dtype to torch.int to test if classifier correctly changes dtype.
         # We cannot test for torch.float16 because it is not supported on cpu.
         classifier = KNNClassifier(
-            model, num_classes=10, knn_k=3, feature_dtype=torch.int
+            model, num_classes=10, knn_k=3, knn_t=0.1, feature_dtype=torch.int
         )
         trainer = Trainer(max_epochs=1, accelerator="cpu", devices=1)
         train_features = torch.randn(4, 3)
@@ -158,7 +160,7 @@ class TestKNNClassifier:
 
         # Test that normalize is called when normalize=True.
         classifier = KNNClassifier(
-            nn.Identity(), num_classes=10, knn_k=3, normalize=True
+            nn.Identity(), num_classes=10, knn_k=3, knn_t=0.1, normalize=True
         )
         trainer.validate(
             model=classifier,
@@ -169,7 +171,7 @@ class TestKNNClassifier:
 
         # Test that normalize is not called when normalize=False.
         classifier = KNNClassifier(
-            nn.Identity(), num_classes=10, knn_k=3, normalize=False
+            nn.Identity(), num_classes=10, knn_k=3, knn_t=0.1, normalize=False
         )
         trainer.validate(
             model=classifier,


### PR DESCRIPTION
According to #1824, the KNN eval results of the SimCLR checkpoint cannot be reproduced. This is because we changed the default `knn_t` from 0.1 to 0.07 during the dev of DINO benchmark #1802 . To make the results reproducible and also give the users the freedom to tune these params, we now make both `knn_k` and `knn_t` configurable and set the defaults to 0.1 for ResNet benchmarks and 0.07 for ViT benchmarks. 

The fix also contains fixes to the `KNNClassifier` where `model.eval()` should be in `validation_step`. The training will never be run after the change in #1800.