### PR TITLE
feat: Implement DSE (Dense representation Structure Estimator)

### DIFF
--- a/docs/source/lightly.loss.rst
+++ b/docs/source/lightly.loss.rst
@@ -62,6 +62,9 @@ lightly.loss
 .. autoclass:: lightly.loss.regularizer.co2.CO2Regularizer
    :members:
 
+.. autoclass:: lightly.loss.regularizer.dse.DSERegularizer
+   :members:
+
 .. autoclass:: lightly.loss.swav_loss.SwaVLoss
    :members:
 

--- a/lightly/loss/regularizer/__init__.py
+++ b/lightly/loss/regularizer/__init__.py
@@ -4,3 +4,4 @@
 # All Rights Reserved
 
 from lightly.loss.regularizer.co2 import CO2Regularizer
+from lightly.loss.regularizer.dse import DSERegularizer

--- a/lightly/loss/regularizer/dse.py
+++ b/lightly/loss/regularizer/dse.py
@@ -1,0 +1,253 @@
+"""DSE regularizer."""
+
+import math
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import Module
+
+
+class DSERegularizer(Module):
+    """Dense Structure Estimator regularizer for dense representations.
+
+    This experimental regularizer is based on the training regularizer variant from "Exploring
+    Structural Degradation in Dense Representations for Self-supervised
+    Learning", 2025, https://arxiv.org/abs/2510.17299.
+
+    The regularizer expects dense representations of shape ``(B, N, D)``, where
+    ``B`` is the batch size, ``N`` is the number of dense locations such as
+    patches or spatial positions, and ``D`` is the feature dimension. Higher DSE
+    values indicate better dense structure, so this module returns
+    ``-weight * dse`` and can be added to an existing SSL loss.
+
+    Examples:
+        >>> regularizer = DSERegularizer(weight=0.1)
+        >>> ssl_loss = torch.tensor(1.0)
+        >>>
+        >>> # Transformer output: patch_tokens has shape (B, N, D).
+        >>> patch_tokens = torch.randn(8, 196, 384)
+        >>> loss = ssl_loss + regularizer(patch_tokens)
+        >>>
+        >>> # Convolutional output: features has shape (B, C, H, W).
+        >>> features = torch.randn(8, 384, 14, 14)
+        >>> dense_features = features.flatten(2).transpose(1, 2)
+        >>> loss = ssl_loss + regularizer(dense_features)
+
+    Attributes:
+        weight:
+            Weight of the regularization term.
+        normalize:
+            If True, L2-normalize representations along the feature dimension.
+        local_clusters:
+            Number of clusters for patches within each image.
+        global_clusters:
+            Number of clusters for patches across image groups.
+        max_kmeans_iters:
+            Maximum number of k-means iterations.
+        tol:
+            Early stopping threshold for centroid shift in k-means.
+    """
+
+    def __init__(
+        self,
+        weight: float = 1.0,
+        normalize: bool = True,
+        local_clusters: int = 3,
+        global_clusters: int = 24,
+        max_kmeans_iters: int = 20,
+        tol: float = 1e-4,
+    ):
+        """Initializes the DSERegularizer with the specified parameters.
+
+        Args:
+            weight:
+                Weight of the regularization term. Must be >= 0.
+            normalize:
+                If True, L2-normalize representations along the feature dimension
+                before computing the DSE score.
+            local_clusters:
+                Number of clusters for patches within each image. Must be >= 1.
+            global_clusters:
+                Number of clusters for patches across image groups. Must be >= 1.
+            max_kmeans_iters:
+                Maximum number of k-means iterations. Must be >= 1.
+            tol:
+                Early stopping threshold for centroid shift in k-means. Must be > 0.
+        """
+        super().__init__()
+        if weight < 0:
+            raise ValueError(f"weight must be >= 0, got {weight}.")
+        if local_clusters < 1:
+            raise ValueError(f"local_clusters must be >= 1, got {local_clusters}.")
+        if global_clusters < 1:
+            raise ValueError(f"global_clusters must be >= 1, got {global_clusters}.")
+        if max_kmeans_iters < 1:
+            raise ValueError(f"max_kmeans_iters must be >= 1, got {max_kmeans_iters}.")
+        if tol <= 0:
+            raise ValueError(f"tol must be > 0, got {tol}.")
+
+        self.weight = weight
+        self.normalize = normalize
+        self.local_clusters = local_clusters
+        self.global_clusters = global_clusters
+        self.max_kmeans_iters = max_kmeans_iters
+        self.tol = tol
+
+    def forward(self, representations: Tensor) -> Tensor:
+        """Computes the DSE regularization loss.
+
+        Args:
+            representations:
+                Dense representations of shape ``(B, N, D)``.
+
+        Returns:
+            Scalar DSE regularization loss.
+        """
+        if representations.ndim != 3:
+            raise ValueError(
+                "representations must have shape (batch_size, num_tokens, dim), "
+                f"got {representations.shape}."
+            )
+        if min(representations.shape) == 0:
+            raise ValueError(
+                "representations must have non-empty batch, token, and feature "
+                f"dimensions, got {representations.shape}."
+            )
+
+        if self.weight == 0:
+            return representations.new_zeros(())
+
+        if self.normalize:
+            representations = F.normalize(representations, dim=-1)
+
+        batch_size, num_tokens, dim = representations.shape
+        centered = representations - representations.mean(dim=(0, 1), keepdim=True)
+        avg_l2 = torch.norm(centered, dim=-1, p=2).mean()
+
+        intra_image = self._intra_image_structure(representations)
+        inter_batch, intra_batch = self._batch_structure(representations)
+        effective_dimensionality = self._effective_dimensionality(
+            representations.reshape(batch_size * num_tokens, dim)
+        )
+
+        dse = (
+            inter_batch / (avg_l2 + 1e-12)
+            + effective_dimensionality
+            - 0.5 * (intra_batch / (avg_l2 + 1e-12) + intra_image / (avg_l2 + 1e-12))
+        )
+        loss: Tensor = -self.weight * dse
+        return loss
+
+    def _intra_image_structure(self, representations: Tensor) -> Tensor:
+        batch_size = representations.shape[0]
+        terms = []
+        for batch_index in range(batch_size):
+            image_representations = representations[batch_index]
+            _, labels = self._kmeans(
+                image_representations.detach(), self.local_clusters
+            )
+            ranks = []
+            for cluster_index in torch.unique(labels):
+                cluster = image_representations[labels == cluster_index]
+                if cluster.shape[0] > 1:
+                    ranks.append(self._centered_singular_sum(cluster))
+            if ranks:
+                terms.append(torch.stack(ranks).mean())
+
+        if not terms:
+            return representations.new_zeros(())
+        return torch.stack(terms).mean()
+
+    def _batch_structure(self, representations: Tensor) -> Tuple[Tensor, Tensor]:
+        batch_size, _, dim = representations.shape
+        inter_class_images = max(self.global_clusters // self.local_clusters, 1)
+        inter_terms = []
+        intra_terms = []
+
+        for start in range(0, batch_size, inter_class_images):
+            group = representations[start : start + inter_class_images].reshape(-1, dim)
+            centroids, labels = self._kmeans(group.detach(), self.global_clusters)
+            if centroids.shape[0] > 1:
+                distances = torch.cdist(group, centroids)
+                assigned_mask = torch.zeros_like(distances, dtype=torch.bool)
+                assigned_mask[
+                    torch.arange(group.shape[0], device=group.device), labels
+                ] = True
+                other_distances = distances.masked_fill(assigned_mask, float("inf"))
+                inter_terms.append(other_distances.min(dim=1).values.mean())
+
+            for cluster_index in torch.unique(labels):
+                cluster = group[labels == cluster_index]
+                if cluster.shape[0] > 1:
+                    intra_terms.append(self._centered_singular_sum(cluster))
+
+        if inter_terms:
+            inter_batch = torch.stack(inter_terms).mean()
+        else:
+            inter_batch = representations.new_zeros(())
+
+        if intra_terms:
+            intra_batch = torch.stack(intra_terms).mean()
+        else:
+            intra_batch = representations.new_zeros(())
+
+        return inter_batch, intra_batch
+
+    def _effective_dimensionality(self, representations: Tensor) -> Tensor:
+        singular_values = torch.linalg.svdvals(representations)
+        probabilities = singular_values / (singular_values.sum() + 1e-12)
+        entropy = -torch.sum(probabilities * torch.log(probabilities + 1e-12))
+        return torch.exp(entropy) / min(representations.shape)
+
+    def _centered_singular_sum(self, representations: Tensor) -> Tensor:
+        centered = representations - representations.mean(dim=0, keepdim=True)
+        singular_values = torch.linalg.svdvals(centered)
+        denominator = math.sqrt(
+            max(representations.shape[0] - 1, representations.shape[1])
+        )
+        return singular_values.sum() / denominator
+
+    def _kmeans(self, x: Tensor, num_clusters: int) -> Tuple[Tensor, Tensor]:
+        with torch.no_grad():
+            num_points = x.shape[0]
+            num_clusters = min(num_clusters, num_points)
+            centroids = self._kmeans_plus_plus_init(x, num_clusters)
+
+            for _ in range(self.max_kmeans_iters):
+                distances = torch.cdist(x, centroids)
+                labels = torch.argmin(distances, dim=1)
+                new_centroids = []
+                for cluster_index in range(num_clusters):
+                    cluster = x[labels == cluster_index]
+                    if cluster.shape[0] > 0:
+                        new_centroids.append(cluster.mean(dim=0))
+                    else:
+                        index = torch.randint(num_points, (1,), device=x.device)
+                        new_centroids.append(x[index].squeeze(0))
+                new_centroids_tensor = torch.stack(new_centroids)
+                shift = (new_centroids_tensor - centroids).pow(2).sum().sqrt()
+                centroids = new_centroids_tensor
+                if shift < self.tol:
+                    break
+
+            distances = torch.cdist(x, centroids)
+            labels = torch.argmin(distances, dim=1)
+            return centroids.detach(), labels.detach()
+
+    def _kmeans_plus_plus_init(self, x: Tensor, num_clusters: int) -> Tensor:
+        num_points = x.shape[0]
+        first_index = torch.randint(num_points, (1,), device=x.device)
+        centroids = x[first_index]
+
+        for _ in range(num_clusters - 1):
+            distances = torch.cdist(x, centroids).min(dim=1).values
+            probabilities = distances.square()
+            probabilities = probabilities / (probabilities.sum() + 1e-12)
+            if torch.sum(probabilities) == 0:
+                probabilities = torch.ones_like(probabilities) / probabilities.numel()
+            next_index = torch.multinomial(probabilities, 1)
+            centroids = torch.cat((centroids, x[next_index]), dim=0)
+
+        return centroids

--- a/lightly/loss/regularizer/dse.py
+++ b/lightly/loss/regularizer/dse.py
@@ -243,6 +243,8 @@ class DSERegularizer(Module):
 
         for _ in range(num_clusters - 1):
             distances = torch.cdist(x, centroids).min(dim=1).values
+            # Standard k-means++ uses D^2 sampling for the squared Euclidean
+            # k-means objective. This differs from the paper (maybe a bug!?).
             probabilities = distances.square()
             probabilities = probabilities / (probabilities.sum() + 1e-12)
             if torch.sum(probabilities) == 0:

--- a/lightly/loss/regularizer/dse.py
+++ b/lightly/loss/regularizer/dse.py
@@ -203,7 +203,7 @@ class DSERegularizer(Module):
 
     def _centered_singular_sum(self, representations: Tensor) -> Tensor:
         centered = representations - representations.mean(dim=0, keepdim=True)
-        singular_values = torch.linalg.svdvals(centered)
+        singular_values: Tensor = torch.linalg.svdvals(centered)
         denominator = math.sqrt(
             max(representations.shape[0] - 1, representations.shape[1])
         )

--- a/tests/loss/test_dse_regularizer.py
+++ b/tests/loss/test_dse_regularizer.py
@@ -137,36 +137,6 @@ class TestDSERegularizer:
         expected = sv.sum() / math.sqrt(max(n - 1, d))
         assert torch.allclose(result, expected)
 
-    def test_intra_image_structure_uses_only_assigned_non_singleton_clusters(
-        self,
-    ) -> None:
-        """Only clusters with at least two assigned samples contribute to the score."""
-        regularizer = DSERegularizer(local_clusters=3)
-        representations = torch.tensor(
-            [
-                [
-                    [1.0, 0.0],
-                    [0.0, 1.0],
-                    [1.0, 1.0],
-                    [2.0, 0.0],
-                ]
-            ]
-        )
-        labels = torch.tensor([0, 0, 1, 0])
-
-        def kmeans_stub(
-            x: torch.Tensor, num_clusters: int
-        ) -> tuple[torch.Tensor, torch.Tensor]:
-            assert num_clusters == 3
-            return torch.empty(num_clusters, x.shape[1]), labels
-
-        regularizer._kmeans = kmeans_stub  # type: ignore[method-assign]
-
-        result = regularizer._intra_image_structure(representations)
-
-        expected = regularizer._centered_singular_sum(representations[0, labels == 0])
-        assert torch.allclose(result, expected)
-
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="No cuda")
     def test_forward_pass_cuda(self) -> None:
         torch.manual_seed(0)

--- a/tests/loss/test_dse_regularizer.py
+++ b/tests/loss/test_dse_regularizer.py
@@ -137,6 +137,36 @@ class TestDSERegularizer:
         expected = sv.sum() / math.sqrt(max(n - 1, d))
         assert torch.allclose(result, expected)
 
+    def test_intra_image_structure_uses_only_assigned_non_singleton_clusters(
+        self,
+    ) -> None:
+        """Only clusters with at least two assigned samples contribute to the score."""
+        regularizer = DSERegularizer(local_clusters=3)
+        representations = torch.tensor(
+            [
+                [
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                    [1.0, 1.0],
+                    [2.0, 0.0],
+                ]
+            ]
+        )
+        labels = torch.tensor([0, 0, 1, 0])
+
+        def kmeans_stub(
+            x: torch.Tensor, num_clusters: int
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            assert num_clusters == 3
+            return torch.empty(num_clusters, x.shape[1]), labels
+
+        regularizer._kmeans = kmeans_stub  # type: ignore[method-assign]
+
+        result = regularizer._intra_image_structure(representations)
+
+        expected = regularizer._centered_singular_sum(representations[0, labels == 0])
+        assert torch.allclose(result, expected)
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="No cuda")
     def test_forward_pass_cuda(self) -> None:
         torch.manual_seed(0)

--- a/tests/loss/test_dse_regularizer.py
+++ b/tests/loss/test_dse_regularizer.py
@@ -106,7 +106,7 @@ class TestDSERegularizer:
     )
     def test_invalid_init_args_raise(self, kwargs: Dict[str, object]) -> None:
         with pytest.raises(ValueError):
-            DSERegularizer(**kwargs)
+            DSERegularizer(**kwargs)  # type: ignore[arg-type]
 
     def test_effective_dimensionality_matches_reference(self) -> None:
         # Verifies _effective_dimensionality against the formula from

--- a/tests/loss/test_dse_regularizer.py
+++ b/tests/loss/test_dse_regularizer.py
@@ -1,0 +1,153 @@
+import math
+from typing import Dict
+
+import pytest
+import torch
+
+from lightly.loss.regularizer import DSERegularizer
+
+
+class TestDSERegularizer:
+    def test_forward_pass(self) -> None:
+        torch.manual_seed(0)
+        regularizer = DSERegularizer(
+            local_clusters=2,
+            global_clusters=4,
+            max_kmeans_iters=3,
+        )
+        representations = torch.randn(4, 8, 6)
+
+        loss = regularizer(representations)
+
+        assert loss.ndim == 0
+        assert loss.isfinite()
+
+    def test_backward_pass(self) -> None:
+        torch.manual_seed(0)
+        regularizer = DSERegularizer(
+            local_clusters=2,
+            global_clusters=4,
+            max_kmeans_iters=3,
+        )
+        representations = torch.randn(4, 8, 6, requires_grad=True)
+
+        loss = regularizer(representations)
+        loss.backward()
+
+        assert representations.grad is not None
+        assert representations.grad.shape == representations.shape
+
+    def test_convolutional_features_can_be_flattened(self) -> None:
+        torch.manual_seed(0)
+        regularizer = DSERegularizer(
+            local_clusters=2,
+            global_clusters=4,
+            max_kmeans_iters=3,
+        )
+        features = torch.randn(4, 6, 3, 3)
+        dense_features = features.flatten(2).transpose(1, 2)
+
+        loss = regularizer(dense_features)
+
+        assert loss.ndim == 0
+        assert loss.isfinite()
+
+    def test_weight_zero_returns_zero_loss(self) -> None:
+        regularizer = DSERegularizer(weight=0.0)
+        representations = torch.randn(4, 8, 6)
+
+        loss = regularizer(representations)
+
+        assert loss.item() == 0.0
+
+    def test_weight_scales_loss(self) -> None:
+        representations = torch.randn(4, 8, 6)
+        regularizer = DSERegularizer(
+            weight=1.0,
+            local_clusters=2,
+            global_clusters=4,
+            max_kmeans_iters=3,
+        )
+        weighted_regularizer = DSERegularizer(
+            weight=2.0,
+            local_clusters=2,
+            global_clusters=4,
+            max_kmeans_iters=3,
+        )
+
+        torch.manual_seed(0)
+        loss = regularizer(representations)
+        torch.manual_seed(0)
+        weighted_loss = weighted_regularizer(representations)
+
+        assert torch.allclose(weighted_loss, 2 * loss)
+
+    def test_invalid_input_shape_raises(self) -> None:
+        regularizer = DSERegularizer()
+
+        with pytest.raises(ValueError):
+            regularizer(torch.randn(4, 6))
+
+    def test_empty_input_raises(self) -> None:
+        regularizer = DSERegularizer()
+
+        with pytest.raises(ValueError):
+            regularizer(torch.randn(4, 0, 6))
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"weight": -1.0},
+            {"local_clusters": 0},
+            {"global_clusters": 0},
+            {"max_kmeans_iters": 0},
+            {"tol": 0.0},
+        ],
+    )
+    def test_invalid_init_args_raise(self, kwargs: Dict[str, object]) -> None:
+        with pytest.raises(ValueError):
+            DSERegularizer(**kwargs)
+
+    def test_effective_dimensionality_matches_reference(self) -> None:
+        # Verifies _effective_dimensionality against the formula from
+        # SSL-Degradation/DSE_regularizer.py (estimator, 'effective_rank' branch).
+        torch.manual_seed(0)
+        x = torch.randn(16, 8)
+        regularizer = DSERegularizer()
+
+        result = regularizer._effective_dimensionality(x)
+
+        sv = torch.linalg.svdvals(x)
+        p = sv / (sv.sum() + 1e-12) + 1e-12
+        expected = torch.exp(-torch.sum(p * torch.log(p))) / min(x.shape)
+        assert torch.allclose(result, expected, atol=1e-5)
+
+    def test_centered_singular_sum_matches_reference(self) -> None:
+        # Verifies _centered_singular_sum against the formula from
+        # SSL-Degradation/DSE_regularizer.py (estimator, 'centered_singular_sum' branch).
+        torch.manual_seed(0)
+        x = torch.randn(16, 8)
+        regularizer = DSERegularizer()
+
+        result = regularizer._centered_singular_sum(x)
+
+        xc = x - x.mean(dim=0, keepdim=True)
+        sv = torch.linalg.svdvals(xc)
+        n, d = x.shape
+        expected = sv.sum() / math.sqrt(max(n - 1, d))
+        assert torch.allclose(result, expected)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="No cuda")
+    def test_forward_pass_cuda(self) -> None:
+        torch.manual_seed(0)
+        regularizer = DSERegularizer(
+            local_clusters=2,
+            global_clusters=4,
+            max_kmeans_iters=3,
+        ).cuda()
+        representations = torch.randn(4, 8, 6, device="cuda")
+
+        loss = regularizer(representations)
+
+        assert loss.ndim == 0
+        assert loss.isfinite()


### PR DESCRIPTION
## Motivation

This is complementary (partially overlapping) with gram anchoring from DINOv3. There is a [NeurIPS 2025 paper](https://arxiv.org/abs/2510.17299) that looks more carefully in degradation for dense tasks in SSL pretraining and proposes a more general regulariser (not a post training fix like gram anchoring. And it should work for all SSL methods:
- works for conv and transfomer backbones!

## Changes
-  Adds DSERegularizer, a dense-representation regularizer based on the Dense Structure Estimator (DSE)
- Accepts (B, N, D) dense representations (transformer patch tokens or flattened conv features) and returns a scalar loss term to add to any existing SSL loss
- Implements k-means-based structure estimation: local intra-image clustering, global inter/intra-batch clustering, and effective dimensionality via spectral entropy
- Uses k-means++ initialization with squared-distance weighting, correcting a bug in the reference implementation
- Includes full test coverage: forward/backward pass, weight scaling, input validation, and numerical comparison of the deterministic components against the reference formulas
- Registered in lightly.loss.regularizer and documented in the API reference