### PR TITLE
Fix #1902: `cosine_schedule` returns `np.float64` instead of `float`,...

### DIFF
--- a/lightly/utils/scheduler.py
+++ b/lightly/utils/scheduler.py
@@ -64,7 +64,7 @@ def cosine_schedule(
             * (np.cos(np.pi * step / (max_steps - 1)) + 1)
             / 2
         )
-    return decay
+    return float(decay)
 
 
 def cosine_warmup_schedule(

--- a/tests/utils/test_scheduler.py
+++ b/tests/utils/test_scheduler.py
@@ -76,6 +76,28 @@ def test_cosine_schedule__error(
         )
 
 
+@pytest.mark.parametrize(
+    "step, max_steps, period",
+    [
+        (1, 10, None),   # normal cosine branch (was returning np.float64)
+        (0, 10, 10),     # period branch (was returning np.float64)
+        (0, 1, None),    # max_steps <= 1 branch
+        (9, 10, None),   # step >= max_steps - 1 branch
+    ],
+)
+def test_cosine_schedule__returns_plain_float(
+    step: int, max_steps: int, period: Optional[int]
+) -> None:
+    result = scheduler.cosine_schedule(
+        step=step,
+        max_steps=max_steps,
+        start_value=1.0,
+        end_value=0.0,
+        period=period,
+    )
+    assert type(result) is float
+
+
 def test_cosine_schedule__warn_step_exceeds_max_steps() -> None:
     with pytest.warns(
         RuntimeWarning, match="Current step number 11 exceeds max_steps 10."


### PR DESCRIPTION
Closes #1902

`cosine_schedule` now returns a plain Python `float` instead of `np.float64`.

## Changes

- **`lightly/utils/scheduler.py`** — `cosine_schedule`: wrap the final `return decay` in `float(...)` (line 67). The cosine branch computed `decay` via NumPy arithmetic, producing `np.float64`; the else-branches already returned plain floats, creating an inconsistent return type.
- **`tests/utils/test_scheduler.py`** — `test_cosine_schedule__returns_plain_float`: new parametrized test asserting `type(result) is float` across all four code paths: the normal cosine branch, the `period`-based cosine branch, the `max_steps <= 1` early-exit, and the `step >= max_steps - 1` early-exit.

## Motivation

`cosine_schedule` returned `np.float64` whenever the cosine computation was reached (i.e., `step < max_steps - 1` with no early exit). When the returned decay value was stored in a PyTorch checkpoint and later loaded with `weights_only=True` (the default as of recent PyTorch versions), loading failed unless `numpy.float64` was explicitly added to safe globals via `torch.serialization.add_safe_globals([numpy.float64])`. The fix is a minimal one-character change — `float(decay)` — that strips the NumPy scalar wrapper before returning.

## Testing

The new `test_cosine_schedule__returns_plain_float` parametrized test covers all return paths and enforces `type(result) is float` (strict identity check, not `isinstance`, so `np.float64` would fail). All four parameter combinations exercise a distinct branch in `cosine_schedule`:

| `step` | `max_steps` | `period` | Branch hit |
|--------|-------------|----------|------------|
| 1 | 10 | `None` | Standard cosine (previously returned `np.float64`) |
| 0 | 10 | 10 | Period-based cosine (previously returned `np.float64`) |
| 0 | 1 | `None` | `max_steps <= 1` early return |
| 9 | 10 | `None` | `step >= max_steps - 1` early return |

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*