### PR TITLE
[MNT-style]: Add ruff pydocstyle for Google-style docstrings

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Ruff formatting normalization (lightly-ai/lightly#1564)
 e7047dec9ef72f1d2d718e4915328021be661865
+
+# Ruff docstring normalization (lightly-ai/lightly#1217)
+926eadbaaed579b464303152792f02e763563279

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,5 +9,5 @@ repos:
   rev: v0.12.7
   hooks:
     - id: ruff-check
-      args: [--fix, --select, I]
+      args: [--fix]
     - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,7 @@ Important notes:
 - Make your functions checkable through static typecheckers (`mypy`). This means that it must have proper [type hints](https://docs.python.org/3/library/typing.html) everywhere. We use Python 3.10-style type-hints for Union-types, i.e. `str | Path` instead of `Union[str, Path]`. For backwards-compatibility, this requires that every module using such type-hints imports `from __future__ import annotations` at the very top of the module.
 - Don't overlook the `Raises`.
 - Use punctuation.
+- Docstrings follow the Google convention. The selected `pydocstyle` rules in `pyproject.toml` are checked by `ruff` and run as part of `make format-check` and `make lint`.
 - **Please look carefully at the examples provided below (from the styleguide)**.
 
 #### Packages and Modules

--- a/benchmarks/imagenet/resnet50/swav.py
+++ b/benchmarks/imagenet/resnet50/swav.py
@@ -180,7 +180,6 @@ def _update_queue(
     queues: ModuleList,
 ):
     """Adds the high resolution projections to the queues and returns the queues."""
-
     if len(projections) != len(queues):
         raise ValueError(
             f"The number of queues ({len(queues)}) should be equal to the number of high "

--- a/docs/source/getting_started/benchmarks/cifar10_benchmark.py
+++ b/docs/source/getting_started/benchmarks/cifar10_benchmark.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Benchmark Results
+"""Benchmark Results
 
 Updated: 27.03.2023 (42a6a924b1b6d5b6cc89a6b2a0a0942cc4af93ab)
 

--- a/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenet100_benchmark.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Benchmark Results
+"""Benchmark Results
 
 Updated: 13.02.2023
 

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Note that this benchmark also supports a multi-GPU setup. If you run it on
+"""Note that this benchmark also supports a multi-GPU setup. If you run it on
 a system with multiple GPUs make sure that you kill all the processes when
 killing the application. Due to the way we setup this benchmark the distributed
 processes might continue the benchmark if one of the nodes is killed.

--- a/docs/source/tutorials_source/package/tutorial_checkpoint_finetuning.py
+++ b/docs/source/tutorials_source/package/tutorial_checkpoint_finetuning.py
@@ -1,5 +1,4 @@
-"""
-.. _lightly-checkpoint-finetuning-tutorial-7:
+""".. _lightly-checkpoint-finetuning-tutorial-7:
 
 Tutorial 7: Finetuning Lightly Checkpoints
 ===========================================

--- a/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
+++ b/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
@@ -1,5 +1,4 @@
-"""
-.. _lightly-custom-augmentation-5:
+""".. _lightly-custom-augmentation-5:
 
 Tutorial 5: Custom Augmentations
 ==============================================
@@ -354,7 +353,6 @@ dataloader_test = torch.utils.data.DataLoader(
 # Next, we add a small helper function to generate embeddings of our images
 def generate_embeddings(model, dataloader):
     """Generates representations for all images in the dataloader"""
-
     embeddings = []
     filenames = []
     with torch.no_grad():

--- a/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
+++ b/docs/source/tutorials_source/package/tutorial_moco_memory_bank.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-
-.. _lightly-moco-tutorial-2:
+""".. _lightly-moco-tutorial-2:
 
 Tutorial 2: Train MoCo on CIFAR-10
 ==============================================

--- a/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
+++ b/docs/source/tutorials_source/package/tutorial_pretrain_detectron2.py
@@ -1,5 +1,4 @@
-"""
-.. _lightly-detectron-tutorial-6:
+""".. _lightly-detectron-tutorial-6:
 
 .. role:: bash(code)
    :language: bash

--- a/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
+++ b/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
@@ -1,5 +1,4 @@
-"""
-.. _lightly-simclr-tutorial-3:
+""".. _lightly-simclr-tutorial-3:
 
 Tutorial 3: Train SimCLR on Clothing
 ==============================================
@@ -189,7 +188,6 @@ def generate_embeddings(model, dataloader):
     """Generates representations for all images in the dataloader with
     the given model
     """
-
     embeddings = []
     filenames = []
     with torch.no_grad():

--- a/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
+++ b/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
@@ -1,5 +1,4 @@
-"""
-.. _lightly-simsiam-tutorial-4:
+""".. _lightly-simsiam-tutorial-4:
 
 Tutorial 4: Train SimSiam on Satellite Images
 ==============================================

--- a/docs/source/tutorials_source/package/tutorial_timm_backbone.py
+++ b/docs/source/tutorials_source/package/tutorial_timm_backbone.py
@@ -1,5 +1,4 @@
-"""
-.. _lightly-timm-backbone-tutorial-8:
+""".. _lightly-timm-backbone-tutorial-8:
 
 Tutorial 8: Using timm Models as Backbones
 ===========================================

--- a/docs/source/tutorials_source/platform/tutorial_label_studio_export.py
+++ b/docs/source/tutorials_source/platform/tutorial_label_studio_export.py
@@ -1,6 +1,4 @@
-"""
-
-.. _lightly-tutorial-export-labelstudio:
+""".. _lightly-tutorial-export-labelstudio:
 
 Tutorial 10: Export to LabelStudio
 =============================================

--- a/lightly/active_learning/config/selection_config.py
+++ b/lightly/active_learning/config/selection_config.py
@@ -30,10 +30,14 @@ class SelectionConfig:
         >>> config = SelectionConfig(method=SamplingMethod.CORESET, n_samples=100)
         >>>
         >>> # give your selection a name
-        >>> config = SelectionConfig(method=SamplingMethod.CORESET, n_samples=100, name='my-selection')
+        >>> config = SelectionConfig(
+        ...     method=SamplingMethod.CORESET, n_samples=100, name="my-selection"
+        ... )
         >>>
         >>> # use minimum distance between samples as stopping criterion
-        >>> config = SelectionConfig(method=SamplingMethod.CORESET, n_samples=-1, min_distance=0.1)
+        >>> config = SelectionConfig(
+        ...     method=SamplingMethod.CORESET, n_samples=-1, min_distance=0.1
+        ... )
 
     """
 

--- a/lightly/api/api_workflow_artifacts.py
+++ b/lightly/api/api_workflow_artifacts.py
@@ -39,8 +39,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download artifacts
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_artifacts(run=run, output_dir="my_run/artifacts")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_artifacts(
+            ...     run=run, output_dir="my_run/artifacts"
+            ... )
 
         """
         if run.artifacts is None:
@@ -86,8 +90,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download checkpoint
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_checkpoint(run=run, output_path="my_checkpoint.ckpt")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_checkpoint(
+            ...     run=run, output_path="my_checkpoint.ckpt"
+            ... )
 
         """
         self._download_compute_worker_run_artifact_by_type(
@@ -127,8 +135,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download report
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_report_pdf(run=run, output_path="report.pdf")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_report_pdf(
+            ...     run=run, output_path="report.pdf"
+            ... )
 
         """
         self._download_compute_worker_run_artifact_by_type(
@@ -172,8 +184,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download checkpoint
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_report_json(run=run, output_path="report.json")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_report_json(
+            ...     run=run, output_path="report.json"
+            ... )
 
         """
         warnings.warn(
@@ -220,8 +236,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download checkpoint
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_report_v2_json(run=run, output_path="report_v2.json")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_report_v2_json(
+            ...     run=run, output_path="report_v2.json"
+            ... )
 
         """
         self._download_compute_worker_run_artifact_by_type(
@@ -261,7 +281,9 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download log file
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
             >>> client.download_compute_worker_run_log(run=run, output_path="log.txt")
 
         """
@@ -302,8 +324,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download memory log file
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_memory_log(run=run, output_path="memlog.txt")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_memory_log(
+            ...     run=run, output_path="memlog.txt"
+            ... )
 
         """
         self._download_compute_worker_run_artifact_by_type(
@@ -343,8 +369,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download corruptness check information file
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_corruptness_check_information(run=run, output_path="corruptness_check_information.json")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_corruptness_check_information(
+            ...     run=run, output_path="corruptness_check_information.json"
+            ... )
             >>>
             >>> # print all corrupt samples and corruptions
             >>> with open("corruptness_check_information.json", 'r') as f:
@@ -390,8 +420,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # download sequence information file
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> client.download_compute_worker_run_sequence_information(run=run, output_path="sequence_information.json")
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> client.download_compute_worker_run_sequence_information(
+            ...     run=run, output_path="sequence_information.json"
+            ... )
 
         """
         self._download_compute_worker_run_artifact_by_type(
@@ -476,8 +510,12 @@ class _ArtifactsMixin:
             >>>     pass
             >>>
             >>> # get checkpoint read_url
-            >>> run = client.get_compute_worker_run_from_scheduled_run(scheduled_run_id=scheduled_run_id)
-            >>> checkpoint_read_url = client.get_compute_worker_run_checkpoint_url(run=run)
+            >>> run = client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id=scheduled_run_id
+            ... )
+            >>> checkpoint_read_url = client.get_compute_worker_run_checkpoint_url(
+            ...     run=run
+            ... )
 
         """
         artifact = self._get_artifact_by_type(

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -260,7 +260,6 @@ class ApiWorkflowClient(
 
         :meta private:  # Skip docstring generation
         """
-
         # check to see if server side encryption for S3 is desired
         # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingServerSideEncryption.html
         # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html

--- a/lightly/api/api_workflow_collaboration.py
+++ b/lightly/api/api_workflow_collaboration.py
@@ -25,13 +25,17 @@ class _CollaborationMixin:
         Examples:
           >>> # share a dataset with a user
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-          >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=["user@something.com"])
+          >>> client.share_dataset_only_with(
+          ...     dataset_id="MY_DATASET_ID", user_emails=["user@something.com"]
+          ... )
           >>>
           >>> # share dataset with a user while keep sharing it with previous users
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
           >>> user_emails = client.get_shared_users(dataset_id="MY_DATASET_ID")
           >>> user_emails.append("additional_user2@something.com")
-          >>> client.share_dataset_only_with(dataset_id="MY_DATASET_ID", user_emails=user_emails)
+          >>> client.share_dataset_only_with(
+          ...     dataset_id="MY_DATASET_ID", user_emails=user_emails
+          ... )
           >>>
           >>> # revoke access to all users
           >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
@@ -59,7 +63,6 @@ class _CollaborationMixin:
             >>> client.get_shared_users(dataset_id="MY_DATASET_ID")
             >>> ["user@something.com"]
         """
-
         access_configs: List[SharedAccessConfigData] = (
             self._collaboration_api.get_shared_access_configs_by_dataset_id(
                 dataset_id=dataset_id

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -103,7 +103,9 @@ class _ComputeWorkerMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> worker_id = client.register_compute_worker(name="my-worker", labels=["worker-label"])
+            >>> worker_id = client.register_compute_worker(
+            ...     name="my-worker", labels=["worker-label"]
+            ... )
             >>> worker_id
             '64709eac61e9ce68180a6529'
         """
@@ -420,7 +422,9 @@ class _ComputeWorkerMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> client.get_compute_worker_run_from_scheduled_run(scheduled_run_id="646f338a8a5613b57d8b73a1")
+            >>> client.get_compute_worker_run_from_scheduled_run(
+            ...     scheduled_run_id="646f338a8a5613b57d8b73a1"
+            ... )
             {'artifacts': [...],
              'config_id': '6470a16461e9ce68180a6530',
              'created_at': 1679479418110,
@@ -475,6 +479,7 @@ class _ComputeWorkerMixin:
         """Returns the schedule run data given the id of the scheduled run.
 
         TODO (MALTE, 09/2022): Have a proper API endpoint for doing this.
+
         Args:
             scheduled_run_id:
                 The ID with which the run was scheduled.
@@ -710,7 +715,6 @@ def _validate_config(
         InvalidConfigurationError: If obj is not a valid config.
 
     """
-
     if cfg is None:
         return
 

--- a/lightly/api/api_workflow_datasets.py
+++ b/lightly/api/api_workflow_datasets.py
@@ -34,7 +34,9 @@ class _DatasetsMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.IMAGES
+            ... )
             >>> dataset_id = client.dataset_id
             >>> client.dataset_exists(dataset_id=dataset_id)
             True
@@ -72,7 +74,9 @@ class _DatasetsMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.IMAGES
+            ... )
             >>> client.dataset_name_exists(dataset_name="your-dataset-name")
             True
         """
@@ -89,7 +93,9 @@ class _DatasetsMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.IMAGES
+            ... )
             >>> dataset_id = client.dataset_id
             >>> client.get_dataset_by_id(dataset_id=dataset_id)
             {'created_at': 1685009504596,
@@ -134,7 +140,9 @@ class _DatasetsMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.IMAGES
+            ... )
             >>> client.get_datasets_by_name(dataset_name="your-dataset-name")
             [{'created_at': 1685009504596,
              'datasource_processed_until_timestamp': 1685009513,
@@ -271,7 +279,9 @@ class _DatasetsMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.IMAGES
+            ... )
             >>> client.get_datasets()
             [{'created_at': 1685009504596,
              'datasource_processed_until_timestamp': 1685009513,
@@ -377,10 +387,14 @@ class _DatasetsMixin:
             >>> from lightly.openapi_generated.swagger_client.models import DatasetType
             >>>
             >>> client = ApiWorkflowClient(token="YOUR_TOKEN")
-            >>> client.create_dataset('your-dataset-name', dataset_type=DatasetType.IMAGES)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.IMAGES
+            ... )
             >>>
             >>> # or to work with videos
-            >>> client.create_dataset('your-dataset-name', dataset_type=DatasetType.VIDEOS)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.VIDEOS
+            ... )
             >>>
             >>> # retrieving dataset_id of the created dataset
             >>> dataset_id = client.dataset_id
@@ -389,7 +403,6 @@ class _DatasetsMixin:
             >>> client.dataset_type
             'Videos'
         """
-
         if self.dataset_name_exists(dataset_name=dataset_name):
             raise ValueError(
                 f"A dataset with the name '{dataset_name}' already exists! Please use "
@@ -494,7 +507,9 @@ class _DatasetsMixin:
 
         Examples:
             >>> client = ApiWorkflowClient(token="MY_AWESOME_TOKEN")
-            >>> client.create_dataset("your-dataset-name", dataset_type=DatasetType.IMAGES)
+            >>> client.create_dataset(
+            ...     "your-dataset-name", dataset_type=DatasetType.IMAGES
+            ... )
             >>> dataset_id = client.dataset_id
             >>> client.dataset_exists(dataset_id=dataset_id)
             True

--- a/lightly/api/api_workflow_datasources.py
+++ b/lightly/api/api_workflow_datasources.py
@@ -320,7 +320,7 @@ class _DatasourcesMixin:
 
         >>> from lightly.api import ApiWorkflowClient
         >>> client = ApiWorkflowClient(
-        ...    token="MY_LIGHTLY_TOKEN", dataset_id="MY_DATASET_ID"
+        ...     token="MY_LIGHTLY_TOKEN", dataset_id="MY_DATASET_ID"
         ... )
         >>> client.list_datasource_permissions()
         {

--- a/lightly/api/api_workflow_download_dataset.py
+++ b/lightly/api/api_workflow_download_dataset.py
@@ -74,7 +74,6 @@ class _DownloadDatasetMixin:
             Downloading 3 images (with 3 workers):
             100%|██████████████████████████████████| 3/3 [00:01<00:00,  1.99imgs/s]
         """
-
         # check if images are available
         dataset = self._datasets_api.get_dataset_by_id(self.dataset_id)
         if dataset.img_type != ImageType.FULL:
@@ -228,7 +227,7 @@ class _DownloadDatasetMixin:
             >>> client.set_dataset_id_by_name("my-dataset")
             >>> client.download_embeddings_csv_by_id(
             ...     embedding_id="646f346004d77b4e1424e67e",
-            ...     output_path="/tmp/embeddings.csv"
+            ...     output_path="/tmp/embeddings.csv",
             ... )
             >>>
             >>> # File content:
@@ -294,7 +293,9 @@ class _DownloadDatasetMixin:
             >>>
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
-            >>> client.export_label_studio_tasks_by_tag_id(tag_id="646f34608a5613b57d8b73cc")
+            >>> client.export_label_studio_tasks_by_tag_id(
+            ...     tag_id="646f34608a5613b57d8b73cc"
+            ... )
             [{'id': 0, 'data': {'image': '...', ...}}]
         """
         label_studio_tasks = list(

--- a/lightly/api/api_workflow_export.py
+++ b/lightly/api/api_workflow_export.py
@@ -35,7 +35,9 @@ class _ExportDatasetMixin:
             >>>
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
-            >>> client.export_label_studio_tasks_by_tag_id(tag_id="646f34608a5613b57d8b73cc")
+            >>> client.export_label_studio_tasks_by_tag_id(
+            ...     tag_id="646f34608a5613b57d8b73cc"
+            ... )
             [{'id': 0, 'data': {'image': '...', ...}}]
         """
         label_studio_tasks: List[LabelStudioTask] = list(
@@ -103,7 +105,9 @@ class _ExportDatasetMixin:
             >>>
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
-            >>> client.export_label_box_data_rows_by_tag_id(tag_id="646f34608a5613b57d8b73cc")
+            >>> client.export_label_box_data_rows_by_tag_id(
+            ...     tag_id="646f34608a5613b57d8b73cc"
+            ... )
             [{'externalId': '2218961434_7916358f53_z.jpg', 'imageUrl': ...}]
         """
         warnings.warn(
@@ -175,6 +179,7 @@ class _ExportDatasetMixin:
         Args:
             tag_id:
                 ID of the tag which should exported.
+
         Returns:
             A list of dictionaries in a format compatible with Labelbox v4.
 
@@ -183,7 +188,9 @@ class _ExportDatasetMixin:
             >>>
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
-            >>> client.export_label_box_v4_data_rows_by_tag_id(tag_id="646f34608a5613b57d8b73cc")
+            >>> client.export_label_box_v4_data_rows_by_tag_id(
+            ...     tag_id="646f34608a5613b57d8b73cc"
+            ... )
             [{'row_data': '...', 'global_key': 'image-1.jpg', 'media_type': 'IMAGE'}
         """
         label_box_data_rows: List[LabelBoxV4DataRow] = list(
@@ -210,8 +217,10 @@ class _ExportDatasetMixin:
         Args:
             tag_name:
                 Name of the tag which should exported.
+
         Returns:
             A list of dictionaries in a format compatible with Labelbox.
+
         Examples:
             >>> # write json file which can be imported in Label Studio
             >>> tasks = client.export_label_box_v4_data_rows_by_tag_name(

--- a/lightly/api/api_workflow_selection.py
+++ b/lightly/api/api_workflow_selection.py
@@ -87,7 +87,6 @@ class _SelectionMixin:
 
         :meta private:  # Skip docstring generation
         """
-
         warnings.warn(
             DeprecationWarning(
                 "ApiWorkflowClient.selection() is deprecated "
@@ -179,7 +178,6 @@ class _SelectionMixin:
         Last the SamplingCreateRequest is created with the necessary nested class instances.
 
         """
-
         sampling_config = SamplingConfig(
             stopping_condition=SamplingConfigStoppingCondition(
                 n_samples=selection_config.n_samples,

--- a/lightly/api/api_workflow_tags.py
+++ b/lightly/api/api_workflow_tags.py
@@ -127,7 +127,6 @@ class _TagsMixin:
 
         :meta private:  # Skip docstring generation
         """
-
         if exclude_parent_tag:
             parent_tag_id = tag_data.prev_tag_id
             tag_arithmetics_request = TagArithmeticsRequest(
@@ -181,11 +180,12 @@ class _TagsMixin:
             >>>
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
-            >>> filenames = ['image-1.png', 'image-2.png']
-            >>> client.create_tag_from_filenames(fnames_new_tag=filenames, new_tag_name='new-tag')
+            >>> filenames = ["image-1.png", "image-2.png"]
+            >>> client.create_tag_from_filenames(
+            ...     fnames_new_tag=filenames, new_tag_name="new-tag"
+            ... )
             {'id': '6470c4c1060894655c5a8ed5'}
         """
-
         # make sure the tag name does not exist yet
         tags = self.get_all_tags()
         if new_tag_name in [tag.name for tag in tags]:
@@ -250,8 +250,10 @@ class _TagsMixin:
             >>>
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
-            >>> filenames = ['image-1.png', 'image-2.png']
-            >>> tag_id = client.create_tag_from_filenames(fnames_new_tag=filenames, new_tag_name='new-tag')["id"]
+            >>> filenames = ["image-1.png", "image-2.png"]
+            >>> tag_id = client.create_tag_from_filenames(
+            ...     fnames_new_tag=filenames, new_tag_name="new-tag"
+            ... )["id"]
             >>> client.delete_tag_by_id(tag_id=tag_id)
         """
         self._tags_api.delete_tag_by_tag_id(dataset_id=self.dataset_id, tag_id=tag_id)
@@ -268,8 +270,10 @@ class _TagsMixin:
             >>>
             >>> # Already created some Lightly Worker runs with this dataset
             >>> client.set_dataset_id_by_name("my-dataset")
-            >>> filenames = ['image-1.png', 'image-2.png']
-            >>> client.create_tag_from_filenames(fnames_new_tag=filenames, new_tag_name='new-tag')
+            >>> filenames = ["image-1.png", "image-2.png"]
+            >>> client.create_tag_from_filenames(
+            ...     fnames_new_tag=filenames, new_tag_name="new-tag"
+            ... )
             >>> client.delete_tag_by_name(tag_name="new-tag")
         """
         tag_data = self.get_tag_by_name(tag_name=tag_name)

--- a/lightly/api/api_workflow_upload_embeddings.py
+++ b/lightly/api/api_workflow_upload_embeddings.py
@@ -191,7 +191,6 @@ class _UploadEmbeddingsMixin:
 
         :meta private:  # Skip docstring generation
         """
-
         # read embedding from API
         embedding_read_url = self._embeddings_api.get_embeddings_csv_read_url_by_id(
             self.dataset_id, embedding_id

--- a/lightly/api/api_workflow_upload_metadata.py
+++ b/lightly/api/api_workflow_upload_metadata.py
@@ -68,7 +68,6 @@ class _UploadCustomMetadataMixin:
 
         :meta private:  # Skip docstring generation
         """
-
         # The mapping is filename -> image_id -> custom_metadata
         # This mapping is created in linear time.
         filename_to_image_id = {
@@ -143,7 +142,6 @@ class _UploadCustomMetadataMixin:
 
         :meta private:  # Skip docstring generation
         """
-
         self.verify_custom_metadata_format(custom_metadata)
 
         # For each metadata, we need the corresponding sample_id
@@ -229,7 +227,9 @@ class _UploadCustomMetadataMixin:
             The API response.
 
         Examples:
-            >>> from lightly.openapi_generated.swagger_codegen.models.configuration_entry import ConfigurationEntry
+            >>> from lightly.openapi_generated.swagger_codegen.models.configuration_entry import (
+            ...     ConfigurationEntry,
+            ... )
             >>> entry = ConfigurationEntry(
             >>>     name='Weather',
             >>>     path='weather',

--- a/lightly/api/bitmask.py
+++ b/lightly/api/bitmask.py
@@ -76,20 +76,22 @@ def _unset_kth_bit(x: int, k: int) -> int:
 
 class BitMask:
     """Utility class to represent and manipulate tags.
+
     Attributes:
         x:
             An integer representation of the binary mask.
+
     Examples:
         >>> # the following are equivalent
         >>> mask = BitMask(6)
-        >>> mask = BitMask.from_hex('0x6')
-        >>> mask = Bitmask.from_bin('0b0110')
+        >>> mask = BitMask.from_hex("0x6")
+        >>> mask = Bitmask.from_bin("0b0110")
         >>> # for a dataset with 10 images, assume the following tag
         >>> # 0001011001 where the 1st, 4th, 5th and 7th image are selected
         >>> # this tag would be stored as 0x59.
-        >>> hexstring = '0x59'                    # what you receive from the api
+        >>> hexstring = "0x59"  # what you receive from the api
         >>> mask = BitMask.from_hex(hexstring)  # create a bitmask from it
-        >>> indices = mask.to_indices()         # get list of indices which are one
+        >>> indices = mask.to_indices()  # get list of indices which are one
         >>> # indices is [0, 3, 4, 6]
     """
 
@@ -122,8 +124,9 @@ class BitMask:
 
     def to_indices(self) -> List[int]:
         """Returns the list of indices bits which are set to 1 from the right.
+
         Examples:
-            >>> mask = BitMask('0b0101')
+            >>> mask = BitMask("0b0101")
             >>> indices = mask.to_indices()
             >>> # indices is [0, 2]
         """
@@ -145,9 +148,10 @@ class BitMask:
 
     def union(self, other):
         """Calculates the union of two bit masks.
+
         Examples:
-            >>> mask1 = BitMask.from_bin('0b0011')
-            >>> mask2 = BitMask.from_bin('0b1100')
+            >>> mask1 = BitMask.from_bin("0b0011")
+            >>> mask2 = BitMask.from_bin("0b1100")
             >>> mask1.union(mask2)
             >>> # mask1.binstring is '0b1111'
         """
@@ -155,9 +159,10 @@ class BitMask:
 
     def intersection(self, other):
         """Calculates the intersection of two bit masks.
+
         Examples:
-            >>> mask1 = BitMask.from_bin('0b0011')
-            >>> mask2 = BitMask.from_bin('0b1100')
+            >>> mask1 = BitMask.from_bin("0b0011")
+            >>> mask2 = BitMask.from_bin("0b1100")
             >>> mask1.intersection(mask2)
             >>> # mask1.binstring is '0b0000'
         """
@@ -165,9 +170,10 @@ class BitMask:
 
     def difference(self, other):
         """Calculates the difference of two bit masks.
+
         Examples:
-            >>> mask1 = BitMask.from_bin('0b0111')
-            >>> mask2 = BitMask.from_bin('0b1100')
+            >>> mask1 = BitMask.from_bin("0b0111")
+            >>> mask2 = BitMask.from_bin("0b1100")
             >>> mask1.difference(mask2)
             >>> # mask1.binstring is '0b0011'
         """
@@ -204,8 +210,9 @@ class BitMask:
 
     def set_kth_bit(self, k: int):
         """Sets the kth bit from the right to '1'.
+
         Examples:
-            >>> mask = BitMask('0b0000')
+            >>> mask = BitMask("0b0000")
             >>> mask.set_kth_bit(2)
             >>> # mask.binstring is '0b0100'
         """
@@ -213,8 +220,9 @@ class BitMask:
 
     def unset_kth_bit(self, k: int):
         """Unsets the kth bit from the right to '0'.
+
         Examples:
-            >>> mask = BitMask('0b1111')
+            >>> mask = BitMask("0b1111")
             >>> mask.unset_kth_bit(2)
             >>> # mask.binstring is '0b1011'
         """

--- a/lightly/api/retry_utils.py
+++ b/lightly/api/retry_utils.py
@@ -219,8 +219,7 @@ class Retry:
         return f"{exception.__class__.__name__}. Details: {error_details}"
 
     def should_retry(self, ex: BaseException) -> bool:
-        """
-        Takes an exception as input and returns True
+        """Takes an exception as input and returns True
         if the failed call should be retried and False otherwise.
         If False is returned then the original exception is raised.
         """

--- a/lightly/api/swagger_rest_client.py
+++ b/lightly/api/swagger_rest_client.py
@@ -50,11 +50,13 @@ class PatchRESTClientObjectMixin:
     Should only used in combination with RESTClientObject and must come before the
     RESTClientObject in the inheritance order. So this is ok:
 
-        >>> class MyRESTClientObject(PatchRESTClientObjectMixin, RESTClientObject): pass
+        >>> class MyRESTClientObject(PatchRESTClientObjectMixin, RESTClientObject):
+        ...     pass
 
     while this doesn't work:
 
-        >>> class MyRESTClientObject(RESTClientObject, PatchRESTClientObjectMixin): pass
+        >>> class MyRESTClientObject(RESTClientObject, PatchRESTClientObjectMixin):
+        ...     pass
 
     A wrong inheritance order will result in the super() calls no calling the correct
     parent classes.

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -148,15 +148,14 @@ class DatasourceType(Enum):
 
 
 def get_signed_url_destination(signed_url: str = "") -> DatasourceType:
-    """
-    Tries to figure out the of which cloud provider/datasource type a signed url comes from (S3, GCS, Azure)
+    """Tries to figure out the of which cloud provider/datasource type a signed url comes from (S3, GCS, Azure)
+
     Args:
         signed_url:
             The signed url of a "bucket" provider
     Returns:
         DatasourceType
     """
-
     assert isinstance(signed_url, str)
 
     if "storage.googleapis.com/" in signed_url:

--- a/lightly/cli/_cli_simclr.py
+++ b/lightly/cli/_cli_simclr.py
@@ -27,7 +27,6 @@ class _SimCLR(nn.Module):
 
     def forward(self, x0: torch.Tensor, x1: torch.Tensor = None):
         """Embeds and projects the input images."""
-
         # forward pass of first input x0
         f0 = self.backbone(x0).flatten(start_dim=1)
         out0 = self.projection_head(f0)

--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -39,7 +39,6 @@ def fix_hydra_arguments(config_path: str = "config", config_name: str = "config"
     Hydra introduced the `version_base` argument in version 1.2.0
     We use this helper to provide backwards compatibility to older hydra verisons.
     """
-
     hydra_args = {"config_path": config_path, "config_name": config_name}
 
     try:
@@ -123,7 +122,6 @@ def _filter_state_dict(state_dict, remove_model_prefix_offset: int = 1):
     Allows backwards compatability to checkpoints before v1.0.6.
 
     """
-
     prev_backbone = "features"
     curr_backbone = "backbone"
 
@@ -150,7 +148,6 @@ def _fix_projection_head_keys(state_dict):
     Prevents unexpected key error when loading old checkpoints.
 
     """
-
     projection_head_identifier = "projection_head"
     prediction_head_identifier = "prediction_head"
     projection_head_insert = "layers"
@@ -180,7 +177,6 @@ def load_from_state_dict(
     num_splits: int = 0,
 ):
     """Loads the model weights from the state dictionary."""
-
     # step 1: filter state dict
     if apply_filter:
         state_dict = _filter_state_dict(state_dict)

--- a/lightly/cli/download_cli.py
+++ b/lightly/cli/download_cli.py
@@ -113,7 +113,7 @@ def download_cli(cfg):
             output_dir.
 
     Examples:
-        >>> # download list of all files in the dataset from the Lightly platform
+        >>> # download list of all files in the dataset from the Lightly platform
         >>> lightly-download token='123' dataset_id='XYZ'
         >>>
         >>> # download list of all files in tag 'my-tag' from the Lightly platform

--- a/lightly/cli/embed_cli.py
+++ b/lightly/cli/embed_cli.py
@@ -111,7 +111,7 @@ def embed_cli(cfg) -> str:
         The path to the created embeddings file.
 
     Examples:
-        >>> # embed images with default settings and a lightly model
+        >>> # embed images with default settings and a lightly model
         >>> lightly-embed input_dir=data/
         >>>
         >>> # embed images with default settings and a custom checkpoint

--- a/lightly/cli/lightly_cli.py
+++ b/lightly/cli/lightly_cli.py
@@ -53,7 +53,7 @@ def lightly_cli(cfg):
             Path to the input directory where images are stored.
 
     Examples:
-        >>> # train model and embed images with default settings
+        >>> # train model and embed images with default settings
         >>> lightly-magic input_dir=data/
         >>>
         >>> # train model for 10 epochs and embed images

--- a/lightly/cli/version_cli.py
+++ b/lightly/cli/version_cli.py
@@ -3,7 +3,7 @@
 
 Example:
     >>> # show the version of the installed package
-    >>> lightly-version
+    >>> lightly - version
 """
 
 # Copyright (c) 2021. Lightly AG and its affiliates.

--- a/lightly/cli/version_cli.py
+++ b/lightly/cli/version_cli.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """**Lightly Version:** Show the version of the installed package.
 
-Example:
-    >>> # show the version of the installed package
-    >>> lightly - version
+Example::
+
+    # show the version of the installed package
+    $ lightly-version
 """
 
 # Copyright (c) 2021. Lightly AG and its affiliates.

--- a/lightly/core.py
+++ b/lightly/core.py
@@ -103,8 +103,8 @@ def train_model_and_embed_images(
         >>> embeddings, _, _ = lightly.train_model_and_embed_images(
         >>>     input_dir='path/to/data')
         >>>
-        >>> # train a model and embed images with separate config file
-        >>> my_config_path = 'my/config/file.yaml'
+        >>> # train a model and embed images with separate config file
+        >>> my_config_path = "my/config/file.yaml"
         >>> embeddings, _, _ = lightly.train_model_and_embed_images(
         >>>     input_dir='path/to/data', config_path=my_config_path)
         >>>
@@ -147,22 +147,22 @@ def train_embedding_model(config_path: str = None, **kwargs):
         >>> checkpoint_path = lightly.train_embedding_model(
         >>>     input_dir='path/to/data')
         >>>
-        >>> # train a model with separate config file
-        >>> my_config_path = 'my/config/file.yaml'
+        >>> # train a model with separate config file
+        >>> my_config_path = "my/config/file.yaml"
         >>> checkpoint_path = lightly.train_embedding_model(
         >>>     input_dir='path/to/data', config_path=my_config_path)
         >>>
         >>> # train a model with default settings and overwrites: large batch
         >>> # sizes are benefitial for self-supervised training and more
-        >>> # workers speed up the dataloading process.
+        >>> # workers speed up the dataloading process.
         >>> my_loader = {
         >>>     batch_size: 100,
         >>>     num_workers: 8,
         >>> }
         >>> checkpoint_path = lightly.train_embedding_model(
         >>>     input_dir='path/to/data', loader=my_loader)
-        >>> # the command above is equivalent to:
-        >>> # lightly-ssl-train input_dir='path/to/data' loader.batch_size=100 loader.num_workers=8
+        >>> # the command above is equivalent to:
+        >>> # lightly-ssl-train input_dir='path/to/data' loader.batch_size=100 loader.num_workers=8
     """
     config_path = _get_config_path(config_path)
     config_args = _load_config_file(config_path)
@@ -191,24 +191,24 @@ def embed_images(checkpoint: str, config_path: str = None, **kwargs):
 
     Examples:
         >>> import lightly
-        >>> my_checkpoint_path = 'path/to/checkpoint.ckpt'
+        >>> my_checkpoint_path = "path/to/checkpoint.ckpt"
         >>>
         >>> # embed images with default configs
         >>> embeddings, _, _ = lightly.embed_images(
         >>>     my_checkpoint_path, input_dir='path/to/data')
         >>>
-        >>> # embed images with separate config file
-        >>> my_config_path = 'my/config/file.yaml'
+        >>> # embed images with separate config file
+        >>> my_config_path = "my/config/file.yaml"
         >>> embeddings, _, _ = lightly.embed_images(
         >>>     my_checkpoint_path, input_dir='path/to/data', config_path=my_config_path)
         >>>
         >>> # embed images with default settings and overwrites: at inference,
-        >>> # we can use larger input_sizes because it requires less memory.
+        >>> # we can use larger input_sizes because it requires less memory.
         >>> my_collate = {input_size: 256}
         >>> embeddings, _, _ = lightly.embed_images(
         >>>     my_checkpoint_path, input_dir='path/to/data', collate=my_collate)
-        >>> # the command above is equivalent to:
-        >>> # lightly-embed input_dir='path/to/data' collate.input_size=256
+        >>> # the command above is equivalent to:
+        >>> # lightly-embed input_dir='path/to/data' collate.input_size=256
 
     """
     config_path = _get_config_path(config_path)

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -128,10 +128,10 @@ class VideoLoader(threading.local):
         >>> from torchvision import io
         >>>
         >>> # get timestamps
-        >>> ts, fps = io.read_video_timestamps('myvideo.mp4', pts_unit = 'sec')
+        >>> ts, fps = io.read_video_timestamps("myvideo.mp4", pts_unit="sec")
         >>>
         >>> # create a VideoLoader
-        >>> video_loader = VideoLoader('myvideo.mp4', ts)
+        >>> video_loader = VideoLoader("myvideo.mp4", ts)
         >>>
         >>> # get frame at specific timestamp
         >>> frame = video_loader.read_frame(ts[21])
@@ -504,7 +504,7 @@ class VideoDataset(datasets.VisionDataset):
         E.g. when retrieving a sample from the video
         `my_video.mp4` at frame 153, the filename will be:
 
-        >>> my_video-153-mp4.png
+        >>> my_video - 153 - mp4.png
 
         Args:
             index:

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -501,10 +501,8 @@ class VideoDataset(datasets.VisionDataset):
         The filename is created from the video filename, the frame number, and
         the video format. The frame number will be zero padded to make sure
         all filenames have the same length and can easily be sorted.
-        E.g. when retrieving a sample from the video
-        `my_video.mp4` at frame 153, the filename will be:
-
-        >>> my_video - 153 - mp4.png
+        For example, when retrieving a sample from the video ``my_video.mp4``
+        at frame 153, the filename will be ``my_video-153-mp4.png``.
 
         Args:
             index:

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -59,11 +59,11 @@ class BaseCollateFunction(nn.Module):
 
         Examples:
             >>> # define a random transformation and the collate function
-            >>> transform = ... # some random augmentations
+            >>> transform = ...  # some random augmentations
             >>> collate_fn = BaseCollateFunction(transform)
             >>>
             >>> # input is a batch of tuples (here, batch_size = 1)
-            >>> input = [(img, 0, 'my-image.png')]
+            >>> input = [(img, 0, "my-image.png")]
             >>> output = collate_fn(input)
             >>>
             >>> # output consists of two random transforms of the images,
@@ -264,7 +264,6 @@ class SimCLRCollateFunction(ImageCollateFunction):
             Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
 
     Examples:
-
         >>> # SimCLR for ImageNet
         >>> collate_fn = SimCLRCollateFunction()
         >>>
@@ -352,7 +351,6 @@ class MoCoCollateFunction(ImageCollateFunction):
             Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
 
     Examples:
-
         >>> # MoCo v1 for ImageNet
         >>> collate_fn = MoCoCollateFunction()
         >>>
@@ -502,7 +500,6 @@ class SwaVCollateFunction(MultiCropCollateFunction):
             Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
 
     Examples:
-
         >>> # SwaV for Imagenet
         >>> collate_fn = SwaVCollateFunction()
         >>>
@@ -807,7 +804,6 @@ class PIRLCollateFunction(nn.Module):
             Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
 
     Examples:
-
         >>> # PIRL for ImageNet
         >>> collate_fn = PIRLCollateFunction()
         >>>
@@ -871,7 +867,8 @@ class PIRLCollateFunction(nn.Module):
     def forward(self, batch: List[tuple]):
         """Overriding the BaseCollateFunction class's forward method because
         for PIRL we need only one augmented batch, as opposed to both, which the
-        BaseCollateFunction creates."""
+        BaseCollateFunction creates.
+        """
         batch_size = len(batch)
 
         # list of transformed images
@@ -1308,8 +1305,7 @@ class VICRegLCollateFunction(nn.Module):
         torch.Tensor,
         torch.Tensor,
     ]:
-        """
-        Applies transforms to images in the input batch.
+        """Applies transforms to images in the input batch.
 
         Args:
             batch:
@@ -1321,7 +1317,6 @@ class VICRegLCollateFunction(nn.Module):
             labels (as torch.Tensor), and filenames (as torch.Tensor).
 
         """
-
         views_global = []
         views_local = []
         grids_global = []
@@ -1454,8 +1449,7 @@ class IJEPAMaskCollator:
         return mask, mask_complement
 
     def __call__(self, batch):
-        """
-        Create encoder and predictor masks when collating imgs into a batch
+        """Create encoder and predictor masks when collating imgs into a batch
         # 1. sample enc block (size + location) using seed
         # 2. sample pred block (size) using seed
         # 3. sample several enc block locations for each image (w/o seed)

--- a/lightly/data/dataset.py
+++ b/lightly/data/dataset.py
@@ -53,7 +53,7 @@ class LightlyDataset:
         >>> # `- img2.png
         >>> # `- ...
         >>> import lightly.data as data
-        >>> dataset = data.LightlyDataset(input_dir='path/to/mydata/')
+        >>> dataset = data.LightlyDataset(input_dir="path/to/mydata/")
         >>> sample, target, fname = dataset[0]
         >>>
         >>> # also works with subfolders
@@ -129,7 +129,7 @@ class LightlyDataset:
             >>> # load cifar10 from torchvision
             >>> import torchvision
             >>> import lightly.data as data
-            >>> base = torchvision.datasets.CIFAR10(root='./')
+            >>> base = torchvision.datasets.CIFAR10(root="./")
             >>> dataset = data.LightlyDataset.from_torch_dataset(base)
 
         """
@@ -209,7 +209,6 @@ class LightlyDataset:
                 as a png image to prevent compression artifacts.
 
         """
-
         if self.dataset.transform is not None:
             raise RuntimeError("Cannot dump dataset which applies transforms!")
 
@@ -259,7 +258,6 @@ class LightlyDataset:
             newly created jpg (case 2, 3)
 
         """
-
         has_input_dir = hasattr(self, "input_dir") and isinstance(self.input_dir, str)
         if has_input_dir:
             path_to_image = os.path.join(self.input_dir, filename)
@@ -347,7 +345,6 @@ def _dump_image(dataset, output_dir, filename, index, fmt):
     then save it to the output directory with the specified format.
 
     """
-
     if isinstance(dataset, datasets.ImageFolder):
         # can safely copy the image from the input to the output directory
         _copy_image(dataset.root, output_dir, filename)

--- a/lightly/data/multi_view_collate.py
+++ b/lightly/data/multi_view_collate.py
@@ -15,7 +15,9 @@ class MultiViewCollate:
     Example:
         >>> transform = SimCLRTransform()
         >>> dataset = LightlyDataset(input_dir, transform=transform)
-        >>> dataloader = DataLoader(dataset, batch_size=4, collate_fn=MultiViewCollate())
+        >>> dataloader = DataLoader(
+        ...     dataset, batch_size=4, collate_fn=MultiViewCollate()
+        ... )
         >>> for views, targets, filenames in dataloader:
         >>>     view0, view1 = views  # each view is a tensor of shape (batch_size, channels, height, width)
     """
@@ -33,7 +35,7 @@ class MultiViewCollate:
                 representing a transformed version of the original image. `label` and
                 `filename` are the class label and filename for the corresponding image.
 
-                Example:
+        Example:
                     >>> batch = [
                     >>>     ([img_0_view_0, ..., img_0_view_N], label_0, filename_0),   # image 0
                     >>>     ([img_1_view_0, ..., img_1_view_N], label_1, filename_1),   # image 1
@@ -51,7 +53,7 @@ class MultiViewCollate:
                 - **filenames**: A list of strings containing filenames for all images
                   in the batch.
 
-            Example:
+        Example:
                 >>> output = (
                 >>>     [
                 >>>         Tensor([img_0_view_0, ..., img_B_view_0]),    # view 0

--- a/lightly/embedding/_base.py
+++ b/lightly/embedding/_base.py
@@ -41,7 +41,6 @@ class BaseEmbedding(LightningModule):
             dataloader: (torch.utils.data.DataLoader)
 
         """
-
         super(BaseEmbedding, self).__init__()
         self.model = model
         self.criterion = criterion

--- a/lightly/embedding/embedding.py
+++ b/lightly/embedding/embedding.py
@@ -60,9 +60,9 @@ class SelfSupervisedEmbedding(BaseEmbedding):
         >>>     optimizer,
         >>>     dataloader,
         >>> )
-        >>> # train the self-supervised embedding with default settings
+        >>> # train the self-supervised embedding with default settings
         >>> encoder.train_embedding()
-        >>> # pass pytorch-lightning trainer arguments as kwargs
+        >>> # pass pytorch-lightning trainer arguments as kwargs
         >>> encoder.train_embedding(max_epochs=10)
 
     """
@@ -108,7 +108,6 @@ class SelfSupervisedEmbedding(BaseEmbedding):
             >>> embeddings, labels, fnames = encoder.embed(dataloader)
 
         """
-
         self.model.eval()
         filenames = []
 

--- a/lightly/loss/barlow_twins_loss.py
+++ b/lightly/loss/barlow_twins_loss.py
@@ -63,7 +63,6 @@ class BarlowTwinsLoss(torch.nn.Module):
         Returns:
             Computed Barlow Twins Loss.
         """
-
         # Normalize repr. along the batch dimension
         z_a_norm, z_b_norm = _normalize(z_a), _normalize(z_b)
 
@@ -101,7 +100,6 @@ def _normalize(z: torch.Tensor) -> torch.Tensor:
 
 def _off_diagonal(x: Tensor) -> Tensor:
     """Returns a flattened view of the off-diagonal elements of a square matrix."""
-
     # Ensure the input is a square matrix
     n, m = x.shape
     assert n == m

--- a/lightly/loss/dcl_loss.py
+++ b/lightly/loss/dcl_loss.py
@@ -27,6 +27,7 @@ def negative_mises_fisher_weights(
             Shape: (batch_size, embedding_size)
         sigma:
             Similarities are scaled by inverse sigma.
+
     Returns:
         A tensor with shape (batch_size,) where each entry is the weight for one
         of the input images.

--- a/lightly/loss/dino_loss.py
+++ b/lightly/loss/dino_loss.py
@@ -127,7 +127,6 @@ class DINOLoss(Module):
         Returns:
             The average cross-entropy loss.
         """
-
         # Get teacher temperature
         if teacher_temp is not None:
             teacher_temperature = torch.tensor(teacher_temp)
@@ -172,7 +171,6 @@ class DINOLoss(Module):
                 Tensor with shape (num_views, batch_size, output_dim) containing
                 features from the teacher model.
         """
-
         # Calculate the batch center using the specified center function
         batch_center = self._center_fn(x=teacher_out, dim=(0, 1))
 

--- a/lightly/loss/directclr_loss.py
+++ b/lightly/loss/directclr_loss.py
@@ -100,7 +100,6 @@ class DirectCLRLoss(NTXentLoss):
         Returns:
             DirectCLR Loss value.
         """
-
         out0 = out0.flatten(start_dim=1)[:, : self.loss_dim]
         out1 = out1.flatten(start_dim=1)[:, : self.loss_dim]
 

--- a/lightly/loss/emp_ssl_loss.py
+++ b/lightly/loss/emp_ssl_loss.py
@@ -38,6 +38,7 @@ def invariance_loss(z: Tensor) -> Tensor:
     Args:
         z:
             Patch embeddings.
+
     Returns:
         Similarity loss.
     """
@@ -66,8 +67,10 @@ class EMPSSLLoss(Module):
     Examples:
         >>> # initialize loss function
         >>> loss_fn = EMP_SSLLoss()
-        >>> base_transform = VICRegViewTransform() # As discussed in paper
-        >>> transform_fn = MultiCropTransform(transforms=base_transform, crop_counts=100)
+        >>> base_transform = VICRegViewTransform()  # As discussed in paper
+        >>> transform_fn = MultiCropTransform(
+        ...     transforms=base_transform, crop_counts=100
+        ... )
         >>>
         >>> # generate the transformed samples
         >>> samples = transform_fn(image)
@@ -106,7 +109,6 @@ class EMPSSLLoss(Module):
         Returns:
             The computed EMP-SSL loss.
         """
-
         # z has shape (num_views, batch_size, dim)
         z = torch.stack(z_views)
 

--- a/lightly/loss/hypersphere_loss.py
+++ b/lightly/loss/hypersphere_loss.py
@@ -1,6 +1,5 @@
-"""
-FIXME: hypersphere is perhaps bad naming as I am not sure it is the essence;
- alignment-and-uniformity loss perhaps? Does not sound as nice.
+"""FIXME: hypersphere is perhaps bad naming as I am not sure it is the essence;
+alignment-and-uniformity loss perhaps? Does not sound as nice.
 """
 
 import torch

--- a/lightly/loss/koleo_loss.py
+++ b/lightly/loss/koleo_loss.py
@@ -35,7 +35,6 @@ class KoLeoLoss(Module):
             eps:
                 Small value to avoid division by zero.
         """
-
         super().__init__()
         self.p = p
         self.eps = eps

--- a/lightly/loss/lejepa_loss.py
+++ b/lightly/loss/lejepa_loss.py
@@ -109,13 +109,11 @@ class SIGReg(nn.Module):
         return statistic.mean()
 
     def forward(self, proj: torch.Tensor) -> torch.Tensor:
-        """
-        Compute the SIGReg loss for a batch of projections.
+        """Compute the SIGReg loss for a batch of projections.
 
         Args:
             proj: Projected embeddings of shape (..., N, C).
         """
-
         num_features = proj.size(-1)
         num_samples = proj.size(-2)
         if self.gather_distributed and lightly_dist.world_size() > 1:

--- a/lightly/loss/msn_loss.py
+++ b/lightly/loss/msn_loss.py
@@ -40,6 +40,7 @@ def sharpen(probabilities: Tensor, temperature: float) -> Tensor:
         temperature:
             Temperature in (0, 1]. Lower temperature results in stronger sharpening (
             output probabilities are less uniform).
+
     Returns:
         Probabilities tensor with shape (batch_size, dim).
     """
@@ -68,6 +69,7 @@ def sinkhorn(
             Number of iterations of the sinkhorn algorithms. Set to 0 to disable.
         gather_distributed:
             If True, features from all GPUs are gathered during normalization.
+
     Returns:
         A normalized probabilities tensor.
     """

--- a/lightly/loss/negative_cosine_similarity.py
+++ b/lightly/loss/negative_cosine_similarity.py
@@ -17,7 +17,7 @@ class NegativeCosineSimilarity(torch.nn.Module):
         >>> loss_fn = NegativeCosineSimilarity()
         >>>
         >>> # generate two representation tensors
-        >>> # with batch size 10 and dimension 128
+        >>> # with batch size 10 and dimension 128
         >>> x0 = torch.randn(10, 128)
         >>> x1 = torch.randn(10, 128)
         >>>

--- a/lightly/loss/ntx_ent_loss.py
+++ b/lightly/loss/ntx_ent_loss.py
@@ -117,7 +117,6 @@ class NTXentLoss(nn.Module):
         Returns:
             Contrastive Cross Entropy Loss value.
         """
-
         device = out0.device
         batch_size, _ = out0.shape
 

--- a/lightly/loss/regularizer/co2.py
+++ b/lightly/loss/regularizer/co2.py
@@ -89,7 +89,6 @@ class CO2Regularizer(Module):
         Returns:
             The regularization term multiplied by the weight factor alpha.
         """
-
         # Normalize the output to length 1
         out0 = torch.nn.functional.normalize(out0, dim=1)
         out1 = torch.nn.functional.normalize(out1, dim=1)

--- a/lightly/loss/tico_loss.py
+++ b/lightly/loss/tico_loss.py
@@ -102,7 +102,6 @@ class TiCoLoss(torch.nn.Module):
             AssertionError: If z_a or z_b have a batch size <= 1.
             AssertionError: If z_a and z_b do not have the same shape.
         """
-
         assert z_a.shape[0] > 1 and z_b.shape[0] > 1, (
             f"z_a and z_b must have batch size > 1 but found {z_a.shape[0]} and {z_b.shape[0]}"
         )

--- a/lightly/loss/vicregl_loss.py
+++ b/lightly/loss/vicregl_loss.py
@@ -48,7 +48,7 @@ class VICRegLLoss(Module):
         >>>
         >>> # generate two random transforms of images
         >>> views_and_grids = transform(images)
-        >>> views = views_and_grids[:6] # 2 global views + 4 local views
+        >>> views = views_and_grids[:6]  # 2 global views + 4 local views
         >>> grids = views_and_grids[6:]
         >>>
         >>> # feed through model images

--- a/lightly/loss/wmse_loss.py
+++ b/lightly/loss/wmse_loss.py
@@ -58,7 +58,6 @@ class Whitening2d(nn.Module):
         Raises:
             RuntimeError: If torch.linalg.solve_triangular is not available in the PyTorch installation.
         """
-
         super(Whitening2d, self).__init__()
 
         if not _SOLVE_TRIANGULAR_AVAILABLE:

--- a/lightly/models/_momentum.py
+++ b/lightly/models/_momentum.py
@@ -44,15 +44,15 @@ class _MomentumEncoderMixin:
     >>>         self.backbone = backbone
     >>>         self.projection_head = get_projection_head()
     >>>
-    >>>         # initialize momentum_backbone and momentum_projection_head
+    >>> # initialize momentum_backbone and momentum_projection_head
     >>>         self._init_momentum_encoder()
     >>>
     >>>     def forward(self, x: Tensor):
     >>>
-    >>>         # do the momentum update
+    >>> # do the momentum update
     >>>         self._momentum_update(0.999)
     >>>
-    >>>         # use momentum backbone
+    >>> # use momentum backbone
     >>>         y = self.momentum_backbone(x)
     >>>         y = self.momentum_projection_head(y)
 

--- a/lightly/models/_momentum.py
+++ b/lightly/models/_momentum.py
@@ -44,16 +44,12 @@ class _MomentumEncoderMixin:
     >>>         self.backbone = backbone
     >>>         self.projection_head = get_projection_head()
     >>>
-    >>> # initialize momentum_backbone and momentum_projection_head
-    >>>         self._init_momentum_encoder()
+    >>>         self._init_momentum_encoder()  # initialize momentum_backbone and momentum_projection_head
     >>>
     >>>     def forward(self, x: Tensor):
+    >>>         self._momentum_update(0.999)  # do the momentum update
     >>>
-    >>> # do the momentum update
-    >>>         self._momentum_update(0.999)
-    >>>
-    >>> # use momentum backbone
-    >>>         y = self.momentum_backbone(x)
+    >>>         y = self.momentum_backbone(x)  # use momentum backbone
     >>>         y = self.momentum_projection_head(y)
 
     """

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -489,7 +489,6 @@ class SMoGPredictionHead(ProjectionHead):
             output_dim:
                 Dimensionality of the output features.
         """
-
         super(SMoGPredictionHead, self).__init__(
             [
                 (input_dim, hidden_dim, nn.BatchNorm1d(hidden_dim), nn.ReLU()),

--- a/lightly/models/modules/heads_timm.py
+++ b/lightly/models/modules/heads_timm.py
@@ -38,7 +38,6 @@ class AIMPredictionHeadBlock(Module):
         mlp_layer: Type[Module] = Mlp,
     ) -> None:
         """Initializes the AIMPredictionHeadBlock module with the specified parameters."""
-
         super().__init__()
         self.norm = norm_layer(input_dim)  # type: ignore[call-arg]
         self.mlp = mlp_layer(  # type: ignore[call-arg]
@@ -106,7 +105,6 @@ class AIMPredictionHead(Module):
         block_fn: Type[Module] = AIMPredictionHeadBlock,
     ) -> None:
         """Initializes the AIMPredictionHead module with the specified parameters."""
-
         super().__init__()
         self.blocks = Sequential(
             # Linear layer to project the input dimension to the hidden dimension.

--- a/lightly/models/modules/ijepa.py
+++ b/lightly/models/modules/ijepa.py
@@ -56,7 +56,6 @@ class IJEPAPredictor(vision_transformer.Encoder):
         **kwargs,
     ):
         """Initializes the IJEPAPredictor with the specified dimensions."""
-
         super().__init__(
             seq_length=seq_length,
             num_layers=num_layers,
@@ -91,7 +90,6 @@ class IJEPAPredictor(vision_transformer.Encoder):
         Returns:
             IJEPAPredictor: An I-JEPA predictor backbone initialized from the ViT encoder.
         """
-
         # Create a new instance with dummy values as they will be overwritten
         # by the copied vit_encoder attributes
         encoder = cls(
@@ -200,7 +198,6 @@ class IJEPAEncoder(vision_transformer.Encoder):
         norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
         """Initializes the IJEPAEncoder with the specified dimensions."""
-
         super().__init__(
             seq_length=seq_length,
             num_layers=num_layers,
@@ -215,7 +212,6 @@ class IJEPAEncoder(vision_transformer.Encoder):
     @classmethod
     def from_vit_encoder(cls, vit_encoder: vision_transformer.Encoder):
         """Creates a IJEPA encoder from a torchvision ViT encoder."""
-
         # Create a new instance with dummy values as they will be overwritten
         # by the copied vit_encoder attributes
         encoder = cls(
@@ -249,7 +245,6 @@ class IJEPAEncoder(vision_transformer.Encoder):
         Returns:
             Batch of encoded output tokens.
         """
-
         input = input + self.interpolate_pos_encoding(input)
         if idx_keep is not None:
             input = utils.apply_masks(input, idx_keep)
@@ -269,7 +264,6 @@ class IJEPAEncoder(vision_transformer.Encoder):
             Interpolated positional embedding.
 
         """
-
         # code copied from:
         # https://github.com/facebookresearch/msn/blob/4388dc1eadbe3042b85d3296d41b9b207656e043/src/deit.py#L291
         npatch = input.shape[1] - 1
@@ -376,7 +370,6 @@ class IJEPABackbone(vision_transformer.VisionTransformer):
     @classmethod
     def from_vit(cls, vit: vision_transformer.VisionTransformer):
         """Creates a IJEPABackbone from a torchvision ViT model."""
-
         # Create a new instance with dummy values as they will be overwritten
         # by the copied vit_encoder attributes
         backbone = cls(
@@ -420,7 +413,6 @@ class IJEPABackbone(vision_transformer.VisionTransformer):
             Tensor with shape (batch_size, hidden_dim) containing the
             encoded class token for every image.
         """
-
         if idx_keep is not None:
             if not isinstance(idx_keep, list):
                 idx_keep = [idx_keep]

--- a/lightly/models/modules/ijepa_timm.py
+++ b/lightly/models/modules/ijepa_timm.py
@@ -63,7 +63,6 @@ class IJEPAPredictorTIMM(nn.Module):  # type: ignore[misc]
         norm_layer: Callable[..., nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
         """Initializes the IJEPAPredictorTIMM with the specified dimensions."""
-
         super().__init__()
 
         self.predictor_embed = nn.Linear(mlp_dim, predictor_embed_dim, bias=True)
@@ -117,7 +116,6 @@ class IJEPAPredictorTIMM(nn.Module):  # type: ignore[misc]
         Returns:
             The predicted output tensor.
         """
-
         assert (masks is not None) and (masks_x is not None), (
             "Cannot run predictor without mask indices"
         )

--- a/lightly/models/modules/masked_autoencoder.py
+++ b/lightly/models/modules/masked_autoencoder.py
@@ -52,7 +52,6 @@ class MAEEncoder(vision_transformer.Encoder):
         norm_layer: Callable[..., torch.nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
         """Initializes the MAEEncoder with the specified dimensions."""
-
         super().__init__(
             seq_length=seq_length,
             num_layers=num_layers,
@@ -81,7 +80,6 @@ class MAEEncoder(vision_transformer.Encoder):
         Returns:
             A MAEEncoder with the same architecture as vit_encoder.
         """
-
         # Create a new instance with dummy values as they will be overwritten
         # by the copied vit_encoder attributes
         encoder = cls(
@@ -226,7 +224,6 @@ class MAEBackbone(vision_transformer.VisionTransformer):
         conv_stem_configs: Optional[List[ConvStemConfig]] = None,
     ):
         """Initializes the MAEBackbone with the specified dimensions."""
-
         super().__init__(
             image_size=image_size,
             patch_size=patch_size,
@@ -355,7 +352,6 @@ class MAEBackbone(vision_transformer.VisionTransformer):
             Tensor with shape (batch_size, sequence_length - 1, hidden_dim)
             containing the patch tokens.
         """
-
         x = self.conv_proj(images)
         tokens = x.flatten(2).transpose(1, 2)
         if prepend_class_token:
@@ -364,7 +360,6 @@ class MAEBackbone(vision_transformer.VisionTransformer):
 
     def _initialize_weights(self) -> None:
         """Initializes weights for the backbone components."""
-
         # Initialize the patch embedding layer like a linear layer instead of conv
         # layer.
         w = self.conv_proj.weight.data
@@ -424,7 +419,6 @@ class MAEDecoder(vision_transformer.Encoder):
         norm_layer: Callable[..., nn.Module] = partial(nn.LayerNorm, eps=1e-6),
     ):
         """Initializes the MAEDecoder with the specified dimensions."""
-
         super().__init__(
             seq_length=seq_length,
             num_layers=num_layers,
@@ -449,7 +443,6 @@ class MAEDecoder(vision_transformer.Encoder):
         Returns:
             Tensor with shape (batch_size, seq_length, out_dim).
         """
-
         out = self.embed(input)
         out = self.decode(out)
         return self.predict(out)
@@ -509,7 +502,6 @@ class MAEDecoder(vision_transformer.Encoder):
 
 def _initialize_2d_sine_cosine_positional_embedding(pos_embedding: Parameter) -> None:
     """Initializes a 2D sine-cosine positional embedding."""
-
     _, seq_length, hidden_dim = pos_embedding.shape
     grid_size = int((seq_length - 1) ** 0.5)
     sine_cosine_embedding = utils.get_2d_sine_cosine_positional_embedding(

--- a/lightly/models/modules/masked_autoencoder_timm.py
+++ b/lightly/models/modules/masked_autoencoder_timm.py
@@ -67,7 +67,6 @@ class MAEDecoderTIMM(Module):
         mask_token: Optional[Parameter] = None,
     ):
         """Initializes the MAEDecoderTIMM with the specified parameters."""
-
         super().__init__()
 
         self.decoder_embed = nn.Linear(embed_dim, decoder_embed_dim, bias=True)
@@ -116,7 +115,6 @@ class MAEDecoderTIMM(Module):
         Returns:
             Tensor with shape (batch_size, seq_length, out_dim).
         """
-
         out = self.embed(input)
         out = self.decode(out)
         return self.predict(out)
@@ -176,7 +174,6 @@ class MAEDecoderTIMM(Module):
 
     def _initialize_weights(self) -> None:
         """Initializes weights for the decoder components."""
-
         torch.nn.init.normal_(self.mask_token, std=0.02)
         utils.initialize_2d_sine_cosine_positional_embedding(
             pos_embedding=self.decoder_pos_embed, has_class_token=True

--- a/lightly/models/modules/masked_vision_transformer.py
+++ b/lightly/models/modules/masked_vision_transformer.py
@@ -8,8 +8,7 @@ from lightly.models import utils
 
 
 class MaskedVisionTransformer(ABC, Module):
-    """
-    Abstract base class for Masked Vision Transformer models.
+    """Abstract base class for Masked Vision Transformer models.
 
     Defines the interface for a Masked Vision Transformer. This class includes abstract
     methods that must be implemented by concrete subclasses to define the forward pass,

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -49,9 +49,9 @@ class MemoryBankModule(Module):
         >>>         output, negatives = super().forward(output)
         >>>
         >>>         if negatives is not None:
-        >>>             # evaluate loss with negative samples
+        >>> # evaluate loss with negative samples
         >>>         else:
-        >>>             # evaluate loss without negative samples
+        >>> # evaluate loss without negative samples
 
     """
 
@@ -121,7 +121,6 @@ class MemoryBankModule(Module):
             (num_features, dim) otherwise.
 
         """
-
         # no memory bank, return the output
         if self.size[0] == 0:
             return output, None

--- a/lightly/models/modules/memory_bank.py
+++ b/lightly/models/modules/memory_bank.py
@@ -49,9 +49,9 @@ class MemoryBankModule(Module):
         >>>         output, negatives = super().forward(output)
         >>>
         >>>         if negatives is not None:
-        >>> # evaluate loss with negative samples
+        >>>             pass  # evaluate loss with negative samples
         >>>         else:
-        >>> # evaluate loss without negative samples
+        >>>             pass  # evaluate loss without negative samples
 
     """
 

--- a/lightly/models/modules/nn_memory_bank.py
+++ b/lightly/models/modules/nn_memory_bank.py
@@ -33,7 +33,7 @@ class NNMemoryBankModule(MemoryBankModule):
         >>> model = NNCLR(backbone)
         >>> criterion = NTXentLoss(temperature=0.1)
         >>>
-        >>> nn_replacer = NNmemoryBankModule(size=(2 ** 16, 128))
+        >>> nn_replacer = NNmemoryBankModule(size=(2**16, 128))
         >>>
         >>> # forward pass
         >>> (z0, p0), (z1, p1) = model(x0, x1)
@@ -59,7 +59,6 @@ class NNMemoryBankModule(MemoryBankModule):
             update: If `True` updated the memory bank by adding output to it
 
         """
-
         output, bank = super(NNMemoryBankModule, self).forward(output, update=update)
         assert bank is not None
         bank = bank.to(output.device).t()

--- a/lightly/models/nnclr.py
+++ b/lightly/models/nnclr.py
@@ -110,7 +110,7 @@ class NNCLR(nn.Module):
         >>> model = NNCLR(backbone)
         >>> criterion = NTXentLoss(temperature=0.1)
         >>>
-        >>> nn_replacer = NNmemoryBankModule(size=2 ** 16)
+        >>> nn_replacer = NNmemoryBankModule(size=2**16)
         >>>
         >>> # forward pass
         >>> (z0, p0), (z1, p1) = model(x0, x1)

--- a/lightly/models/resnet.py
+++ b/lightly/models/resnet.py
@@ -73,7 +73,6 @@ class BasicBlock(nn.Module):
         Returns:
             Tensor of shape bsz x channels x W x H
         """
-
         out: Tensor = self.conv1(x)
         out = self.bn1(out)
         out = F.relu(out)
@@ -143,7 +142,6 @@ class Bottleneck(nn.Module):
         Returns:
             Tensor of shape bsz x channels x W x H
         """
-
         out: Tensor = self.conv1(x)
         out = self.bn1(out)
         out = F.relu(out)
@@ -273,10 +271,9 @@ def ResNetGenerator(
     Examples:
         >>> # binary classifier with ResNet-34
         >>> from lightly.models import ResNetGenerator
-        >>> resnet = ResNetGenerator('resnet-34', num_classes=2)
+        >>> resnet = ResNetGenerator("resnet-34", num_classes=2)
 
     """
-
     model_params = {
         "resnet-9": {"block": BasicBlock, "layers": [1, 1, 1, 1]},
         "resnet-18": {"block": BasicBlock, "layers": [2, 2, 2, 2]},

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -283,7 +283,6 @@ def update_momentum(model: nn.Module, model_ema: nn.Module, m: float):
         >>> update_momentum(moco, moco_momentum, m=0.999)
         >>> update_momentum(projection_head, projection_head_momentum, m=0.999)
     """
-
     model_params = list(model.parameters())
     model_ema_params = list(model_ema.parameters())
 
@@ -542,10 +541,9 @@ def patchify(images: torch.Tensor, patch_size: int) -> torch.Tensor:
 def unpatchify(
     patches: torch.Tensor, patch_size: int, channels: int = 3
 ) -> torch.Tensor:
-    """
-    Reconstructs images from their patches.
+    """Reconstructs images from their patches.
 
-     Args:
+    Args:
          patches:
              Patches tensor with shape (batch_size, num_patches, channels * patch_size ** 2).
          patch_size:
@@ -553,7 +551,7 @@ def unpatchify(
          channels:
              The number of channels the image must have
 
-     Returns:
+    Returns:
          Reconstructed images tensor with shape (batch_size, channels, height, width).
     """
     N, C = patches.shape[0], channels
@@ -708,6 +706,7 @@ def random_block_mask(
             Maximum number of attempts to find a valid block mask for an image.
         device:
             Device on which to create the mask.
+
     Returns:
         A boolean tensor with shape (batch_size, height, width) where each entry
         is True if the patch should be masked and False otherwise.
@@ -715,7 +714,6 @@ def random_block_mask(
     Raises:
         ValueError: If 'max_image_mask_ratio' is less than 'min_image_mask_ratio'.
     """
-
     if max_image_mask_ratio < min_image_mask_ratio:
         raise ValueError(
             "max_image_mask_ratio must be greater or equal to min_image_mask_ratio."
@@ -781,6 +779,7 @@ def random_block_mask_image(
             Maximum number of attempts to find a valid block mask.
         device:
             Device on which to create the mask.
+
     Returns:
         A boolean tensor with shape (height, width) where each entry is True if the
         patch should be masked and False otherwise.
@@ -789,7 +788,6 @@ def random_block_mask_image(
         ValueError: If 'max_num_masks_per_block' is less than 'min_num_masks_per_block' or
             if 'max_block_aspect_ratio' is less than 'min_block_aspect_ratio'
     """
-
     if max_block_aspect_ratio is None:
         max_block_aspect_ratio = 1 / min_block_aspect_ratio
     if max_num_masks_per_block is None:
@@ -862,7 +860,6 @@ def nearest_neighbors(
         A tuple of tensors, containing the nearest neighbors in input_maps and candidate_maps.
         They both have shape: [batch_size, input_map_size, feature_dimension]
     """
-
     if num_matches is None or num_matches == -1 or num_matches > input_maps.size(1):
         num_matches = input_maps.size(1)
 
@@ -908,6 +905,7 @@ def most_similar_index(
             Tensor with shape (B, N, C) containing the features to compare.
         y:
             Tensor with shape (B, N, C) containing the features to search for similarity.
+
     Returns:
         Index with shape (B, N) such that y[i, index[i, j]] is most similar to x[i, j]
         over all y[i, ...].
@@ -936,6 +934,7 @@ def select_most_similar(
             Tensor with shape (B, N, C).
         y_values:
             Tensor with shape (B, N, D).
+
     Returns:
         Values with shape (B, N, D) where values[i, j] is the entry in y_values[i, ...]
         such that x[i, j] is the most similar to y[i, ...].
@@ -1043,6 +1042,7 @@ def initialize_positional_embedding(
         num_prefix_tokens:
             Number of prefix tokens in the positional embedding. This includes the class
             token.
+
     Raises:
         ValueError: If an invalid strategy is provided.
     """
@@ -1113,6 +1113,7 @@ def get_2d_sine_cosine_positional_embedding(
             Height and width of the grid.
         cls_token:
             If True, a positional embedding for the class token is generated.
+
     Returns:
         Positional embedding with shape (grid_size * grid_size, embed_dim) or
         (1 + grid_size * grid_size, embed_dim) if cls_token is True.
@@ -1147,6 +1148,7 @@ def get_2d_sine_cosine_positional_embedding_from_grid(
             Embedding dimension.
         grid:
             Grid of shape (2, grid_size, grid_size) with x and y coordinates.
+
     Returns:
         Positional embedding with shape (grid_size * grid_size, embed_dim).
     """
@@ -1180,6 +1182,7 @@ def get_1d_sine_cosine_positional_embedding_from_positions(
             Embedding dimension.
         pos:
             Positions to be encoded with shape (N, M).
+
     Returns:
         Positional embedding with shape (N * M, embed_dim).
     """
@@ -1234,6 +1237,7 @@ def update_drop_path_rate(
             Drop path rate update mode. Can be "linear" or "uniform". Linear increases
             the drop path rate from 0 to drop_path_rate over the depth of the model.
             Uniform sets the drop path rate to drop_path_rate for all blocks.
+
     Raises:
         ValueError: If an unknown mode is provided.
     """
@@ -1304,7 +1308,6 @@ def apply_masks(x: Tensor, masks: Tensor | list[Tensor]) -> Tensor:
     Returns:
         Tensor of shape (B * num_masks, K, D) where K is the number of patches to keep.
     """
-
     if not isinstance(masks, list):
         masks = [masks]
 

--- a/lightly/transforms/add_grid_transform.py
+++ b/lightly/transforms/add_grid_transform.py
@@ -31,7 +31,9 @@ class AddGridTransform(Transform):  # type: ignore[misc]
         .. code-block:: python
 
             img = torch.randn((3, 16, 16))
-            bboxes = BoundingBoxes(torch.randn((1, 4)), format="XYXY", canvas_size=img.shape[-2:])
+            bboxes = BoundingBoxes(
+                torch.randn((1, 4)), format="XYXY", canvas_size=img.shape[-2:]
+            )
             mask = Mask(torch.randn((16, 16)).to(torch.int64))
             tr = AddGridTransform(num_rows=4, num_cols=4)
             # the image will be untouched the bounding boxes will be a regular grid

--- a/lightly/transforms/byol_transform.py
+++ b/lightly/transforms/byol_transform.py
@@ -56,8 +56,7 @@ class BYOLView1Transform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:
@@ -116,8 +115,7 @@ class BYOLView2Transform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -252,8 +252,7 @@ class DINOViewTransform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/fda_transform.py
+++ b/lightly/transforms/fda_transform.py
@@ -105,8 +105,7 @@ class FDAView1Transform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:
@@ -206,8 +205,7 @@ class FDAView2Transform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/ibot_transform.py
+++ b/lightly/transforms/ibot_transform.py
@@ -224,8 +224,7 @@ class IBOTViewTransform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/image_grid_transform.py
+++ b/lightly/transforms/image_grid_transform.py
@@ -41,7 +41,7 @@ class ImageGridTransform:
                     [3, global_crop_size, global_crop_size],
                     [3, local_crop_size, local_crop_size],
                     [global_grid_size, global_grid_size, 2],
-                    [local_grid_size, local_grid_size, 2]
+                    [local_grid_size, local_grid_size, 2],
                 ]
 
         """

--- a/lightly/transforms/irfft2d_transform.py
+++ b/lightly/transforms/irfft2d_transform.py
@@ -18,9 +18,8 @@ class IRFFT2DTransform:
     """
 
     def __init__(self, shape: Tuple[int, int]):
-        """
-        Args:
-            shape: The desired output shape (H, W) after applying the inverse FFT
+        """Args:
+        shape: The desired output shape (H, W) after applying the inverse FFT
         """
         self.shape = shape
 

--- a/lightly/transforms/irfft2d_transform.py
+++ b/lightly/transforms/irfft2d_transform.py
@@ -18,8 +18,10 @@ class IRFFT2DTransform:
     """
 
     def __init__(self, shape: Tuple[int, int]):
-        """Args:
-        shape: The desired output shape (H, W) after applying the inverse FFT
+        """Initialize the transform with the desired output shape.
+
+        Args:
+            shape: The desired output shape (H, W) after applying the inverse FFT.
         """
         self.shape = shape
 

--- a/lightly/transforms/jigsaw.py
+++ b/lightly/transforms/jigsaw.py
@@ -35,7 +35,9 @@ class Jigsaw(object):
     Examples:
         >>> from lightly.transforms import Jigsaw
         >>>
-        >>> jigsaw_crop = Jigsaw(n_grid=3, img_size=255, crop_size=64, transform=T.ToTensor())
+        >>> jigsaw_crop = Jigsaw(
+        ...     n_grid=3, img_size=255, crop_size=64, transform=T.ToTensor()
+        ... )
         >>>
         >>> # img is a PIL image
         >>> crops = jigsaw_crops(img)

--- a/lightly/transforms/mae_transform.py
+++ b/lightly/transforms/mae_transform.py
@@ -51,8 +51,7 @@ class MAETransform:
         self.transform = T.Compose(transforms)
 
     def __call__(self, image: Union[Tensor, Image]) -> List[Tensor]:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/msn_transform.py
+++ b/lightly/transforms/msn_transform.py
@@ -172,8 +172,7 @@ class MSNViewTransform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/random_crop_and_flip_with_grid.py
+++ b/lightly/transforms/random_crop_and_flip_with_grid.py
@@ -30,15 +30,12 @@ class Location:
 
 
 class RandomResizedCropWithLocation(T.RandomResizedCrop):  # type: ignore[misc] # Class cannot subclass "RandomResizedCrop" (has type "Any")
-    """
-    Do a random resized crop and return both the resulting image and the location. See base class.
-
-    """
+    """Do a random resized crop and return both the resulting image and the location. See base class."""
 
     def forward(self, img: Image.Image) -> Tuple[Image.Image, Location]:
-        """
-        Args:
+        """Args:
             img (PIL Image or Tensor): Image to be cropped.
+
         Returns:
             PIL Image or Tensor: Randomly cropped image
             Location: Location object containing crop parameters
@@ -78,7 +75,6 @@ class RandomHorizontalFlipWithLocation(T.RandomHorizontalFlip):  # type: ignore[
             PIL Image or Tensor: Randomly flipped image
             Location: Location object with updated location.horizontal_flip parameter
         """
-
         if torch.rand(1) < self.p:
             img = F.hflip(img)
             location.horizontal_flip = True
@@ -103,7 +99,6 @@ class RandomVerticalFlipWithLocation(T.RandomVerticalFlip):  # type: ignore[misc
             PIL Image or Tensor: Randomly flipped image
             Location: Location object with updated location.vertical_flip parameter
         """
-
         if torch.rand(1) < self.p:
             img = F.vflip(img)
             location.vertical_flip = True
@@ -165,7 +160,6 @@ class RandomResizedCropAndFlip(nn.Module):  # type: ignore[misc] # Class cannot 
         Returns:
             A tuple containing the transformed PIL image and the grid tensor.
         """
-
         img, location = self.resized_crop.forward(img=img)
         img, location = self.horizontal_flip.forward(img, location)
         img, location = self.vertical_flip.forward(img, location)
@@ -188,7 +182,6 @@ class RandomResizedCropAndFlip(nn.Module):  # type: ignore[misc] # Class cannot 
             A grid tensor of shape (grid_size, grid_size, 2), where the last dimension represents the (x, y) coordinate
             of the center of each cell in the original image space.
         """
-
         cell_width = location.width / self.grid_size
         cell_height = location.height / self.grid_size
         x = torch.linspace(

--- a/lightly/transforms/random_crop_and_flip_with_grid.py
+++ b/lightly/transforms/random_crop_and_flip_with_grid.py
@@ -33,7 +33,9 @@ class RandomResizedCropWithLocation(T.RandomResizedCrop):  # type: ignore[misc] 
     """Do a random resized crop and return both the resulting image and the location. See base class."""
 
     def forward(self, img: Image.Image) -> Tuple[Image.Image, Location]:
-        """Args:
+        """Apply a random resized crop and return the cropped image with its location.
+
+        Args:
             img (PIL Image or Tensor): Image to be cropped.
 
         Returns:

--- a/lightly/transforms/rfft2d_transform.py
+++ b/lightly/transforms/rfft2d_transform.py
@@ -26,6 +26,5 @@ class RFFT2DTransform:
         Returns:
             Tensor: The image in the frequency domain after applying RFFT2D, of shape (C, H, W).
         """
-
         rfft_image: Tensor = torch.fft.rfft2(image)
         return rfft_image

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -169,8 +169,7 @@ class SimCLRViewTransform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/simsiam_transform.py
+++ b/lightly/transforms/simsiam_transform.py
@@ -158,8 +158,7 @@ class SimSiamViewTransform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/smog_transform.py
+++ b/lightly/transforms/smog_transform.py
@@ -164,8 +164,7 @@ class SmoGViewTransform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/swav_transform.py
+++ b/lightly/transforms/swav_transform.py
@@ -167,8 +167,7 @@ class SwaVViewTransform:
         self.transform = T.Compose(transforms)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/transforms/vicreg_transform.py
+++ b/lightly/transforms/vicreg_transform.py
@@ -167,8 +167,7 @@ class VICRegViewTransform:
         self.transform = T.Compose(transform)
 
     def __call__(self, image: Union[Tensor, Image]) -> Tensor:
-        """
-        Applies the transforms to the input image.
+        """Applies the transforms to the input image.
 
         Args:
             image:

--- a/lightly/utils/benchmarking/knn_classifier.py
+++ b/lightly/utils/benchmarking/knn_classifier.py
@@ -66,7 +66,7 @@ class KNNClassifier(LightningModule):
             >>>         self.projection_head = SimCLRProjectionHead(512, 512, 128)
             >>>
             >>>     def forward(self, x):
-            >>>         # Forward must return image features.
+            >>> # Forward must return image features.
             >>>         features = self.backbone(x).flatten(start_dim=1)
             >>>         return features
             >>>

--- a/lightly/utils/benchmarking/knn_classifier.py
+++ b/lightly/utils/benchmarking/knn_classifier.py
@@ -66,8 +66,7 @@ class KNNClassifier(LightningModule):
             >>>         self.projection_head = SimCLRProjectionHead(512, 512, 128)
             >>>
             >>>     def forward(self, x):
-            >>> # Forward must return image features.
-            >>>         features = self.backbone(x).flatten(start_dim=1)
+            >>>         features = self.backbone(x).flatten(start_dim=1)  # Forward must return image features.
             >>>         return features
             >>>
             >>> # Initialize a model.

--- a/lightly/utils/benchmarking/linear_classifier.py
+++ b/lightly/utils/benchmarking/linear_classifier.py
@@ -41,7 +41,6 @@ class BaseClassifier(LightningModule, ABC):
                 Tuple of integers defining the top-k accuracy metrics to compute.
 
         Examples:
-
             >>> from pytorch_lightning import Trainer
             >>> from torch import nn
             >>> import torchvision
@@ -56,7 +55,7 @@ class BaseClassifier(LightningModule, ABC):
             >>>         self.projection_head = SimCLRProjectionHead(512, 512, 128)
             >>>
             >>>     def forward(self, x):
-            >>>         # Forward must return image features.
+            >>> # Forward must return image features.
             >>>         features = self.backbone(x).flatten(start_dim=1)
             >>>         return features
             >>>

--- a/lightly/utils/benchmarking/linear_classifier.py
+++ b/lightly/utils/benchmarking/linear_classifier.py
@@ -55,8 +55,7 @@ class BaseClassifier(LightningModule, ABC):
             >>>         self.projection_head = SimCLRProjectionHead(512, 512, 128)
             >>>
             >>>     def forward(self, x):
-            >>> # Forward must return image features.
-            >>>         features = self.backbone(x).flatten(start_dim=1)
+            >>>         features = self.backbone(x).flatten(start_dim=1)  # Forward must return image features.
             >>>         return features
             >>>
             >>> # Initialize a model.

--- a/lightly/utils/bounding_box.py
+++ b/lightly/utils/bounding_box.py
@@ -29,7 +29,7 @@ class BoundingBox:
         >>> # often the coordinates are not yet normalized by image size
         >>> # for example, for a 100 x 100 image, the coordinates could be
         >>> # (x0, y0, x1, y1) = (10, 20, 30, 40)
-        >>> W, H = 100, 100 # get image shape
+        >>> W, H = 100, 100  # get image shape
         >>> bbox = BoundingBox(10 / W, 20 / H, 30 / W, 40 / H)
     """
 

--- a/lightly/utils/io.py
+++ b/lightly/utils/io.py
@@ -127,7 +127,6 @@ def save_embeddings(
         >>>     labels,
         >>>     filenames)
     """
-
     n_embeddings = len(embeddings)
     n_filenames = len(filenames)
     n_labels = len(labels)

--- a/lightly/utils/reordering.py
+++ b/lightly/utils/reordering.py
@@ -22,7 +22,7 @@ def sort_items_by_keys(
 
     Examples:
         >>> keys = [3, 2, 1]
-        >>> items = ['!', 'world', 'hello']
+        >>> items = ["!", "world", "hello"]
         >>> sorted_keys = [1, 2, 3]
         >>> sorted_items = sort_items_by_keys(
         >>>     keys,

--- a/lightly/utils/scheduler.py
+++ b/lightly/utils/scheduler.py
@@ -100,6 +100,7 @@ def cosine_warmup_schedule(
             The number of steps over which the cosine function completes a full cycle.
             If no period is provided, the scheduler will complete a half cycle over
             max_steps - warmup_steps.
+
     Returns:
         Cosine decay value.
     """

--- a/lightly/utils/version_compare.py
+++ b/lightly/utils/version_compare.py
@@ -11,9 +11,8 @@ def version_compare(v0: str, v1: str) -> int:
     newer.
 
     Examples:
-
         >>> # compare two versions
-        >>> version_compare('1.2.0', '1.1.2')
+        >>> version_compare("1.2.0", "1.1.2")
         >>> 1
     """
     v0_parsed = [int(n) for n in v0.split(".")][::-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,13 +138,32 @@ target-version = "py37"
 extend-exclude = ["lightly/openapi_generated"]
 
 [tool.ruff.lint]
-select = ["I"]
+select = ["I", "D202", "D209", "D212", "D214", "D410", "D411", "D412"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["lightly"]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+# Deprecated paths (mirrors pyproject.toml's mypy excludes for deprecated code).
+"lightly/active_learning/**" = ["D"]
+"lightly/models/simclr.py" = ["D"]
+"lightly/models/moco.py" = ["D"]
+"lightly/models/barlowtwins.py" = ["D"]
+"lightly/models/nnclr.py" = ["D"]
+"lightly/models/simsiam.py" = ["D"]
+"lightly/models/byol.py" = ["D"]
+"tests/models/test_ModelsSimSiam.py" = ["D"]
+"tests/models/test_ModelsSimCLR.py" = ["D"]
+"tests/models/test_ModelsNNCLR.py" = ["D"]
+"tests/models/test_ModelsMoCo.py" = ["D"]
+"tests/models/test_ModelsBYOL.py" = ["D"]
+
 [tool.ruff.format]
+docstring-code-format = true
 
 [tool.coverage.run]
 omit = ["lightly/openapi_generated/*"]

--- a/tests/loss/test_dcl_loss.py
+++ b/tests/loss/test_dcl_loss.py
@@ -108,9 +108,7 @@ class TestDCLLoss:
     def test_dclloss_matches_reference(
         self, batch_size: int, dim: int, temperature: float, seed: int = 0
     ) -> None:
-        """
-        Ensure patched DCLLoss matches loop-based reference for multiple configs.
-        """
+        """Ensure patched DCLLoss matches loop-based reference for multiple configs."""
         torch.manual_seed(seed)
         out0 = torch.randn(batch_size, dim)
         out1 = torch.randn(batch_size, dim)
@@ -127,9 +125,8 @@ class TestDCLLoss:
 def dcl_reference(
     x1: torch.Tensor, x2: torch.Tensor, temperature: float
 ) -> torch.Tensor:
-    """
-    Loop-based reference:
-      L = avg_i[ -sim_pos(i) + log(sum_j exp(sim_neg(i,j))) ]
+    """Loop-based reference:
+    L = avg_i[ -sim_pos(i) + log(sum_j exp(sim_neg(i,j))) ]
     """
     z1 = torch.nn.functional.normalize(x1, dim=1)
     z2 = torch.nn.functional.normalize(x2, dim=1)

--- a/tests/loss/test_dcl_loss.py
+++ b/tests/loss/test_dcl_loss.py
@@ -125,8 +125,10 @@ class TestDCLLoss:
 def dcl_reference(
     x1: torch.Tensor, x2: torch.Tensor, temperature: float
 ) -> torch.Tensor:
-    """Loop-based reference:
-    L = avg_i[ -sim_pos(i) + log(sum_j exp(sim_neg(i,j))) ]
+    """Compute DCL loss with a Python loop as a reference implementation.
+
+    Loop-based reference:
+      L = avg_i[ -sim_pos(i) + log(sum_j exp(sim_neg(i,j))) ]
     """
     z1 = torch.nn.functional.normalize(x1, dim=1)
     z2 = torch.nn.functional.normalize(x2, dim=1)

--- a/tests/loss/test_dino_loss.py
+++ b/tests/loss/test_dino_loss.py
@@ -54,9 +54,7 @@ class OriginalDINOLoss(nn.Module):
 
     @typing.no_type_check
     def forward(self, student_output, teacher_output, epoch):
-        """
-        Cross-entropy between softmax outputs of the teacher and student networks.
-        """
+        """Cross-entropy between softmax outputs of the teacher and student networks."""
         student_out = student_output / self.student_temp
         student_out = student_out.chunk(self.ncrops)
 
@@ -83,9 +81,7 @@ class OriginalDINOLoss(nn.Module):
     @typing.no_type_check
     @torch.no_grad()
     def update_center(self, teacher_output):
-        """
-        Update center used for teacher output.
-        """
+        """Update center used for teacher output."""
         batch_center = torch.sum(teacher_output, dim=0, keepdim=True)
         batch_center = batch_center / len(teacher_output)
         # ema update

--- a/tests/loss/test_macl_loss.py
+++ b/tests/loss/test_macl_loss.py
@@ -30,7 +30,6 @@ def _cal_macl_loss_original(
     Returns:
         The loss value.
     """
-
     A = torch.mean(pos.detach())
     tau = tau_0 * (1.0 + alpha * (A - A0))
 

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -606,7 +606,8 @@ def test_random_block_mask_image__aspect_ratio(
 
 def test_random_block_mask_image__aspect_ratio_one() -> None:
     """With aspect ratio 1.0 and num_mask=min_num_masks_per_block we expect a single,
-    square masked block."""
+    square masked block.
+    """
     mask = utils.random_block_mask_image(
         size=(14, 14),
         num_masks=9,

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -6,14 +6,16 @@ import toml
 
 def test_requirements_base__pyproject() -> None:
     """Check that all dependencies in requirements/base.txt are also in
-    pyproject.toml."""
+    pyproject.toml.
+    """
     missing_deps = _requirements("base") - _pyproject("dependencies")
     assert not missing_deps
 
 
 def test_requirements_base__openapi() -> None:
     """Check that all dependencies in requirements/openapi.txt are also in
-    requirements/base.txt."""
+    requirements/base.txt.
+    """
     openapi = {
         dep for dep in _requirements("openapi") if not dep.startswith("setuptools")
     }

--- a/tests/utils/test_dist__gather__benchmark_module.py
+++ b/tests/utils/test_dist__gather__benchmark_module.py
@@ -41,8 +41,7 @@ def close_torch_distributed() -> Generator[None, None, None]:
     reason="This test is running in parallel and breaks codecov",
 )
 class TestGatherLayerBenchmarkModule:
-    """
-    Tests that the gather layer works as expected.
+    """Tests that the gather layer works as expected.
 
     Because using a DDPStrategy causes the whole script to be executed multiple
     times, running a proper test is difficult. The approach used here:

--- a/tests/utils/test_dist__gather__losses.py
+++ b/tests/utils/test_dist__gather__losses.py
@@ -67,8 +67,7 @@ def close_torch_distributed() -> Generator[None, None, None]:
     reason="This test is running in parallel and breaks codecov",
 )
 class TestGatherLayer_Losses:
-    """
-    Tests that the gather layer works as expected.
+    """Tests that the gather layer works as expected.
 
     Because using a DDPStrategy causes the whole script to be executed multiple
     times, running a proper test is difficult. The approach used here:


### PR DESCRIPTION
## Summary

Adopts `ruff`'s pydocstyle plugin to verify Google-style docstrings as part of the existing toolchain. Scoped to tooling only, not docstring content cleanup as per [discussion in this thread](https://github.com/lightly-ai/lightly/issues/1217#issuecomment-4280774122).

Closes #1217

## What's enabled

| Surface | Behaviour |
|---|---|
| `[tool.ruff.lint] select` | extends to seven safely auto-fixable D rules: `D202, D209, D212, D214, D410, D411, D412` |
| `[tool.ruff.lint.pydocstyle]` | `convention = "google"` (applies the standard Google-convention exclusions) |
| `[tool.ruff.lint.per-file-ignores]` | mirrors the explicitly-deprecated paths from `[tool.mypy] exclude` |
| `[tool.ruff.format]` | `docstring-code-format = true`, normalizes Python code blocks inside docstrings |
| `.pre-commit-config.yaml` | drops `--select I` from `ruff-check` so the new D rules trigger locally |
| `CONTRIBUTING.md` | one-line note that docstrings follow the Google convention and are checked by ruff |

The selected D rules are exactly those marked `[*]` (safely auto-fixable) by `ruff check --select D --statistics` under Google convention. Manual-fix and unsafe-fix D rules (`D100-D107` undocumented-*, `D205, D401, D415, ...`) are unselected.

## Commit structure: tooling changes vs formatting normalization

Three commits, designed so the second can be skipped during review:

1. Commit 1 (config + docs): `pyproject.toml`, `.pre-commit-config.yaml`, `CONTRIBUTING.md`. Small, easy to review manually.
2. Commit 2: One-time normalisation (101 files). Pure tool output from `ruff check --fix` and `ruff format` on top of commit 1, no manual edits.
3. Commit 3: `git-blame-ignore-revs` so git blame skips the formatting commit (per @guarin's [suggestion](https://github.com/lightly-ai/lightly/issues/1564#issuecomment-4224799936))
## Notes for reviewers

- `per-file-ignores` mirrors only the explicitly deprecated portions of `[tool.mypy] exclude` (the three sub-lists with "deprecated" in their header comments). The provisionally-untyped portion (`# TODO: Remove these one by one`) is not mirrored, since the selected D rules are auto-fixable and impose no manual effort.
- Two deprecated files appear in commit 2's diff (`lightly/active_learning/config/selection_config.py`, `lightly/models/nnclr.py`). These come from `docstring-code-format = true` reformatting Python inside `>>>` blocks, not from D rules. `per-file-ignores` excludes those paths from D rule lint, not from formatter normalization. Matches #1914's accepted behaviour of running `ruff format` on all files.

## Developer note

After pulling this change, run:

```bash
pre-commit clean
pre-commit install
```

to pick up the widened pre-commit hook (D rules now run on commit, not just `make format-check`).
