### PR TITLE
Fix Minimal Dep Tests

### DIFF
--- a/.github/workflows/test_minimal_deps.yml
+++ b/.github/workflows/test_minimal_deps.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           # Install libavformat-dev and libavdevice-dev for PyAV as versions before 9.0
           # do not provide wheels including FFMPEG.
+          # TODO (Yutong, 06/25): we specifically use libvpx7 version 1.11.0-2ubuntu2 to fix the hold of broken package when installing 1.11.0-2ubuntu2.3, 
+          # this should be removed once the issue is resolved for `1.11.0-2ubuntu2.3` and above in the future.
           sudo apt-get install libvpx7=1.11.0-2ubuntu2 libavformat-dev libavdevice-dev 
           make install-uv reset-venv
           source .venv/bin/activate


### PR DESCRIPTION
Fix (temporarily) the failed min dep test due to the hold of broken package `libvpx7_1.11.0-2ubuntu2.3_amd64.deb`.

See https://github.com/lightly-ai/lightly/actions/runs/15578360299/job/43876130740?pr=1844 for the error logs