### PR TITLE
MaskedCausalBlock.__init__() got an unexpected keyword argument 'proj_bias'

### DIFF
--- a/lightly/models/modules/masked_causal_vision_transformer.py
+++ b/lightly/models/modules/masked_causal_vision_transformer.py
@@ -105,20 +105,10 @@ class MaskedCausalBlock(Block):  # type: ignore[misc]
     - [0]: AIM, 2024, https://arxiv.org/abs/2401.08541
     """
 
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
-        dim: int,
-        num_heads: int,
-        mlp_ratio: float = 4.0,
-        qkv_bias: bool = False,
-        qk_norm: bool = False,
-        proj_drop: float = 0.0,
-        attn_drop: float = 0.0,
-        init_values: Optional[float] = None,
-        drop_path: float = 0.0,
-        act_layer: Type[Module] = GELU,
-        norm_layer: Type[Module] = LayerNorm,
-        mlp_layer: Type[Module] = Mlp,
+        *args,
+        **kwargs,
     ) -> None:
         """Initializes the MaskedCausalBlock with the specified parameters.
 
@@ -133,6 +123,8 @@ class MaskedCausalBlock(Block):  # type: ignore[misc]
                 If True, add bias to the query, key, and value tensors.
             qk_norm:
                 If True, apply layer normalization to queries and keys.
+            proj_bias:
+                If True, add bias to the projection layer (with TIMM >= 1.0.14).
             proj_drop:
                 Percentage of elements set to zero after the projection layer.
             attn_drop:
@@ -149,27 +141,12 @@ class MaskedCausalBlock(Block):  # type: ignore[misc]
                 MLP layer to use.
         """
         super().__init__(
-            dim=dim,
-            num_heads=num_heads,
-            mlp_ratio=mlp_ratio,
-            qkv_bias=qkv_bias,
-            qk_norm=qk_norm,
-            proj_drop=proj_drop,
-            attn_drop=attn_drop,
-            init_values=init_values,
-            drop_path=drop_path,
-            act_layer=act_layer,
-            norm_layer=norm_layer,
-            mlp_layer=mlp_layer,
+            *args,
+            **kwargs,
         )
         self.attn = MaskedCausalAttention(
-            dim,
-            num_heads=num_heads,
-            qkv_bias=qkv_bias,
-            qk_norm=qk_norm,
-            attn_drop=attn_drop,
-            proj_drop=proj_drop,
-            norm_layer=norm_layer,
+            *args,
+            **kwargs,
         )
 
     def forward(self, x: Tensor, mask: Optional[Tensor] = None) -> Tensor:
@@ -200,39 +177,10 @@ class MaskedCausalVisionTransformer(VisionTransformer):  # type: ignore[misc]
     - [0]: AIM, 2024, https://arxiv.org/abs/2401.08541
     """
 
-    def __init__(
+    def __init__(  # type: ignore[no-untyped-def]
         self,
-        img_size: Union[int, Tuple[int, int]] = 224,
-        patch_size: Union[int, Tuple[int, int]] = 16,
-        in_chans: int = 3,
-        num_classes: int = 1000,
-        global_pool: str = "",
-        embed_dim: int = 768,
-        depth: int = 12,
-        num_heads: int = 12,
-        mlp_ratio: float = 4.0,
-        qkv_bias: bool = True,
-        qk_norm: bool = False,
-        init_values: Optional[float] = None,
-        class_token: bool = True,
-        no_embed_class: bool = False,
-        reg_tokens: int = 0,
-        pre_norm: bool = False,
-        fc_norm: Optional[bool] = None,
-        dynamic_img_size: bool = False,
-        dynamic_img_pad: bool = False,
-        drop_rate: float = 0.0,
-        pos_drop_rate: float = 0.0,
-        patch_drop_rate: float = 0.0,
-        proj_drop_rate: float = 0.0,
-        attn_drop_rate: float = 0.0,
-        drop_path_rate: float = 0.0,
-        weight_init: str = "",
-        embed_layer: Callable = PatchEmbed,  # type: ignore[type-arg]
-        norm_layer: Optional[LayerType] = None,
-        act_layer: Optional[LayerType] = None,
-        block_fn: Type[Module] = MaskedCausalBlock,
-        mlp_layer: Type[Module] = Mlp,
+        *args,
+        **kwargs,
     ) -> None:
         """Initializes the MaskedCausalVisionTransformer with the specified parameters.
 
@@ -259,6 +207,8 @@ class MaskedCausalVisionTransformer(VisionTransformer):  # type: ignore[misc]
                 If True, add bias to the query, key, and value tensors.
             qk_norm:
                 If True, apply layer normalization to queries and keys.
+            proj_bias:
+                If True, add bias to the projection layer (with TIMM >= 1.0.14).
             init_values:
                 Initial values for the layer.
             class_token:
@@ -300,38 +250,10 @@ class MaskedCausalVisionTransformer(VisionTransformer):  # type: ignore[misc]
             mlp_layer:
                 MLP layer to use.
         """
+        kwargs.setdefault("block_fn", MaskedCausalBlock)
         super().__init__(
-            img_size=img_size,
-            patch_size=patch_size,
-            in_chans=in_chans,
-            num_classes=num_classes,
-            global_pool=global_pool,
-            embed_dim=embed_dim,
-            depth=depth,
-            num_heads=num_heads,
-            mlp_ratio=mlp_ratio,
-            qkv_bias=qkv_bias,
-            qk_norm=qk_norm,
-            init_values=init_values,
-            class_token=class_token,
-            no_embed_class=no_embed_class,
-            reg_tokens=reg_tokens,
-            pre_norm=pre_norm,
-            fc_norm=fc_norm,
-            dynamic_img_size=dynamic_img_size,
-            dynamic_img_pad=dynamic_img_pad,
-            drop_rate=drop_rate,
-            pos_drop_rate=pos_drop_rate,
-            patch_drop_rate=patch_drop_rate,
-            proj_drop_rate=proj_drop_rate,
-            attn_drop_rate=attn_drop_rate,
-            drop_path_rate=drop_path_rate,
-            weight_init=weight_init,
-            embed_layer=embed_layer,
-            norm_layer=norm_layer,
-            act_layer=act_layer,
-            block_fn=block_fn,
-            mlp_layer=mlp_layer,
+            *args,
+            **kwargs,
         )
 
     def forward_features(self, x: Tensor, mask: Optional[Tensor] = None) -> Tensor:

--- a/lightly/models/modules/masked_causal_vision_transformer.py
+++ b/lightly/models/modules/masked_causal_vision_transformer.py
@@ -1,12 +1,10 @@
-from typing import Callable, Optional, Tuple, Type, Union
+from typing import Optional
 
 import torch
 import torch.nn.functional as F
-from timm.layers import LayerType, Mlp, PatchEmbed
 from timm.models import _manipulate
 from timm.models.vision_transformer import Attention, Block, VisionTransformer
 from torch import Tensor, jit
-from torch.nn import GELU, LayerNorm, Module
 
 
 # Type ignore because superclass has Any types.

--- a/lightly/models/modules/masked_causal_vision_transformer.py
+++ b/lightly/models/modules/masked_causal_vision_transformer.py
@@ -10,7 +10,8 @@ from torch import Tensor, jit
 # Type ignore because superclass has Any types.
 class MaskedCausalAttention(Attention):  # type: ignore[misc]
     """Identical to timm.models.vision_transformer.Attention, but supports causal
-    attention with masking.
+    attention with masking. Please check the source code of the
+    timm.models.vision_transformer.Attention class for input parameters.
 
     The implementation is based on AIM [0].
 
@@ -96,7 +97,8 @@ class MaskedCausalAttention(Attention):  # type: ignore[misc]
 # Type ignore because superclass has Any types.
 class MaskedCausalBlock(Block):  # type: ignore[misc]
     """Identical to timm.models.vision_transformer.Block, but uses PrefixCausalAttention
-    instead of Attention.
+    instead of Attention. Please check the source code of the timm.models.vision_transformer.Block
+    class for input parameters.
 
     The implementation is based on AIM [0].
 
@@ -108,35 +110,9 @@ class MaskedCausalBlock(Block):  # type: ignore[misc]
         *args,
         **kwargs,
     ) -> None:
-        """Initializes the MaskedCausalBlock with the specified parameters.
+        """Initializes the MaskedCausalBlock with the specified parameters. Please check the source code of the timm.models.vision_transformer.Block
+        class for input parameters.
 
-        Args:
-            dim:
-                Dimension of the input tokens.
-            num_heads:
-                Number of attention heads.
-            mlp_ratio:
-                Ratio of MLP hidden dim to embedding dim.
-            qkv_bias:
-                If True, add bias to the query, key, and value tensors.
-            qk_norm:
-                If True, apply layer normalization to queries and keys.
-            proj_bias:
-                If True, add bias to the projection layer (with TIMM >= 1.0.14).
-            proj_drop:
-                Percentage of elements set to zero after the projection layer.
-            attn_drop:
-                Percentage of elements set to zero after the attention head.
-            init_values:
-                Initial values for the layer.
-            drop_path:
-                Drop path rate for the block.
-            act_layer:
-                Activation layer to use.
-            norm_layer:
-                Normalization layer to use.
-            mlp_layer:
-                MLP layer to use.
         """
         super().__init__(
             *args,
@@ -170,7 +146,8 @@ class MaskedCausalBlock(Block):  # type: ignore[misc]
 
 # Type ignore because superclass has Any types.
 class MaskedCausalVisionTransformer(VisionTransformer):  # type: ignore[misc]
-    """Vision transformer with masked causal attention based on AIM [0].
+    """Vision transformer with masked causal attention based on AIM [0]. Please check the source code of the timm.models.vision_transformer.VisionTransformer
+    class for input parameters.
 
     - [0]: AIM, 2024, https://arxiv.org/abs/2401.08541
     """
@@ -180,73 +157,9 @@ class MaskedCausalVisionTransformer(VisionTransformer):  # type: ignore[misc]
         *args,
         **kwargs,
     ) -> None:
-        """Initializes the MaskedCausalVisionTransformer with the specified parameters.
+        """Initializes the MaskedCausalVisionTransformer with the specified parameters. Please check the source code of the timm.models.vision_transformer.VisionTransformer
+        class for input parameters.
 
-        Args:
-            img_size:
-                Input image size.
-            patch_size:
-                Width and height of the image patches.
-            in_chans:
-                Number of image input channels.
-            num_classes:
-                Number of classes for the classification head.
-            global_pool:
-                Global pooling type.
-            embed_dim:
-                Embedding dimension.
-            depth:
-                Depth of the transformer.
-            num_heads:
-                Number of attention heads.
-            mlp_ratio:
-                Ratio of MLP hidden dim to embedding dim.
-            qkv_bias:
-                If True, add bias to the query, key, and value tensors.
-            qk_norm:
-                If True, apply layer normalization to queries and keys.
-            proj_bias:
-                If True, add bias to the projection layer (with TIMM >= 1.0.14).
-            init_values:
-                Initial values for the layer.
-            class_token:
-                If True, add class token to the embeddings.
-            no_embed_class:
-                If True, do not embed class token.
-            reg_tokens:
-                Number of regularization tokens.
-            pre_norm :
-                If True, apply layer normalization before the transformer.
-            fc_norm:
-                If True, apply layer normalization to the final fully connected layer.
-            dynamic_img_size:
-                If True, dynamically adjust the image size.
-            dynamic_img_pad:
-                If True, dynamically pad the image.
-            drop_rate:
-                Percentage of elements set to zero after the dropout layer.
-            pos_drop_rate:
-                Percentage of elements set to zero after the positional dropout layer.
-            patch_drop_rate:
-                Percentage of elements set to zero after the patch dropout layer.
-            proj_drop_rate:
-                Percentage of elements set to zero after the projection dropout layer.
-            attn_drop_rate:
-                Percentage of elements set to zero after the attention head dropout.
-            drop_path_rate:
-                Drop path rate for the block.
-            weight_init:
-                Weight initialization method.
-            embed_layer:
-                Callable that creates the embedding layer.
-            norm_layer:
-                Normalization layer to use.
-            act_layer:
-                Activation layer to use.
-            block_fn:
-                Block function to use.
-            mlp_layer:
-                MLP layer to use.
         """
         kwargs.setdefault("block_fn", MaskedCausalBlock)
         super().__init__(


### PR DESCRIPTION
Close #1829

Starting v1.0.14 TIMM added an extra parameter `proj_bias` for `Attention`, `Block`, and `VisionTransformer`, which we inherit from with our `MaskedCausalxxx`.

Given that it would be super cumbersome to have different `__init__` interfaces based on package versions and that these classes are already well typed in TIMM, I decide that we skip reiterating the params explicitly and instead use `*args` and `**kwargs` to prevent interfacet change issues altogether. The docstrings are still kept for reference.