### PR TITLE
Add DirectCLR (#781)

### DIFF
--- a/examples/pytorch/directclr.py
+++ b/examples/pytorch/directclr.py
@@ -1,0 +1,56 @@
+# This example requires the following dependencies to be installed:
+# pip install lightly
+
+# Note: The model and training settings do not follow the reference settings
+# from the paper. The settings are chosen such that the example can easily be
+# run on a small dataset with a single GPU.
+
+import torch
+import torchvision
+from torch import nn
+
+from lightly.loss import NTXentLoss
+from lightly.models import DirectCLR
+from lightly.transforms.simclr_transform import SimCLRTransform
+
+resnet = torchvision.models.resnet18()
+backbone = nn.Sequential(*list(resnet.children())[:-1])
+model = DirectCLR(backbone)
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+model.to(device)
+
+transform = SimCLRTransform(input_size=32, gaussian_blur=0.0)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
+
+dataloader = torch.utils.data.DataLoader(
+    dataset,
+    batch_size=256,
+    shuffle=True,
+    drop_last=True,
+    num_workers=8,
+)
+
+criterion = NTXentLoss()
+optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
+
+print("Starting Training")
+for epoch in range(10):
+    total_loss = 0
+    for batch in dataloader:
+        x0, x1 = batch[0]
+        x0 = x0.to(device)
+        x1 = x1.to(device)
+        z0 = model(x0)
+        z1 = model(x1)
+        loss = criterion(z0, z1)
+        total_loss += loss.detach()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+    avg_loss = total_loss / len(dataloader)
+    print(f"epoch: {epoch:>02}, loss: {avg_loss:.5f}")

--- a/lightly/models/__init__.py
+++ b/lightly/models/__init__.py
@@ -21,6 +21,7 @@ checkpoints.
 from lightly.models import utils
 from lightly.models.barlowtwins import BarlowTwins
 from lightly.models.byol import BYOL
+from lightly.models.directclr import DirectCLR
 from lightly.models.moco import MoCo
 from lightly.models.nnclr import NNCLR
 from lightly.models.resnet import ResNetGenerator

--- a/lightly/models/directclr.py
+++ b/lightly/models/directclr.py
@@ -1,0 +1,106 @@
+""" DirectCLR Model """
+
+# Copyright (c) 2025. Lightly AG and its affiliates.
+# All Rights Reserved
+
+import warnings
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+
+class DirectCLR(nn.Module):
+    """Implementation of the DirectCLR architecture
+
+    Recommended loss: :py:class:`lightly.loss.ntx_ent_loss.NTXentLoss`
+
+    [0] DirectCLR, 2021, https://arxiv.org/abs/2110.09348
+
+    Attributes:
+        backbone:
+            Backbone model to extract features from images.
+        dim:
+            Length of the subvector of the feature vector on which to apply the loss.
+
+    """
+
+    def __init__(self, backbone: nn.Module, dim: int = 32) -> None:
+        super(DirectCLR, self).__init__()
+
+        self.backbone = backbone
+        self.dim = dim
+
+        warnings.warn(
+            Warning(
+                "The high-level building block DirectCLR will be deprecated in version 1.3.0. "
+                + "Use low-level building blocks instead. "
+                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+            ),
+            DeprecationWarning,
+        )
+
+    def forward(
+        self, x0: Tensor, x1: Optional[Tensor] = None, return_features: bool = False
+    ) -> (
+        Tensor
+        | Tuple[Tensor, Tensor]
+        | Tuple[Tuple[Tensor, Tensor], Tuple[Tensor, Tensor]]
+    ):
+        """Embeds and projects the input images.
+
+        Extracts features with the backbone and takes the first self.dim
+        values as subvector of the output space. If both x0 and x1 are not None,
+        both will be passed through the backbone and sliced. If x1 is None, only
+        x0 will be forwarded.
+
+        Args:
+            x0:
+                Tensor of shape bsz x channels x W x H.
+            x1:
+                Tensor of shape bsz x channels x W x H.
+            return_features:
+                Whether or not to return the intermediate features backbone(x).
+
+        Returns:
+            The subvector output of the embedding of x0 and (if x1 is not None)
+            the subvector output of x1. If return_features is True, the output for
+            each x is a tuple (out, f) where f are the features before slicing.
+
+        Examples:
+            >>> # single input, single output
+            >>> out = model(x)
+            >>>
+            >>> # single input with return_features=True
+            >>> out, f = model(x, return_features=True)
+            >>>
+            >>> # two inputs, two outputs
+            >>> out0, out1 = model(x0, x1)
+            >>>
+            >>> # two inputs, two outputs with return_features=True
+            >>> (out0, f0), (out1, f1) = model(x0, x1, return_features=True)
+
+        """
+
+        # forward pass of first input x0
+        f0: Tensor = self.backbone(x0).flatten(start_dim=1)
+        out0: Tensor = f0[:, 0 : self.dim]
+
+        # return out0 if x1 is None
+        if x1 is None:
+            # return features if requested
+            if return_features:
+                return out0, f0
+            return out0
+
+        # forward pass of second input x1
+        f1: Tensor = self.backbone(x1).flatten(start_dim=1)
+        out1: Tensor = f1[:, 0 : self.dim]
+
+        # return features if requested
+        if return_features:
+            return (out0, f0), (out1, f1)
+
+        # return both outputs
+        return out0, out1

--- a/tests/models/test_ModelsDirectCLR.py
+++ b/tests/models/test_ModelsDirectCLR.py
@@ -1,0 +1,101 @@
+import unittest
+from typing import List
+
+import torch
+import torch.nn as nn
+
+import lightly
+from lightly.models import DirectCLR, ResNetGenerator
+
+
+def get_backbone(resnet: nn.Module, num_ftrs: int = 64) -> nn.Module:
+    # ignoring type checking as mypy infers this to be Tensor | Module
+    last_conv_channels: int = list(resnet.children())[-1].in_features  # type: ignore
+    backbone = nn.Sequential(
+        lightly.models.batchnorm.get_norm_layer(3, 0),
+        *list(resnet.children())[:-1],
+        nn.Conv2d(last_conv_channels, num_ftrs, 1),
+        nn.AdaptiveAvgPool2d(1),
+    )
+    return backbone
+
+
+class TestModelsDirectCLR(unittest.TestCase):
+    def setUp(self) -> None:
+        self.resnet_variants: List[str] = ["resnet-18", "resnet-50"]
+        self.batch_size: int = 2
+        self.input_tensor: torch.Tensor = torch.rand((self.batch_size, 3, 32, 32))
+
+    def test_create_variations_cpu(self) -> None:
+        for model_name in self.resnet_variants:
+            resnet = ResNetGenerator(model_name)
+            model = DirectCLR(get_backbone(resnet))
+            self.assertIsNotNone(model)
+
+    def test_create_variations_gpu(self) -> None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        if device == "cuda":
+            for model_name in self.resnet_variants:
+                resnet = ResNetGenerator(model_name)
+                model = DirectCLR(get_backbone(resnet)).to(device)
+                self.assertIsNotNone(model)
+        else:
+            pass
+
+    def test_feature_dim_configurable(self) -> None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        for model_name in self.resnet_variants:
+            for num_ftrs in [16, 64]:
+                resnet = ResNetGenerator(model_name)
+                model = DirectCLR(get_backbone(resnet, num_ftrs=num_ftrs)).to(device)
+
+                # check that feature vector has correct dimension
+                with torch.no_grad():
+                    out_features = model.backbone(self.input_tensor.to(device))
+                self.assertEqual(out_features.shape[1], num_ftrs)
+                self.assertIsNotNone(model)
+
+    def test_variations_input_dimension(self) -> None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        for model_name in self.resnet_variants:
+            for input_width, input_height in zip([32, 64], [64, 64]):
+                resnet = ResNetGenerator(model_name)
+                model = DirectCLR(get_backbone(resnet, num_ftrs=64)).to(device)
+
+                input_tensor = torch.rand(
+                    (self.batch_size, 3, input_height, input_width)
+                )
+                with torch.no_grad():
+                    out = model(input_tensor.to(device))
+
+                self.assertIsNotNone(model)
+                self.assertIsNotNone(out)
+
+    def test_tuple_input(self) -> None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        resnet = ResNetGenerator("resnet-18")
+        model = DirectCLR(get_backbone(resnet, num_ftrs=64), dim=32).to(device)
+
+        x0 = torch.rand((self.batch_size, 3, 64, 64)).to(device)
+        x1 = torch.rand((self.batch_size, 3, 64, 64)).to(device)
+
+        out = model(x0)
+        self.assertEqual(out.shape, (self.batch_size, 32))
+
+        out, features = model(x0, return_features=True)
+        self.assertEqual(out.shape, (self.batch_size, 32))
+        self.assertEqual(features.shape, (self.batch_size, 64))
+
+        out0, out1 = model(x0, x1)
+        self.assertEqual(out0.shape, (self.batch_size, 32))
+        self.assertEqual(out1.shape, (self.batch_size, 32))
+
+        (out0, f0), (out1, f1) = model(x0, x1, return_features=True)
+        self.assertEqual(out0.shape, (self.batch_size, 32))
+        self.assertEqual(out1.shape, (self.batch_size, 32))
+        self.assertEqual(f0.shape, (self.batch_size, 64))
+        self.assertEqual(f1.shape, (self.batch_size, 64))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue #781 proposes adding DirectCLR to Lightly. In PR #963 a loss was proposed but never merged.

As the paper uses a version of [infoNCE that is identical to NTX-ent](https://discordapp.com/channels/@me/1399964647523876874/1400461672883159160), we can use our existing implementation of NTX-ent instead. This way, implementing DirectCLR becomes a simple matter of taking the first _d_ values of the embedding and applying the NTX-ent loss to that instead (if my understanding is correct :smile:  ).

As DirectCLR does away with a projection head, I did not see an obvious way to implement it under low level module blocks. The proposed implementation is added as a deprecated model, but perhaps it does not even need to get its own model file and can just live as an example.

This PR:
- Adds DirectCLR as deprecated model
- Adds example for DirectCLR
- Adds test for DirectCLR

This PR _does not_:
- Add DirectCLR to lightly cli
- Implement benchmarks for DirectCLR

Let me know if you would prefer to see a variant outside of the deprecated high-level models. I could make a "dummy" projection head which just slices the embedding for example.