### PR TITLE
Fix the banner and tab name of LightlySSL Docs

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -15,7 +15,7 @@
     .wy-nav-content{
       position: relative;
     }
-    .lighlty-worker-banner{
+    .lightly-train-banner{
       background: #092643;
       height: 40px;
       width: 100%;
@@ -28,15 +28,15 @@
       align-items: center;
       z-index: 9999;
     }
-    .lighlty-worker-banner a{
+    .lightly-train-banner a{
       color: #2CC2BD;
     }
     .rst-content{
       margin-top: 40px;
     }
   </style>
-  <div class="lighlty-worker-banner">
-    <span>Looking to easily do active learning on millions of samples? See our <a href="http://docs.lightly.ai" target="_blank">Lighly<b>One</b> Worker</a> docs.</span>
+  <div class="lightly-train-banner">
+    <span>Interested in training your own vision foundation model? Check out <a href="https://docs.lightly.ai/train/stable/index.html" target="_blank"><b>LightlyTrain</b> </a>!</span>
   </div>
   {% if theme_style_external_links|tobool %}
   <div class="rst-content style-external-links">

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,7 @@ import lightly
 
 # -- Project information -----------------------------------------------------
 
-project = "lightly"
+project = "LightlySSL"
 copyright_year = "2020-<script>document.write((new Date()).getFullYear())</script>"
 copyright = "Lightly AG"
 website_url = "https://www.lightly.ai/"

--- a/docs/source/getting_started/command_line_tool.rst
+++ b/docs/source/getting_started/command_line_tool.rst
@@ -158,7 +158,7 @@ Once you have a trained model checkpoint, you can create an embedding of a datas
 
 .. code-block:: bash
 
-    # use pre-trained models provided by Lighly
+    # use pre-trained models provided by Lightly
     lightly-embed input_dir=cat
 
     # use custom checkpoint


### PR DESCRIPTION
Fix the banner and tab name of LightlySSL Docs

Preview: 
[Documentation — LightlySSL 1.5.22 documentation.pdf](https://github.com/user-attachments/files/21411558/Documentation.LightlySSL.1.5.22.documentation.pdf)
