### PR TITLE
Add random block wise mask from Pixio

### DIFF
--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -614,6 +614,121 @@ def random_token_mask(
     return idx_keep, idx_mask
 
 
+def random_block_wise_mask(
+    size: Tuple[int, int],
+    mask_ratio: float = 0.75,
+    block_size: int = 2,
+    mask_class_token: bool = False,
+    device: Optional[Union[torch.device, str]] = None,
+) -> Tuple[Tensor, Tensor]:
+    """Creates random block-wise masks for tokens.
+
+    This function masks patches in groups (blocks) rather than individually.
+    It is particularly useful for image patch masking where spatial coherence
+    is desired. The sequence is reshaped into a 2D grid, patches are grouped
+    into blocks, and entire blocks are randomly selected for masking.
+
+    Based on the block-wise masking approach from Pixio's MAE implementation
+    (https://github.com/pixiu-ai/pixiu).
+
+    Args:
+        size:
+            Size of the token batch for which to generate masks.
+            Should be (batch_size, sequence_length).
+        mask_ratio:
+            Proportion of tokens to mask.
+        block_size:
+            Size of the blocks. The sequence is reshaped into a square grid,
+            and this parameter determines the block dimensions. For example,
+            block_size=2 groups patches into 2x2 blocks. Must divide the
+            grid size evenly.
+        mask_class_token:
+            If False the class token (index 0) is never masked. If True the
+            class token might be masked.
+        device:
+            Device on which to create the index masks.
+
+    Returns:
+        A (index_keep, index_mask) tuple where each index is a tensor.
+        index_keep contains the indices of the unmasked tokens and has shape
+        (batch_size, num_keep). index_mask contains the indices of the masked
+        tokens and has shape (batch_size, sequence_length - num_keep).
+
+    Raises:
+        ValueError: If the sequence length (minus prefix tokens) cannot form
+            a square grid or if the block_size does not divide the grid evenly.
+    """
+    batch_size, sequence_length = size
+    num_prefix_tokens = 0 if mask_class_token else 1
+    num_patches = sequence_length - num_prefix_tokens
+
+    if num_patches <= 0:
+        raise ValueError(
+            "Sequence length must be greater than prefix tokens (1 if not masking class token)."
+        )
+
+    grid_size = int(math.sqrt(num_patches))
+
+    if grid_size * grid_size != num_patches:
+        raise ValueError(
+            f"Sequence length minus prefix tokens ({num_patches}) must be a perfect square "
+            f"to form a square grid. Got sequence_length={sequence_length}."
+        )
+
+    if grid_size % block_size != 0:
+        raise ValueError(
+            f"Block size ({block_size}) must divide the grid size ({grid_size}) evenly."
+        )
+
+    num_blocks_per_dim = grid_size // block_size
+    num_blocks = num_blocks_per_dim * num_blocks_per_dim
+    num_blocks_keep = int(num_blocks * (1 - mask_ratio))
+
+    noise = torch.rand(batch_size, num_blocks, device=device)
+
+    if not mask_class_token:
+        noise[:, 0] = -1
+
+    block_indices = torch.argsort(noise, dim=1)
+    blocks_keep = block_indices[:, :num_blocks_keep]
+
+    block_rows = blocks_keep // num_blocks_per_dim
+    block_cols = blocks_keep % num_blocks_per_dim
+
+    patch_offsets = torch.arange(block_size * block_size, device=device)
+    patch_offset_rows = patch_offsets // block_size
+    patch_offset_cols = patch_offsets % block_size
+
+    block_rows_expanded = block_rows.unsqueeze(-1).expand(
+        -1, -1, block_size * block_size
+    ) * block_size + patch_offset_rows.unsqueeze(0).unsqueeze(0)
+    block_cols_expanded = block_cols.unsqueeze(-1).expand(
+        -1, -1, block_size * block_size
+    ) * block_size + patch_offset_cols.unsqueeze(0).unsqueeze(0)
+
+    patch_rows_flat = block_rows_expanded.flatten(1)
+    patch_cols_flat = block_cols_expanded.flatten(1)
+
+    patch_indices = patch_rows_flat * grid_size + patch_cols_flat
+
+    if not mask_class_token:
+        patch_indices = patch_indices + 1
+        prefix_token = torch.zeros(batch_size, 1, dtype=torch.long, device=device)
+        idx_keep = torch.cat([prefix_token, patch_indices], dim=1)
+        idx_keep = torch.sort(torch.unique(idx_keep, dim=1), dim=1)[0]
+    else:
+        idx_keep = patch_indices
+
+    all_indices = torch.arange(sequence_length, device=device).expand(
+        batch_size, sequence_length
+    )
+    mask_mask = torch.ones(batch_size, sequence_length, dtype=torch.bool, device=device)
+    mask_mask.scatter_(1, idx_keep, False)
+    idx_mask = all_indices[mask_mask].reshape(batch_size, -1)
+
+    return idx_keep, idx_mask
+
+
 def random_prefix_mask(
     size: Tuple[int, int],
     max_prefix_length: int,

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -635,6 +635,7 @@ def random_block_wise_mask(
         size:
             Size of the token batch for which to generate masks.
             Should be (batch_size, sequence_length).
+            sequence_length should be a perfect square.
         mask_ratio:
             Proportion of tokens to mask.
         block_size:

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -618,7 +618,7 @@ def random_block_wise_mask(
     size: Tuple[int, int],
     mask_ratio: float = 0.75,
     block_size: int = 2,
-    mask_class_token: bool = False,
+    num_prefix_tokens: int = 1,
     device: Optional[Union[torch.device, str]] = None,
 ) -> Tuple[Tensor, Tensor]:
     """Creates random block-wise masks for tokens.
@@ -642,9 +642,9 @@ def random_block_wise_mask(
             and this parameter determines the block dimensions. For example,
             block_size=2 groups patches into 2x2 blocks. Must divide the
             grid size evenly.
-        mask_class_token:
-            If False the class token (index 0) is never masked. If True the
-            class token might be masked.
+        num_prefix_tokens:
+            Number of prefix tokens (CLS/REG) at sequence start protected from
+            masking. These tokens are prepended to the sequence after masking.
         device:
             Device on which to create the index masks.
 
@@ -659,7 +659,6 @@ def random_block_wise_mask(
             a square grid or if the block_size does not divide the grid evenly.
     """
     batch_size, sequence_length = size
-    num_prefix_tokens = 0 if mask_class_token else 1
     num_patches = sequence_length - num_prefix_tokens
 
     if num_patches <= 0:
@@ -686,7 +685,7 @@ def random_block_wise_mask(
 
     noise = torch.rand(batch_size, num_blocks, device=device)
 
-    if not mask_class_token:
+    if num_prefix_tokens > 0:
         noise[:, 0] = -1
 
     block_indices = torch.argsort(noise, dim=1)
@@ -711,10 +710,14 @@ def random_block_wise_mask(
 
     patch_indices = patch_rows_flat * grid_size + patch_cols_flat
 
-    if not mask_class_token:
-        patch_indices = patch_indices + 1
-        prefix_token = torch.zeros(batch_size, 1, dtype=torch.long, device=device)
-        idx_keep = torch.cat([prefix_token, patch_indices], dim=1)
+    if num_prefix_tokens > 0:
+        patch_indices = patch_indices + num_prefix_tokens
+        prefix_indices = (
+            torch.arange(num_prefix_tokens, device=device)
+            .unsqueeze(0)
+            .expand(batch_size, -1)
+        )
+        idx_keep = torch.cat([prefix_indices, patch_indices], dim=1)
         idx_keep = torch.sort(torch.unique(idx_keep, dim=1), dim=1)[0]
     else:
         idx_keep = patch_indices

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -629,7 +629,7 @@ def random_block_wise_mask(
     into blocks, and entire blocks are randomly selected for masking.
 
     Based on the block-wise masking approach from Pixio's MAE implementation
-    (https://github.com/pixiu-ai/pixiu).
+    (https://github.com/facebookresearch/pixio).
 
     Args:
         size:

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -635,7 +635,9 @@ def random_block_wise_mask(
         size:
             Size of the token batch for which to generate masks.
             Should be (batch_size, sequence_length).
-            sequence_length should be a perfect square.
+            The non-prefix portion of the sequence,
+            (sequence_length - num_prefix_tokens), should be a perfect
+            square. Prefix tokens are excluded from the square grid.
         mask_ratio:
             Proportion of tokens to mask.
         block_size:

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -987,7 +987,8 @@ class TestRandomBlockWiseMask:
         expected = torch.arange(seq_length).unsqueeze(0).expand(batch_size, -1)
         assert torch.equal(sorted_combined, expected)
 
-    def test_mask_class_token_false(self) -> None:
+    def test_num_prefix_tokens_one(self) -> None:
+        """Test with default num_prefix_tokens=1 (CLS token protected)."""
         torch.manual_seed(42)
         batch_size, seq_length = 4, 65
 
@@ -995,24 +996,43 @@ class TestRandomBlockWiseMask:
             idx_keep, idx_mask = random_block_wise_mask(
                 size=(batch_size, seq_length),
                 mask_ratio=0.75,
-                mask_class_token=False,
+                num_prefix_tokens=1,
             )
             assert torch.all(idx_keep[:, 0] == 0)
             assert not torch.any(idx_mask == 0)
 
-    def test_mask_class_token_true(self) -> None:
+    def test_num_prefix_tokens_zero(self) -> None:
+        """Test with num_prefix_tokens=0 (no prefix token protected)."""
         torch.manual_seed(42)
         batch_size, seq_length = 4, 64
         idx_keep, idx_mask = random_block_wise_mask(
             size=(batch_size, seq_length),
             mask_ratio=0.5,
-            mask_class_token=True,
+            num_prefix_tokens=0,
         )
 
         combined = torch.cat([idx_keep, idx_mask], dim=1)
         sorted_combined = torch.sort(combined, dim=1)[0]
         expected = torch.arange(seq_length).unsqueeze(0).expand(batch_size, -1)
         assert torch.equal(sorted_combined, expected)
+
+    def test_num_prefix_tokens_four(self) -> None:
+        """Test with num_prefix_tokens=4 (multiple regtokens protected)."""
+        torch.manual_seed(42)
+        batch_size, seq_length = 4, 68  # 4 prefix tokens + 64 patches
+
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.75,
+            num_prefix_tokens=4,
+        )
+
+        # First 4 indices should always be in keep
+        assert torch.all(idx_keep[:, :4] == torch.arange(4, device=idx_keep.device))
+        # These indices should never be masked
+        assert not torch.any(idx_mask < 4)
+        # Total length should match
+        assert idx_keep.shape[1] + idx_mask.shape[1] == seq_length
 
     def test_block_alignment(self) -> None:
         torch.manual_seed(42)
@@ -1022,7 +1042,7 @@ class TestRandomBlockWiseMask:
             size=(batch_size, seq_length),
             mask_ratio=0.75,
             block_size=2,
-            mask_class_token=False,
+            num_prefix_tokens=1,
         )
 
         # 16 blocks (8x8 / 2x2), keep 4 blocks = 16 patches + 1 cls = 17
@@ -1037,7 +1057,7 @@ class TestRandomBlockWiseMask:
                 size=(batch_size, seq_length),
                 mask_ratio=mask_ratio,
                 block_size=2,
-                mask_class_token=False,
+                num_prefix_tokens=1,
             )
 
             assert idx_keep.shape[1] + idx_mask.shape[1] == seq_length
@@ -1052,7 +1072,7 @@ class TestRandomBlockWiseMask:
                 size=(batch_size, seq_length),
                 mask_ratio=0.75,
                 block_size=block_size,
-                mask_class_token=False,
+                num_prefix_tokens=1,
             )
 
             assert idx_keep.shape[1] + idx_mask.shape[1] == seq_length
@@ -1087,11 +1107,11 @@ class TestRandomBlockWiseMask:
 
     def test_non_square_sequence_error(self) -> None:
         with pytest.raises(ValueError, match="must be a perfect square"):
-            random_block_wise_mask(size=(2, 51), mask_class_token=False)
+            random_block_wise_mask(size=(2, 51), num_prefix_tokens=1)
 
     def test_invalid_block_size_error(self) -> None:
         with pytest.raises(ValueError, match="must divide the grid size"):
-            random_block_wise_mask(size=(2, 257), block_size=3, mask_class_token=False)
+            random_block_wise_mask(size=(2, 257), block_size=3, num_prefix_tokens=1)
 
     def test_single_batch_element(self) -> None:
         torch.manual_seed(42)
@@ -1113,7 +1133,7 @@ class TestRandomBlockWiseMask:
             size=(batch_size, seq_length),
             mask_ratio=0.75,
             block_size=4,
-            mask_class_token=False,
+            num_prefix_tokens=1,
         )
 
         # 16x16 grid / 4x4 blocks = 4x4=16 blocks, keep 4 blocks = 64 patches + 1 cls
@@ -1128,7 +1148,7 @@ class TestRandomBlockWiseMask:
             size=(batch_size, seq_length),
             mask_ratio=0.75,
             block_size=2,
-            mask_class_token=True,
+            num_prefix_tokens=0,
         )
 
         # 16 blocks, keep 4 blocks = 16 patches

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -24,6 +24,7 @@ from lightly.models.utils import (
     nearest_neighbors,
     normalize_weight,
     pool_masked,
+    random_block_wise_mask,
     update_momentum,
 )
 
@@ -967,3 +968,197 @@ def test_update_drop_path_rate__unknown_mode() -> None:
     model = VisionTransformer(drop_path_rate=0, depth=4)
     with pytest.raises(ValueError, match="Unknown mode"):
         utils.update_drop_path_rate(model=model, drop_path_rate=0.1, mode="unknown")
+
+
+class TestRandomBlockWiseMask:
+    def test_basic_functionality(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 65
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length), mask_ratio=0.75
+        )
+
+        assert idx_keep.shape[0] == batch_size
+        assert idx_mask.shape[0] == batch_size
+        assert idx_keep.shape[1] + idx_mask.shape[1] == seq_length
+
+        combined = torch.cat([idx_keep, idx_mask], dim=1)
+        sorted_combined = torch.sort(combined, dim=1)[0]
+        expected = torch.arange(seq_length).unsqueeze(0).expand(batch_size, -1)
+        assert torch.equal(sorted_combined, expected)
+
+    def test_mask_class_token_false(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 4, 65
+
+        for _ in range(10):
+            idx_keep, idx_mask = random_block_wise_mask(
+                size=(batch_size, seq_length),
+                mask_ratio=0.75,
+                mask_class_token=False,
+            )
+            assert torch.all(idx_keep[:, 0] == 0)
+            assert not torch.any(idx_mask == 0)
+
+    def test_mask_class_token_true(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 4, 64
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.5,
+            mask_class_token=True,
+        )
+
+        combined = torch.cat([idx_keep, idx_mask], dim=1)
+        sorted_combined = torch.sort(combined, dim=1)[0]
+        expected = torch.arange(seq_length).unsqueeze(0).expand(batch_size, -1)
+        assert torch.equal(sorted_combined, expected)
+
+    def test_block_alignment(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 65
+
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.75,
+            block_size=2,
+            mask_class_token=False,
+        )
+
+        # 16 blocks (8x8 / 2x2), keep 4 blocks = 16 patches + 1 cls = 17
+        assert idx_keep.shape[1] == 17
+
+    def test_different_mask_ratios(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 65
+
+        for mask_ratio in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            idx_keep, idx_mask = random_block_wise_mask(
+                size=(batch_size, seq_length),
+                mask_ratio=mask_ratio,
+                block_size=2,
+                mask_class_token=False,
+            )
+
+            assert idx_keep.shape[1] + idx_mask.shape[1] == seq_length
+            assert idx_keep.shape[1] >= 1
+
+    def test_different_block_sizes(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 257
+
+        for block_size in [2, 4, 8]:
+            idx_keep, idx_mask = random_block_wise_mask(
+                size=(batch_size, seq_length),
+                mask_ratio=0.75,
+                block_size=block_size,
+                mask_class_token=False,
+            )
+
+            assert idx_keep.shape[1] + idx_mask.shape[1] == seq_length
+            assert torch.all(idx_keep[:, 0] == 0)
+
+    def test_device_handling(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 65
+
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.75,
+            device="cpu",
+        )
+
+        assert idx_keep.device.type == "cpu"
+        assert idx_mask.device.type == "cpu"
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
+    def test_cuda_device(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 65
+
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.75,
+            device="cuda",
+        )
+
+        assert idx_keep.device.type == "cuda"
+        assert idx_mask.device.type == "cuda"
+
+    def test_non_square_sequence_error(self) -> None:
+        with pytest.raises(ValueError, match="must be a perfect square"):
+            random_block_wise_mask(size=(2, 51), mask_class_token=False)
+
+    def test_invalid_block_size_error(self) -> None:
+        with pytest.raises(ValueError, match="must divide the grid size"):
+            random_block_wise_mask(size=(2, 257), block_size=3, mask_class_token=False)
+
+    def test_single_batch_element(self) -> None:
+        torch.manual_seed(42)
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(1, 65),
+            mask_ratio=0.75,
+            block_size=2,
+        )
+
+        assert idx_keep.shape == (1, idx_keep.shape[1])
+        assert idx_mask.shape == (1, idx_mask.shape[1])
+        assert idx_keep.shape[1] + idx_mask.shape[1] == 65
+
+    def test_16x16_grid(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 257
+
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.75,
+            block_size=4,
+            mask_class_token=False,
+        )
+
+        # 16x16 grid / 4x4 blocks = 4x4=16 blocks, keep 4 blocks = 64 patches + 1 cls
+        assert idx_keep.shape[1] == 65
+        assert idx_mask.shape[1] == 192
+
+    def test_no_prefix_token_masking(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 2, 64
+
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.75,
+            block_size=2,
+            mask_class_token=True,
+        )
+
+        # 16 blocks, keep 4 blocks = 16 patches
+        assert idx_keep.shape[1] == 16
+        assert idx_mask.shape[1] == 48
+
+        combined = torch.cat([idx_keep, idx_mask], dim=1)
+        sorted_combined = torch.sort(combined, dim=1)[0]
+        expected = torch.arange(seq_length).unsqueeze(0).expand(batch_size, -1)
+        assert torch.equal(sorted_combined, expected)
+
+    def test_determinism(self) -> None:
+        torch.manual_seed(123)
+        idx_keep1, idx_mask1 = random_block_wise_mask(
+            size=(2, 65), mask_ratio=0.75, block_size=2
+        )
+        torch.manual_seed(123)
+        idx_keep2, idx_mask2 = random_block_wise_mask(
+            size=(2, 65), mask_ratio=0.75, block_size=2
+        )
+        assert torch.equal(idx_keep1, idx_keep2)
+        assert torch.equal(idx_mask1, idx_mask2)
+
+    def test_batch_consistency(self) -> None:
+        torch.manual_seed(42)
+        batch_size, seq_length = 8, 65
+        idx_keep, idx_mask = random_block_wise_mask(
+            size=(batch_size, seq_length),
+            mask_ratio=0.75,
+            block_size=2,
+        )
+        assert idx_keep.shape[1] == idx_keep[0].shape[0]
+        assert idx_mask.shape[1] == idx_mask[0].shape[0]


### PR DESCRIPTION
#1894 

This is part of a series of PR's to implement the Pixio paper. 

- Tests added
- Documentation referencing the author
- Using same API as the other masking functions

The only difference is the `num_prefix_tokens` vs `mask_class_token`. Since Pixio relies on register tokens, the `mask_class_token` was not suitable for choosing whether to mask or not the REG/CLS tokens.

