### PR TITLE
Add iBOTTransform

### DIFF
--- a/lightly/transforms/__init__.py
+++ b/lightly/transforms/__init__.py
@@ -25,6 +25,7 @@ from lightly.transforms.fda_transform import (
 )
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.gaussian_mixture_masks_transform import GaussianMixtureMask
+from lightly.transforms.ibot_transform import IBOTTransform, IBOTViewTransform
 from lightly.transforms.irfft2d_transform import IRFFT2DTransform
 from lightly.transforms.jigsaw import Jigsaw
 from lightly.transforms.mae_transform import MAETransform

--- a/lightly/transforms/ibot_transform.py
+++ b/lightly/transforms/ibot_transform.py
@@ -1,0 +1,239 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import PIL
+from PIL.Image import Image
+from torch import Tensor
+
+from lightly.transforms.gaussian_blur import GaussianBlur
+from lightly.transforms.multi_view_transform import MultiViewTransform
+from lightly.transforms.solarize import RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.utils import IMAGENET_NORMALIZE
+
+
+class IBOTTransform(MultiViewTransform):
+    """Implements the global and local view augmentations for iBOT [0].
+
+    Input to this transform:
+        PIL Image or Tensor.
+
+    Output of this transform:
+        List of Tensor of length 2 * global + n_local_views. (10 by default)
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - Random solarization
+        - ImageNet normalization
+
+    This class generates two global and a user defined number of local views
+    for each image in a batch. The code is adapted from [1].
+
+    - [0]: iBOT, 2021, https://arxiv.org/abs/2111.07832
+    - [1]: https://github.com/bytedance/ibot/blob/main/main_ibot.py#L574
+
+    Attributes:
+        global_crop_size:
+            Crop size of the global views.
+        global_crop_scale:
+            Tuple of min and max scales relative to global_crop_size.
+        local_crop_size:
+            Crop size of the local views.
+        local_crop_scale:
+            Tuple of min and max scales relative to local_crop_size.
+        n_local_views:
+            Number of generated local views.
+        hf_prob:
+            Probability that horizontal flip is applied.
+        cj_prob:
+            Probability that color jitter is applied.
+        cj_strength:
+            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
+            `cj_hue` are multiplied by this value.
+        cj_bright:
+            How much to jitter brightness.
+        cj_contrast:
+            How much to jitter constrast.
+        cj_sat:
+            How much to jitter saturation.
+        cj_hue:
+            How much to jitter hue.
+        random_gray_scale:
+            Probability of conversion to grayscale.
+        gaussian_blur:
+            Tuple of probabilities to apply gaussian blur on the different
+            views. The input is ordered as follows:
+            (global_view_0, global_view_1, local_views)
+        kernel_size:
+            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
+            Used to calculate sigma of gaussian blur with kernel_size * input_size.
+        kernel_scale:
+            Old argument. Value is deprecated in favor of sigmas. If set, the old behavior applies and `sigmas` is ignored.
+            Used to scale the `kernel_size` of a factor of `kernel_scale`
+        sigmas:
+            Tuple of min and max value from which the std of the gaussian kernel is sampled.
+            Is ignored if `kernel_size` is set.
+        solarization:
+            Probability to apply solarization on the second global view.
+        normalize:
+            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
+
+    """
+
+    def __init__(
+        self,
+        global_crop_size: int = 224,
+        global_crop_scale: Tuple[float, float] = (0.25, 1.0),
+        local_crop_size: int = 96,
+        local_crop_scale: Tuple[float, float] = (0.05, 0.25),
+        n_local_views: int = 10,
+        hf_prob: float = 0.5,
+        cj_prob: float = 0.8,
+        cj_strength: float = 0.5,
+        cj_bright: float = 0.8,
+        cj_contrast: float = 0.8,
+        cj_sat: float = 0.4,
+        cj_hue: float = 0.2,
+        random_gray_scale: float = 0.2,
+        gaussian_blur: Tuple[float, float, float] = (1.0, 0.1, 0.5),
+        kernel_size: Optional[float] = None,
+        kernel_scale: Optional[float] = None,
+        sigmas: Tuple[float, float] = (0.1, 2),
+        solarization_prob: float = 0.2,
+        normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
+    ):
+        # first global crop
+        global_transform_0 = IBOTViewTransform(
+            crop_size=global_crop_size,
+            crop_scale=global_crop_scale,
+            hf_prob=hf_prob,
+            cj_prob=cj_prob,
+            cj_strength=cj_strength,
+            cj_bright=cj_bright,
+            cj_contrast=cj_contrast,
+            cj_hue=cj_hue,
+            cj_sat=cj_sat,
+            random_gray_scale=random_gray_scale,
+            gaussian_blur=gaussian_blur[0],
+            kernel_size=kernel_size,
+            kernel_scale=kernel_scale,
+            sigmas=sigmas,
+            solarization_prob=0,
+            normalize=normalize,
+        )
+
+        # second global crop
+        global_transform_1 = IBOTViewTransform(
+            crop_size=global_crop_size,
+            crop_scale=global_crop_scale,
+            hf_prob=hf_prob,
+            cj_prob=cj_prob,
+            cj_bright=cj_bright,
+            cj_contrast=cj_contrast,
+            cj_hue=cj_hue,
+            cj_sat=cj_sat,
+            random_gray_scale=random_gray_scale,
+            gaussian_blur=gaussian_blur[1],
+            kernel_size=kernel_size,
+            kernel_scale=kernel_scale,
+            sigmas=sigmas,
+            solarization_prob=solarization_prob,
+            normalize=normalize,
+        )
+
+        # transformation for the local small crops
+        local_transform = IBOTViewTransform(
+            crop_size=local_crop_size,
+            crop_scale=local_crop_scale,
+            hf_prob=hf_prob,
+            cj_prob=cj_prob,
+            cj_strength=cj_strength,
+            cj_bright=cj_bright,
+            cj_contrast=cj_contrast,
+            cj_hue=cj_hue,
+            cj_sat=cj_sat,
+            random_gray_scale=random_gray_scale,
+            gaussian_blur=gaussian_blur[2],
+            kernel_size=kernel_size,
+            kernel_scale=kernel_scale,
+            sigmas=sigmas,
+            solarization_prob=0,
+            normalize=normalize,
+        )
+        local_transforms = [local_transform] * n_local_views
+        transforms = [global_transform_0, global_transform_1]
+        transforms.extend(local_transforms)
+        super().__init__(transforms)
+
+
+class IBOTViewTransform:
+    def __init__(
+        self,
+        crop_size: int = 224,
+        crop_scale: Tuple[float, float] = (0.4, 1.0),
+        hf_prob: float = 0.5,
+        cj_prob: float = 0.8,
+        cj_strength: float = 0.5,
+        cj_bright: float = 0.8,
+        cj_contrast: float = 0.8,
+        cj_sat: float = 0.4,
+        cj_hue: float = 0.2,
+        random_gray_scale: float = 0.2,
+        gaussian_blur: float = 1.0,
+        kernel_size: Optional[float] = None,
+        kernel_scale: Optional[float] = None,
+        sigmas: Tuple[float, float] = (0.1, 2),
+        solarization_prob: float = 0.2,
+        normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
+    ):
+        transform = [
+            T.RandomResizedCrop(
+                size=crop_size,
+                scale=crop_scale,
+                # Type ignore needed because BICUBIC is not recognized as an attribute.
+                interpolation=PIL.Image.BICUBIC,  # type: ignore[attr-defined]
+            ),
+            T.RandomHorizontalFlip(p=hf_prob),
+            T.RandomApply(
+                [
+                    T.ColorJitter(
+                        brightness=cj_strength * cj_bright,
+                        contrast=cj_strength * cj_contrast,
+                        saturation=cj_strength * cj_sat,
+                        hue=cj_strength * cj_hue,
+                    )
+                ],
+                p=cj_prob,
+            ),
+            T.RandomGrayscale(p=random_gray_scale),
+            GaussianBlur(
+                kernel_size=kernel_size,
+                scale=kernel_scale,
+                sigmas=sigmas,
+                prob=gaussian_blur,
+            ),
+            RandomSolarization(prob=solarization_prob),
+            T.ToTensor(),
+        ]
+
+        if normalize:
+            transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]
+        self.transform = T.Compose(transform)
+
+    def __call__(self, image: Union[Tensor, Image]) -> Tensor:
+        """
+        Applies the transforms to the input image.
+
+        Args:
+            image:
+                The input image to apply the transforms to.
+
+        Returns:
+            The transformed image.
+
+        """
+        transformed: Tensor = self.transform(image)
+        return transformed

--- a/tests/transforms/test_ibot_transform.py
+++ b/tests/transforms/test_ibot_transform.py
@@ -1,0 +1,23 @@
+from PIL import Image
+
+from lightly.transforms.ibot_transform import IBOTTransform, IBOTViewTransform
+
+from .. import helpers
+
+
+def test_view_on_pil_image() -> None:
+    single_view_transform = IBOTViewTransform(crop_size=32)
+    sample = Image.new("RGB", (100, 100))
+    output = single_view_transform(sample)
+    assert output.shape == (3, 32, 32)
+
+
+def test_multi_view_on_pil_image() -> None:
+    multi_view_transform = IBOTTransform(global_crop_size=32, local_crop_size=8)
+    sample = Image.new("RGB", (100, 100))
+    output = helpers.assert_list_tensor(multi_view_transform(sample))
+    assert len(output) == 12
+    # global views
+    assert all(out.shape == (3, 32, 32) for out in output[:2])
+    # local views
+    assert all(out.shape == (3, 8, 8) for out in output[2:])


### PR DESCRIPTION
This is the first part of the implementation of iBOT.

The HPs are referenced from https://github.com/bytedance/ibot/tree/main?tab=readme-ov-file#ibot-pre-training-with-vits for future benchmark reproduction

The transforms are very similar to the ones used in DINO, except that:

- default of `n_local_views` is 10
- `global_crops_scale` is `(0.25, 1)`
- `local_crops_scale` is `(0.05, 0.25)`

and there are no

- `VerticalFlip`, and
- `RandomRotation`

There are also corresponding tests.