### PR TITLE
Use ToTensor helper function

### DIFF
--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -15,6 +15,7 @@ import torchvision.transforms as T
 from PIL import Image
 
 from lightly.transforms import GaussianBlur, Jigsaw, RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropAndFlip
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.utils import IMAGENET_NORMALIZE
@@ -177,7 +178,7 @@ class ImageCollateFunction(BaseCollateFunction):
             T.RandomApply([color_jitter], p=cj_prob),
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize:
@@ -550,7 +551,7 @@ class SwaVCollateFunction(MultiCropCollateFunction):
                 GaussianBlur(
                     kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur
                 ),
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )
@@ -673,7 +674,7 @@ class DINOCollateFunction(MultiViewCollateFunction):
         )
         normalize = T.Compose(
             [
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )
@@ -763,7 +764,7 @@ class MAECollateFunction(MultiViewCollateFunction):
                 input_size, scale=(min_scale, 1.0), interpolation=3
             ),  # 3 is bicubic
             T.RandomHorizontalFlip(),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize:
@@ -847,7 +848,7 @@ class PIRLCollateFunction(nn.Module):
             T.RandomHorizontalFlip(p=hf_prob),
             T.RandomApply([color_jitter], p=cj_prob),
             T.RandomGrayscale(p=random_gray_scale),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize:
@@ -857,7 +858,7 @@ class PIRLCollateFunction(nn.Module):
         self.no_augment = T.Compose(
             [
                 T.RandomResizedCrop(size=input_size, scale=(min_scale, 1.0)),
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )
@@ -968,7 +969,7 @@ class MSNCollateFunction(MultiViewCollateFunction):
                 GaussianBlur(
                     kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur
                 ),
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )
@@ -982,7 +983,7 @@ class MSNCollateFunction(MultiViewCollateFunction):
                 GaussianBlur(
                     kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur
                 ),
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )
@@ -1067,7 +1068,7 @@ class SMoGCollateFunction(MultiViewCollateFunction):
                                 sigmas=gaussian_blur_sigmas,
                             ),  # TODO
                             RandomSolarization(prob=solarize_probs[i]),
-                            T.ToTensor(),
+                            ToTensor(),
                             T.Normalize(mean=normalize["mean"], std=normalize["std"]),
                         ]
                     )
@@ -1167,7 +1168,7 @@ class VICRegCollateFunction(BaseCollateFunction):
             T.RandomGrayscale(p=random_gray_scale),
             RandomSolarization(prob=solarize_prob),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize:
@@ -1281,7 +1282,7 @@ class VICRegLCollateFunction(nn.Module):
                     sigmas=global_gaussian_blur_sigmas,
                 ),
                 RandomSolarization(prob=global_solarize_prob),
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )
@@ -1296,7 +1297,7 @@ class VICRegLCollateFunction(nn.Module):
                     sigmas=local_gaussian_blur_sigmas,
                 ),
                 RandomSolarization(prob=local_solarize_prob),
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -14,10 +14,10 @@ import torchvision
 from PIL import Image
 
 from lightly.transforms import GaussianBlur, Jigsaw, RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
-from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropAndFlip
 from lightly.transforms.rotation import random_rotation_transform
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 imagenet_normalize = IMAGENET_NORMALIZE

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -11,10 +11,10 @@ from warnings import warn
 import torch
 import torch.nn as nn
 import torchvision
-import torchvision.transforms as T
 from PIL import Image
 
 from lightly.transforms import GaussianBlur, Jigsaw, RandomSolarization
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropAndFlip
 from lightly.transforms.rotation import random_rotation_transform

--- a/lightly/transforms/byol_transform.py
+++ b/lightly/transforms/byol_transform.py
@@ -7,8 +7,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/byol_transform.py
+++ b/lightly/transforms/byol_transform.py
@@ -7,7 +7,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/byol_transform.py
+++ b/lightly/transforms/byol_transform.py
@@ -7,7 +7,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -49,7 +49,7 @@ class BYOLView1Transform:
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
             RandomSolarization(prob=solarization_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]
@@ -109,7 +109,7 @@ class BYOLView2Transform:
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
             RandomSolarization(prob=solarization_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/detcon_transform.py
+++ b/lightly/transforms/detcon_transform.py
@@ -2,8 +2,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from lightly.transforms.add_grid_transform import AddGridTransform
 from lightly.transforms.multi_view_transform_v2 import MultiViewTransformV2
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/detcon_transform.py
+++ b/lightly/transforms/detcon_transform.py
@@ -2,7 +2,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from lightly.transforms.add_grid_transform import AddGridTransform
 from lightly.transforms.multi_view_transform_v2 import MultiViewTransformV2
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/detcon_transform.py
+++ b/lightly/transforms/detcon_transform.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from lightly.transforms.add_grid_transform import AddGridTransform
 from lightly.transforms.multi_view_transform_v2 import MultiViewTransformV2
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -202,7 +202,7 @@ class DetConSViewTransform:
             T.RandomApply(
                 [T.GaussianBlur(kernel_size=kernel_size, sigma=sigmas)], p=gaussian_blur
             ),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -8,7 +8,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -8,7 +8,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -244,7 +244,7 @@ class DINOViewTransform:
                 prob=gaussian_blur,
             ),
             RandomSolarization(prob=solarization_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize:

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -8,8 +8,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/fda_transform.py
+++ b/lightly/transforms/fda_transform.py
@@ -15,8 +15,8 @@ from lightly.transforms.random_frequency_mask_transform import (
 from lightly.transforms.rfft2d_transform import RFFT2DTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/fda_transform.py
+++ b/lightly/transforms/fda_transform.py
@@ -15,7 +15,7 @@ from lightly.transforms.random_frequency_mask_transform import (
 from lightly.transforms.rfft2d_transform import RFFT2DTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -68,7 +68,7 @@ class FDAView1Transform:
 
         transform = [
             T.RandomResizedCrop(size=input_size, scale=(min_scale, 1.0)),
-            T.ToTensor(),
+            ToTensor(),
             RFFT2DTransform(),
             T.RandomApply(
                 [AmplitudeRescaleTransform(range=ampl_rescale_range)],
@@ -98,7 +98,7 @@ class FDAView1Transform:
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
             RandomSolarization(prob=solarization_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]
@@ -169,7 +169,7 @@ class FDAView2Transform:
 
         transform = [
             T.RandomResizedCrop(size=input_size, scale=(min_scale, 1.0)),
-            T.ToTensor(),
+            ToTensor(),
             RFFT2DTransform(),
             T.RandomApply(
                 [AmplitudeRescaleTransform(range=ampl_rescale_range)],
@@ -199,7 +199,7 @@ class FDAView2Transform:
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
             RandomSolarization(prob=solarization_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/fda_transform.py
+++ b/lightly/transforms/fda_transform.py
@@ -15,7 +15,8 @@ from lightly.transforms.random_frequency_mask_transform import (
 from lightly.transforms.rfft2d_transform import RFFT2DTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/ibot_transform.py
+++ b/lightly/transforms/ibot_transform.py
@@ -7,8 +7,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/ibot_transform.py
+++ b/lightly/transforms/ibot_transform.py
@@ -7,7 +7,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/ibot_transform.py
+++ b/lightly/transforms/ibot_transform.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -216,7 +216,7 @@ class IBOTViewTransform:
                 prob=gaussian_blur,
             ),
             RandomSolarization(prob=solarization_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize:

--- a/lightly/transforms/ijepa_transform.py
+++ b/lightly/transforms/ijepa_transform.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Tuple, Union
 from PIL.Image import Image
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/ijepa_transform.py
+++ b/lightly/transforms/ijepa_transform.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple, Union
 from PIL.Image import Image
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -37,7 +37,7 @@ class IJEPATransform:
                 input_size, scale=(min_scale, 1.0), interpolation=3
             ),  # 3 is bicubic
             T.RandomHorizontalFlip(),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transforms.append(T.Normalize(mean=normalize["mean"], std=normalize["std"]))

--- a/lightly/transforms/ijepa_transform.py
+++ b/lightly/transforms/ijepa_transform.py
@@ -3,7 +3,8 @@ from typing import Dict, List, Tuple, Union
 from PIL.Image import Image
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -9,8 +9,8 @@ from PIL import Image as Image
 from PIL.Image import Image as PILImage
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -9,7 +9,8 @@ from PIL import Image as Image
 from PIL.Image import Image as PILImage
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -9,7 +9,7 @@ from PIL import Image as Image
 from PIL.Image import Image as PILImage
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -46,7 +46,7 @@ class Jigsaw(object):
         n_grid: int = 3,
         img_size: int = 255,
         crop_size: int = 64,
-        transform: T.Compose = T.ToTensor(),
+        transform: T.Compose = ToTensor(),
     ):
         self.n_grid = n_grid
         self.img_size = img_size

--- a/lightly/transforms/mae_transform.py
+++ b/lightly/transforms/mae_transform.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple, Union
 from PIL.Image import Image
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -43,7 +43,7 @@ class MAETransform:
                 input_size, scale=(min_scale, 1.0), interpolation=3
             ),  # 3 is bicubic
             T.RandomHorizontalFlip(),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transforms.append(T.Normalize(mean=normalize["mean"], std=normalize["std"]))

--- a/lightly/transforms/mae_transform.py
+++ b/lightly/transforms/mae_transform.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Tuple, Union
 from PIL.Image import Image
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/mae_transform.py
+++ b/lightly/transforms/mae_transform.py
@@ -3,7 +3,8 @@ from typing import Dict, List, Tuple, Union
 from PIL.Image import Image
 from torch import Tensor
 
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/msn_transform.py
+++ b/lightly/transforms/msn_transform.py
@@ -5,7 +5,7 @@ from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -165,7 +165,7 @@ class MSNViewTransform:
             T.RandomApply([color_jitter], p=cj_prob),
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
-            T.ToTensor(),
+            ToTensor(),
             T.Normalize(mean=normalize["mean"], std=normalize["std"]),
         ]
 

--- a/lightly/transforms/msn_transform.py
+++ b/lightly/transforms/msn_transform.py
@@ -5,8 +5,8 @@ from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/msn_transform.py
+++ b/lightly/transforms/msn_transform.py
@@ -5,7 +5,8 @@ from torch import Tensor
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/pirl_transform.py
+++ b/lightly/transforms/pirl_transform.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Tuple, Union
 from lightly.transforms.jigsaw import Jigsaw
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -78,7 +78,7 @@ class PIRLTransform(MultiViewTransform):
         # Cropping and normalisation for non-transformed image
         transforms_no_augment = [
             T.RandomResizedCrop(size=input_size, scale=(min_scale, 1.0)),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize is not None:
@@ -100,7 +100,7 @@ class PIRLTransform(MultiViewTransform):
             T.RandomHorizontalFlip(p=hf_prob),
             T.RandomApply([color_jitter], p=cj_prob),
             T.RandomGrayscale(p=random_gray_scale),
-            T.ToTensor(),
+            ToTensor(),
         ]
 
         if normalize is not None:

--- a/lightly/transforms/pirl_transform.py
+++ b/lightly/transforms/pirl_transform.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Tuple, Union
 from lightly.transforms.jigsaw import Jigsaw
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/pirl_transform.py
+++ b/lightly/transforms/pirl_transform.py
@@ -3,7 +3,8 @@ from typing import Dict, List, Tuple, Union
 from lightly.transforms.jigsaw import Jigsaw
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -162,7 +162,7 @@ class SimCLRViewTransform:
             T.RandomApply([color_jitter], p=cj_prob),
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -6,7 +6,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -6,8 +6,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/simsiam_transform.py
+++ b/lightly/transforms/simsiam_transform.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -151,7 +151,7 @@ class SimSiamViewTransform:
             T.RandomApply([color_jitter], p=cj_prob),
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/simsiam_transform.py
+++ b/lightly/transforms/simsiam_transform.py
@@ -6,7 +6,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/simsiam_transform.py
+++ b/lightly/transforms/simsiam_transform.py
@@ -6,8 +6,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/smog_transform.py
+++ b/lightly/transforms/smog_transform.py
@@ -157,7 +157,7 @@ class SmoGViewTransform:
                 sigmas=sigmas,
             ),
             RandomSolarization(prob=solarize_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/smog_transform.py
+++ b/lightly/transforms/smog_transform.py
@@ -6,8 +6,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/smog_transform.py
+++ b/lightly/transforms/smog_transform.py
@@ -7,6 +7,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.solarize import RandomSolarization
 from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/swav_transform.py
+++ b/lightly/transforms/swav_transform.py
@@ -6,8 +6,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_crop_transform import MultiCropTranform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/swav_transform.py
+++ b/lightly/transforms/swav_transform.py
@@ -6,7 +6,8 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_crop_transform import MultiCropTranform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/swav_transform.py
+++ b/lightly/transforms/swav_transform.py
@@ -6,7 +6,7 @@ from torch import Tensor
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_crop_transform import MultiCropTranform
 from lightly.transforms.rotation import random_rotation_transform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -159,7 +159,7 @@ class SwaVViewTransform:
             T.RandomApply([color_jitter], p=cj_prob),
             T.RandomGrayscale(p=random_gray_scale),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transforms += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/vicreg_transform.py
+++ b/lightly/transforms/vicreg_transform.py
@@ -7,8 +7,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/vicreg_transform.py
+++ b/lightly/transforms/vicreg_transform.py
@@ -7,7 +7,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -160,7 +160,7 @@ class VICRegViewTransform:
             T.RandomGrayscale(p=random_gray_scale),
             RandomSolarization(prob=solarize_prob),
             GaussianBlur(kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transform += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/vicreg_transform.py
+++ b/lightly/transforms/vicreg_transform.py
@@ -7,7 +7,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -7,8 +7,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.image_grid_transform import ImageGridTransform
 from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropAndFlip
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -7,7 +7,7 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.image_grid_transform import ImageGridTransform
 from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropAndFlip
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -207,7 +207,7 @@ class VICRegLViewTransform:
                 sigmas=gaussian_blur_sigmas,
             ),
             RandomSolarization(prob=solarize_prob),
-            T.ToTensor(),
+            ToTensor(),
         ]
         if normalize:
             transforms += [T.Normalize(mean=normalize["mean"], std=normalize["std"])]

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -7,7 +7,8 @@ from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.image_grid_transform import ImageGridTransform
 from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropAndFlip
 from lightly.transforms.solarize import RandomSolarization
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/wmse_transform.py
+++ b/lightly/transforms/wmse_transform.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Tuple
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
@@ -98,7 +98,7 @@ class WMSETransform(MultiViewTransform):
                 GaussianBlur(
                     kernel_size=kernel_size, sigmas=sigmas, prob=gaussian_blur
                 ),
-                T.ToTensor(),
+                ToTensor(),
                 T.Normalize(mean=normalize["mean"], std=normalize["std"]),
             ]
         )

--- a/lightly/transforms/wmse_transform.py
+++ b/lightly/transforms/wmse_transform.py
@@ -2,7 +2,8 @@ from typing import Dict, List, Optional, Tuple
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T, ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/transforms/wmse_transform.py
+++ b/lightly/transforms/wmse_transform.py
@@ -2,8 +2,8 @@ from typing import Dict, List, Optional, Tuple
 
 from lightly.transforms.gaussian_blur import GaussianBlur
 from lightly.transforms.multi_view_transform import MultiViewTransform
-from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.torchvision_v2_compatibility import ToTensor
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 

--- a/lightly/utils/debug.py
+++ b/lightly/utils/debug.py
@@ -5,6 +5,7 @@ import torchvision
 from PIL import Image
 
 from lightly.data.collate import BaseCollateFunction, MultiViewCollateFunction
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 
 try:
     import matplotlib.pyplot as plt
@@ -63,7 +64,7 @@ def apply_transform_without_normalize(
         The transformed image.
     """
     skippable_transforms = (
-        torchvision.transforms.ToTensor,
+        type(ToTensor()),
         torchvision.transforms.Normalize,
     )
     if isinstance(transform, torchvision.transforms.Compose):

--- a/tests/data/test_data_collate.py
+++ b/tests/data/test_data_collate.py
@@ -12,7 +12,6 @@ from lightly.data import (
     PIRLCollateFunction,
     SimCLRCollateFunction,
     SwaVCollateFunction,
-    collate,
 )
 from lightly.data.collate import (
     DINOCollateFunction,
@@ -22,7 +21,7 @@ from lightly.data.collate import (
     VICRegCollateFunction,
     VICRegLCollateFunction,
 )
-from lightly.transforms import RandomRotate
+from lightly.transforms.torchvision_v2_compatibility import ToTensor
 
 
 class TestDataCollate(unittest.TestCase):
@@ -115,7 +114,7 @@ class TestDataCollate(unittest.TestCase):
                         crop_counts=[high, low],
                         crop_min_scales=[0.14, 0.04],
                         crop_max_scales=[1.0, 0.14],
-                        transforms=torchvision.transforms.ToTensor(),
+                        transforms=ToTensor(),
                     )
                     samples, labels, fnames = multi_crop_collate(batch)
                     self.assertIsNotNone(multi_crop_collate)

--- a/tests/data/test_data_collate.py
+++ b/tests/data/test_data_collate.py
@@ -41,7 +41,7 @@ class TestDataCollate(unittest.TestCase):
 
     def test_base_collate(self):
         batch = self.create_batch()
-        transform = transforms.ToTensor()
+        transform = ToTensor()
         collate = BaseCollateFunction(transform)
         samples, labels, fnames = collate(batch)
         samples0, samples1 = samples
@@ -139,7 +139,7 @@ class TestDataCollate(unittest.TestCase):
             )
 
     def test_multi_view_collate(self):
-        to_tensor = transforms.ToTensor()
+        to_tensor = ToTensor()
         hflip = transforms.Compose(
             [
                 transforms.RandomHorizontalFlip(p=1),


### PR DESCRIPTION
This PR implements the use of `lightly.transforms.torchvision_v2_compatibility.ToTensor` in place of torchvision `ToTensor`

`torchvision.transforms.v2.ToTensor` [is deprected](https://docs.pytorch.org/vision/0.20/generated/torchvision.transforms.v2.ToTensor.html?highlight=totensor#torchvision.transforms.v2.ToTensor). The `lightly.transforms.torchvision_v2_compatibility.ToTensor` function was added in #1718 to address this, but the function was never used anywhere. 

The `transform` argument in the `Jigsaw` class currently uses the torchvision v2 `ToTensor`, which means any time that class gets interpreted, such as when you import `LightlyDataset`, a warning is emitted. 

I'm not sure why the helper function was never used anywhere, but it would be nice if, at the very least, the `Jigsaw` default was addressed in future releases. 