### PR TITLE
Improve pre-commit hooks for dev env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,44 +5,9 @@ repos:
   - id: detect-private-key      # check for private keys
   - id: check-added-large-files # prevent commit of files >500kB
     args: ['--maxkb=500']
-- repo: https://github.com/psf/black
-  rev: 24.8.0  # aligned with the version defined in pyproject.toml
-  hooks:
-  - id: black
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2  # aligned with the version defined in pyproject.toml
-  hooks:
-  - id: isort
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.1  # aligned with the version defined in pyproject.toml
-  hooks:
-  - id: mypy
-    additional_dependencies:
-      - 'numpy'
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.8.7
   hooks:
     - id: nbqa-black
     - id: nbqa-isort
       args: ["--profile=black"]
-- repo: local
-  hooks:
-  - id: pytest-check                     # run all tests
-    name: pytest-check
-    entry: make test-fast
-    language: system
-    pass_filenames: false
-    stages: [push]
-    # Avoid running tests if non-tested files have changed.
-    # The regex follows the pattern in the docs: https://pre-commit.com/#regular-expressions
-    exclude: |
-      (?x)^(
-          benchmark_logs/.*|
-          docs/.*|
-          examples/.*|
-          \.gitignore|
-          CONTRIBUTING\.md|
-          LICENSE\.txt|
-          README\.md
-          PRECOMMITHOOKS\.md|
-      )$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,8 @@ Follow these steps to start contributing:
 4. Set up a development environment by running the following command in a virtual environment:
 
    ```bash
-   pip install -e ".[dev]"
+   pip install -e . --all-extras --requirement pyproject.toml
+   pre-commit install
    ```
 
    If you are using [uv](https://github.com/astral-sh/uv) instead of pip, you can use
@@ -94,34 +95,7 @@ Follow these steps to start contributing:
    make install-dev
    ```
 
-5. **(Optional)** Install pre-commit hooks:
-
-   ```bash
-   pip install pre-commit
-   pre-commit install
-   ```
-
-   We use pre-commit hooks to identify simple issues before submission to code review. In particular, our hooks currently check for:
-   * Private keys in the commit
-   * Large files in the commit (>500kB)
-   * Run formatting checks using `black`, `isort` and `mypy`.
-   * Units which don't pass their unit tests (on push only)
-
-   You can verify that the hooks were installed correctly with
-   ```
-   pre-commit run --all-files
-   ```
-   The output should look like this:
-   ```
-   pre-commit run --all-files
-   Detect Private Key................................Passed
-   Check for added large files.......................Passed
-   black.............................................Passed
-   isort.............................................Passed
-   mypy..............................................Passed
-   ```
-
-6. Develop the features on your branch.
+5. Develop the features on your branch.
 
    As you work on the features, you should make sure that the code is formatted and the
    test suite passes:

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ EXCLUDE_NEWER_DATE="2024-08-07"
 .PHONY: install-dev
 install-dev:
 	uv pip install ${EDITABLE} . --all-extras --requirement pyproject.toml
+	pre-commit install
 
 
 # Install package with API dependencies only.


### PR DESCRIPTION
The contributing guide for setting up the dev env re. the pre-commit hooks is confusing. Also, the hook overlap with the Makefile checks and the scope of the mypy check in the hook is not correct.

This PR propose an improvement in the dev env set up. Such that:

- Pre-commit hooks is always installed
- The hooks only contains large file check and necessary tools for Jupyter notebooks. Formatting, checks, and tests should always be done with `make format && make all-checks`
- Make instructions in the contributing guide clearer.