### PR TITLE
Fix: ibotpluplus loss normalisation

### DIFF
--- a/lightly/loss/ibot_loss.py
+++ b/lightly/loss/ibot_loss.py
@@ -142,8 +142,22 @@ class IBOTPlusPlusPatchLoss(IBOTPatchLoss):
         student_out: Tensor,
         mask: Tensor | None = None,
         teacher_temp: float | None = None,
+        visible_loss_weight: float = 1.0,
     ) -> Tensor:
         """Forward pass through the iBOT++ patch loss.
+
+        When ``mask`` is provided, the per-token cross-entropy is split into a
+        masked term and a visible term. The masked term is normalized by the
+        number of masked tokens per image (matching the original iBOT masked
+        image modeling signal), and the visible term is normalized by the number
+        of visible tokens per image and scaled by ``visible_loss_weight``::
+
+            loss = mean_b ( masked_b + visible_loss_weight * visible_b )
+
+        Setting ``visible_loss_weight=0`` recovers the exact iBOT behavior, while
+        ``visible_loss_weight>0`` adds the iBOT++ supervision on visible tokens
+        without diluting the masked-token signal. When ``mask`` is ``None`` the
+        loss falls back to a plain mean over all patch tokens.
 
         Args:
             teacher_out:
@@ -153,12 +167,17 @@ class IBOTPlusPlusPatchLoss(IBOTPatchLoss):
                 Tensor with the same shape as ``teacher_out`` containing full
                 patch logits from the student model.
             mask:
-                Optional boolean tensor with shape ``(B, H, W)`` or ``(B, N)``.
-                Required when ``teacher_out`` has rank 2 so that the batch size
-                ``B`` can be inferred.
+                Optional boolean tensor with shape ``(B, H, W)`` or ``(B, N)``
+                where ``True`` marks masked tokens. Used to weight masked vs.
+                visible tokens, and required when ``teacher_out`` has rank 2 so
+                that the batch size ``B`` can be inferred.
             teacher_temp:
                 The temperature used for the teacher output. If None, the default
                 temperature defined in ``__init__`` is used.
+            visible_loss_weight:
+                Weight applied to the visible-token (unmasked) loss term. Only
+                used when ``mask`` is provided. Defaults to ``1.0``. Use ``0.0``
+                to recover the original iBOT masked-only behavior.
 
         Returns:
             The loss value as a scalar tensor.
@@ -213,9 +232,22 @@ class IBOTPlusPlusPatchLoss(IBOTPatchLoss):
         )
         student_log_softmax = F.log_softmax(student_flat / self.student_temp, dim=-1)
 
-        # (B * N,) -> (B, N) -> scalar
-        loss = -torch.sum(teacher_softmax * student_log_softmax, dim=-1)
-        loss = loss.view(B, N).mean(dim=1).mean()
+        # Per-token cross-entropy: (B * N,) -> (B, N)
+        ce = -torch.sum(teacher_softmax * student_log_softmax, dim=-1).view(B, N)
+
+        if mask is None:
+            # No mask: average equally over all patch tokens.
+            loss = ce.mean()
+        else:
+            # Split into masked and visible terms. The masked term keeps the
+            # original iBOT normalization (per-image mean over masked tokens) so
+            # the masked-token signal is not diluted by the visible tokens.
+            mask_flat = mask.reshape(B, N).to(dtype=ce.dtype)  # 1.0 = masked
+            n_masked = mask_flat.sum(dim=1).clamp(min=1.0)
+            n_visible = (1.0 - mask_flat).sum(dim=1).clamp(min=1.0)
+            masked_loss = (ce * mask_flat).sum(dim=1) / n_masked
+            visible_loss = (ce * (1.0 - mask_flat)).sum(dim=1) / n_visible
+            loss = (masked_loss + visible_loss_weight * visible_loss).mean()
 
         self.center.update(teacher_flat)
 

--- a/lightly/loss/ibot_loss.py
+++ b/lightly/loss/ibot_loss.py
@@ -152,7 +152,7 @@ class IBOTPlusPlusPatchLoss(IBOTPatchLoss):
         image modeling signal), and the visible term is normalized by the number
         of visible tokens per image and scaled by ``visible_loss_weight``::
 
-            loss = mean_b ( masked_b + visible_loss_weight * visible_b )
+            loss = mean_b(masked_b + visible_loss_weight * visible_b)
 
         Setting ``visible_loss_weight=0`` recovers the exact iBOT behavior, while
         ``visible_loss_weight>0`` adds the iBOT++ supervision on visible tokens

--- a/tests/loss/test_ibot_plusplus_loss.py
+++ b/tests/loss/test_ibot_plusplus_loss.py
@@ -91,6 +91,68 @@ class TestIBOTPlusPlusPatchLoss:
 
         assert loss_2d == pytest.approx(loss_3d.item(), rel=1e-5)
 
+    def test_visible_loss_weight_zero_matches_masked_only(self) -> None:
+        # With visible_loss_weight=0 and a mask, iBOT++ must reduce to the
+        # original iBOT masked-only loss (per-image mean over masked tokens).
+        torch.manual_seed(7)
+        B, N, K = 3, 8, 6
+        teacher_temp, student_temp = 0.04, 0.1
+        criterion = IBOTPlusPlusPatchLoss(
+            output_dim=K, teacher_temp=teacher_temp, student_temp=student_temp
+        )
+        # Zero out the center so it has no effect.
+        criterion.center.center.zero_()
+
+        teacher_out = torch.randn(B, N, K)
+        student_out = torch.randn(B, N, K)
+        mask = torch.rand(B, N) < 0.4
+        mask[:, 0] = True  # ensure at least one masked token per image
+
+        loss = criterion(
+            teacher_out=teacher_out,
+            student_out=student_out,
+            mask=mask,
+            visible_loss_weight=0.0,
+        )
+
+        # Manual masked-only reference.
+        q = F.softmax(teacher_out / teacher_temp, dim=-1)
+        log_p = F.log_softmax(student_out / student_temp, dim=-1)
+        ce = -(q * log_p).sum(dim=-1)  # (B, N)
+        m = mask.float()
+        expected = ((ce * m).sum(dim=1) / m.sum(dim=1).clamp(min=1.0)).mean()
+
+        assert loss == pytest.approx(expected.item(), rel=1e-5)
+
+    def test_visible_loss_weight_decouples_masked_and_visible(self) -> None:
+        # With visible_loss_weight=0 the visible tokens must not contribute to
+        # the gradient, while masked tokens do.
+        torch.manual_seed(3)
+        B, N, K = 2, 6, 5
+        teacher_out = torch.randn(B, N, K)
+        mask = torch.zeros(B, N, dtype=torch.bool)
+        mask[:, :3] = True  # first half masked, second half visible
+
+        criterion = IBOTPlusPlusPatchLoss(output_dim=K)
+        criterion.center.center.zero_()
+
+        student_out = torch.randn(B, N, K, requires_grad=True)
+        loss = criterion(
+            teacher_out=teacher_out,
+            student_out=student_out,
+            mask=mask,
+            visible_loss_weight=0.0,
+        )
+        loss.backward()
+
+        assert student_out.grad is not None
+        # Visible tokens get no gradient when their weight is zero.
+        assert torch.allclose(
+            student_out.grad[:, 3:], torch.zeros_like(student_out.grad[:, 3:]), atol=1e-7
+        )
+        # Masked tokens do receive gradient.
+        assert student_out.grad[:, :3].abs().sum() > 0
+
     def test_invalid_shapes_raise(self) -> None:
         criterion = IBOTPlusPlusPatchLoss(output_dim=4)
 

--- a/tests/loss/test_ibot_plusplus_loss.py
+++ b/tests/loss/test_ibot_plusplus_loss.py
@@ -148,7 +148,9 @@ class TestIBOTPlusPlusPatchLoss:
         assert student_out.grad is not None
         # Visible tokens get no gradient when their weight is zero.
         assert torch.allclose(
-            student_out.grad[:, 3:], torch.zeros_like(student_out.grad[:, 3:]), atol=1e-7
+            student_out.grad[:, 3:],
+            torch.zeros_like(student_out.grad[:, 3:]),
+            atol=1e-7,
         )
         # Masked tokens do receive gradient.
         assert student_out.grad[:, :3].abs().sum() > 0


### PR DESCRIPTION
## Changes

Before this change, masked patches contributed too little to the loss. As a result, the model could focus too much on the easier non-masked patches, which caused degraded performance instead of the expected improvement from iBOT++.

- Added a `mask` parameter to the iBOT++ loss so it can separate masked and visible patches
- Added `visible_loss_weight` to control the contribution of visible patches
- The masked patch loss is now normalized separately, so masked patches are not diluted by the visible patches
- This fixes a case where iBOT++ could perform worse than iBOT, especially with a low masking ratio