### PR TITLE
Add nbqa-ruff pre-commit hooks for notebook formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,12 @@ repos:
     - id: ruff-check
       args: [--fix, --select, I]
     - id: ruff-format
+- repo: https://github.com/nbqa-dev/nbqa
+  rev: 1.9.1
+  hooks:
+    - id: nbqa-ruff
+      args: [--fix, --select, I]
+      additional_dependencies: [ruff]
+    - id: nbqa-ruff-format
+      entry: nbqa ruff format
+      additional_dependencies: [ruff]


### PR DESCRIPTION
#1914 Removed notebook formatting from pre-commit

## Description

We migrated to ruff, but the notebook formatting on pre-commit was missing.

Notebook formatting was done in the pre-commit previously. I just restored this behavior to continue formatting notebooks via pre-commit.