### PR TITLE
isort and black for python pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,14 @@ repos:
     - id: nbqa-black
     - id: nbqa-isort
       args: ["--profile=black"]
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+    - id: black
+      exclude: '^lightly/openapi_generated/'
+- repo: https://github.com/pycqa/isort
+  rev: 5.11.5
+  hooks:
+    - id: isort
+      args: [--profile=black]
+      exclude: '^lightly/openapi_generated/'


### PR DESCRIPTION
closes #1908

## Description

Included the necessary pre-commit hooks for running *isort* and *black* on python files.
