### PR TITLE
Fix SIGReg distributed gradient under DDP

### DIFF
--- a/lightly/loss/lejepa_loss.py
+++ b/lightly/loss/lejepa_loss.py
@@ -1,6 +1,7 @@
 import torch
 from torch import distributed as torch_dist
 from torch import nn
+from torch.distributed import nn as torch_dist_nn
 
 from lightly.utils import dist as lightly_dist
 
@@ -90,8 +91,9 @@ class SIGReg(nn.Module):
         cos_sum = x_t.cos().sum(-3)
         sin_sum = x_t.sin().sum(-3)
         if self.gather_distributed and lightly_dist.world_size() > 1:
-            torch_dist.all_reduce(cos_sum)
-            torch_dist.all_reduce(sin_sum)
+            # Using the autograd-aware torch.distributed.nn.all_reduce, ref #1920
+            cos_sum = torch_dist_nn.all_reduce(cos_sum)
+            sin_sum = torch_dist_nn.all_reduce(sin_sum)
 
         cos_mean = cos_sum / num_samples
         sin_mean = sin_sum / num_samples

--- a/tests/loss/test_lejepa_sigreg_loss.py
+++ b/tests/loss/test_lejepa_sigreg_loss.py
@@ -8,6 +8,11 @@ from lightly.loss.lejepa_loss import SIGReg
 
 
 class TestSIGReg:
+    # TODO: the distributed-primitive mocks in the gather_distributed tests
+    # below approximate (but don't fully match) the real c10d/torch.distributed.nn APIs.
+    # Replace them with real Gloo-backed DDP tests once that infrastructure
+    # is available (see PR #1923 review).
+
     def test_backward_pass(self) -> None:
         torch.manual_seed(0)
         loss_fn = SIGReg()
@@ -33,6 +38,7 @@ class TestSIGReg:
     def test_forward_gather_distributed_world_size_gt_one(
         self, mocker: MockerFixture
     ) -> None:
+        # TODO: replace with Gloo DDP testing (see class-level note).
         mocker.patch("lightly.loss.lejepa_loss.lightly_dist.world_size", return_value=2)
         mock_broadcast = mocker.patch.object(dist, "broadcast")
         mock_all_reduce = mocker.patch.object(dist, "all_reduce")
@@ -83,6 +89,7 @@ class TestSIGReg:
         loss_truth = loss_fn_truth(proj_global)
 
         # Distributed: simulate world_size=2 with identical data on each rank.
+        # TODO: replace with Gloo DDP testing (see class-level note).
         mocker.patch(
             "lightly.loss.lejepa_loss.lightly_dist.world_size",
             return_value=world_size,
@@ -139,6 +146,7 @@ class TestSIGReg:
         assert theta_truth.grad is not None
 
         # Distributed: gradient on the local batch with simulated world_size=2.
+        # TODO: replace with Gloo DDP testing (see class-level note).
         mocker.patch(
             "lightly.loss.lejepa_loss.lightly_dist.world_size",
             return_value=world_size,

--- a/tests/loss/test_lejepa_sigreg_loss.py
+++ b/tests/loss/test_lejepa_sigreg_loss.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from pytest_mock import MockerFixture
 from torch import distributed as dist
+from torch.distributed import nn as dist_nn
 
 from lightly.loss.lejepa_loss import SIGReg
 
@@ -35,6 +36,11 @@ class TestSIGReg:
         mocker.patch("lightly.loss.lejepa_loss.lightly_dist.world_size", return_value=2)
         mock_broadcast = mocker.patch.object(dist, "broadcast")
         mock_all_reduce = mocker.patch.object(dist, "all_reduce")
+        mock_dist_nn_all_reduce = mocker.patch.object(
+            dist_nn,
+            "all_reduce",
+            side_effect=lambda tensor, *args, **kwargs: tensor,
+        )
 
         torch.manual_seed(0)
         loss_fn = SIGReg(gather_distributed=True)
@@ -43,7 +49,123 @@ class TestSIGReg:
 
         assert loss.isfinite()
         mock_broadcast.assert_called_once()
-        assert mock_all_reduce.call_count == 3
+        # c10d all_reduce now used only for num_samples_tensor in forward;
+        # cos_sum/sin_sum use the autograd-aware variant from torch.distributed.nn.
+        assert mock_all_reduce.call_count == 1
+        assert mock_dist_nn_all_reduce.call_count == 2
+
+    def test_forward_gather_distributed_matches_non_distributed(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Distributed forward equals non-distributed forward on the global batch.
+
+        Simulates ``world_size=2`` with identical data on both ranks, so the
+        global batch is just two copies of the local batch. Verifies the loss
+        VALUE under ``gather_distributed=True`` equals the loss on the
+        concatenated global batch under ``gather_distributed=False``.
+        """
+        world_size = 2
+        torch.manual_seed(0)
+        proj_local = torch.randn(8, 64, 16)
+        proj_global = torch.cat([proj_local, proj_local], dim=-2)
+        # Use the same projection vectors A in both paths so the two losses
+        # are directly comparable.
+        A_fixed = torch.randn(proj_local.size(-1), 32)
+        A_fixed = A_fixed / A_fixed.norm(p=2, dim=0)
+
+        # Non-distributed truth: SIGReg on the concatenated global batch.
+        loss_fn_truth = SIGReg(num_vectors=32, gather_distributed=False)
+        mocker.patch.object(
+            loss_fn_truth,
+            "_generate_unit_vectors",
+            new=lambda device, dtype, num_features: A_fixed.to(device, dtype),
+        )
+        loss_truth = loss_fn_truth(proj_global)
+
+        # Distributed: simulate world_size=2 with identical data on each rank.
+        mocker.patch(
+            "lightly.loss.lejepa_loss.lightly_dist.world_size",
+            return_value=world_size,
+        )
+        mocker.patch.object(dist, "broadcast")
+        mocker.patch.object(
+            dist,
+            "all_reduce",
+            side_effect=lambda tensor, *args, **kwargs: tensor.data.mul_(world_size),
+        )
+        mocker.patch.object(
+            dist_nn,
+            "all_reduce",
+            side_effect=lambda tensor, *args, **kwargs: tensor * world_size,
+        )
+
+        loss_fn_dist = SIGReg(num_vectors=32, gather_distributed=True)
+        mocker.patch.object(
+            loss_fn_dist,
+            "_generate_unit_vectors",
+            new=lambda device, dtype, num_features: A_fixed.to(device, dtype),
+        )
+        loss_dist = loss_fn_dist(proj_local)
+
+        assert torch.allclose(loss_dist, loss_truth, atol=1e-5)
+
+    def test_gather_distributed_gradient_matches_non_distributed(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Distributed gradient equals non-distributed gradient on the global batch.
+
+        Simulates ``world_size=2`` with identical data on both ranks (so the
+        global batch is two copies of the local batch). Differentiates a scalar
+        parameter ``theta`` and verifies the gradient under
+        ``gather_distributed=True`` equals the gradient under
+        ``gather_distributed=False`` on the global batch.
+        """
+        world_size = 2
+        torch.manual_seed(0)
+        proj_local = torch.randn(8, 64, 16)
+        proj_global = torch.cat([proj_local, proj_local], dim=-2)
+        A_fixed = torch.randn(proj_local.size(-1), 32)
+        A_fixed = A_fixed / A_fixed.norm(p=2, dim=0)
+
+        # Non-distributed truth: gradient on the global batch.
+        theta_truth = torch.tensor(2.0, requires_grad=True)
+        loss_fn_truth = SIGReg(num_vectors=32, gather_distributed=False)
+        mocker.patch.object(
+            loss_fn_truth,
+            "_generate_unit_vectors",
+            new=lambda device, dtype, num_features: A_fixed.to(device, dtype),
+        )
+        loss_fn_truth(theta_truth * proj_global).backward()
+        assert theta_truth.grad is not None
+
+        # Distributed: gradient on the local batch with simulated world_size=2.
+        mocker.patch(
+            "lightly.loss.lejepa_loss.lightly_dist.world_size",
+            return_value=world_size,
+        )
+        mocker.patch.object(dist, "broadcast")
+        mocker.patch.object(
+            dist,
+            "all_reduce",
+            side_effect=lambda tensor, *args, **kwargs: tensor.data.mul_(world_size),
+        )
+        mocker.patch.object(
+            dist_nn,
+            "all_reduce",
+            side_effect=lambda tensor, *args, **kwargs: tensor * world_size,
+        )
+
+        theta_dist = torch.tensor(2.0, requires_grad=True)
+        loss_fn_dist = SIGReg(num_vectors=32, gather_distributed=True)
+        mocker.patch.object(
+            loss_fn_dist,
+            "_generate_unit_vectors",
+            new=lambda device, dtype, num_features: A_fixed.to(device, dtype),
+        )
+        loss_fn_dist(theta_dist * proj_local).backward()
+        assert theta_dist.grad is not None
+
+        assert torch.allclose(theta_dist.grad, theta_truth.grad, atol=1e-5)
 
     def test_knots_must_be_greater_than_one(self) -> None:
         with pytest.raises(ValueError):


### PR DESCRIPTION
markdown
closes #1920

## Description

`SIGReg(gather_distributed=True)` previously called the non-autograd-aware `torch.distributed.all_reduce` on `cos_sum` and `sin_sum`. The cross-rank reduction was not registered in the autograd graph, so each rank's backward only saw its local samples. Under DDP gradient averaging, this produced a parameter gradient that was `1/world_size` of the true global-batch gradient. Forward value was already correct.

This PR switches to `torch.distributed.nn.all_reduce`, the autograd-aware variant. The gradient now flows correctly across ranks, matching the gradient flow in the galilai-group/lejepa reference implementation. Verified numerically at world_size=2 and world_size=4. See #1920 for the full bug analysis and a numerical reproduction.

## Tests
- [ ] My change is covered by existing tests.
- [x] My change needs new tests.
- [x] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

Two regression tests added in `tests/loss/test_lejepa_sigreg_loss.py`, both simulating `world_size=2` with identical data on both ranks (the global batch is then two copies of the local batch):

- `test_forward_gather_distributed_matches_non_distributed`: asserts the loss VALUE under `gather_distributed=True` equals the loss on the global batch under `gather_distributed=False`.
- `test_gather_distributed_gradient_matches_non_distributed`: asserts the gradient under `gather_distributed=True` equals the gradient on the global batch under `gather_distributed=False`. Without the fix this test fails by exactly a factor of `1/world_size`.

The existing `test_forward_gather_distributed_world_size_gt_one` smoke test is updated to mock both `torch.distributed.all_reduce` (now used only for `num_samples_tensor`) and `torch.distributed.nn.all_reduce` (used for `cos_sum`/`sin_sum`). Manually tested with `make all-checks` (mypy clean on the changed files, one pre-existing mypy error in `tests/loss/test_detcon_loss.py` is unrelated to this change).

## Documentation
- [ ] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation ( `.rst` files).
- [ ] I have updated the documentation accordingly.
- [ ] The autodocs update the documentation accordingly.

No public API surface change. The `gather_distributed=True` flag and its behavior are unchanged from a user's perspective; only the internal aggregation primitive is replaced. A short comment is added in `_compute_cf_error_at_each_frequency` explaining the autograd-awareness requirement. No docstrings or `.rst` changes needed.

## Implications/comments/further issues
None