### PR TITLE
fix(loss): raise clear error for single-view DINOLoss instead of silent NaN

### DIFF
--- a/lightly/loss/dino_loss.py
+++ b/lightly/loss/dino_loss.py
@@ -44,15 +44,15 @@ class DINOLoss(Module):
         >>> # initialize loss function
         >>> loss_fn = DINOLoss(128)
         >>>
-        >>> # generate a view of the images with a random transform
-        >>> view = transform(images)
+        >>> # generate two views of the images with a random transform
+        >>> view0, view1 = transform(images), transform(images)
         >>>
-        >>> # embed the view with a student and teacher model
-        >>> teacher_out = teacher(view)
-        >>> student_out = student(view)
+        >>> # embed the views with a student and teacher model
+        >>> teacher_out = [teacher(view0), teacher(view1)]
+        >>> student_out = [student(view0), student(view1)]
         >>>
         >>> # calculate loss
-        >>> loss = loss_fn([teacher_out], [student_out])
+        >>> loss = loss_fn(teacher_out, student_out)
     """
 
     def __init__(
@@ -154,6 +154,15 @@ class DINOLoss(Module):
         # Number of loss terms, ignoring the diagonal
         n_terms = loss.numel() - loss.diagonal().numel()
         batch_size = teacher_out_stacked.shape[1]
+
+        if n_terms == 0:
+            raise ValueError(
+                "DINOLoss requires at least two views in total (the diagonal "
+                "matching the same view index is excluded), but got "
+                f"{len(teacher_out)} teacher view(s) and {len(student_out)} "
+                "student view(s), which leaves no cross-view terms to compute "
+                "the loss from."
+            )
 
         loss = loss.sum() / (n_terms * batch_size)
 

--- a/tests/loss/test_dino_loss.py
+++ b/tests/loss/test_dino_loss.py
@@ -131,6 +131,16 @@ class TestDINOLoss:
             center_momentum=center_momentum,
         )
 
+    def test_single_view_raises(self) -> None:
+        # A single teacher view and a single student view leave no cross-view
+        # terms (the diagonal is excluded), which previously produced a silent
+        # NaN from a 0 / 0 division.
+        loss_fn = DINOLoss(output_dim=8)
+        teacher_out = torch.randn(4, 8)
+        student_out = torch.randn(4, 8)
+        with pytest.raises(ValueError, match="at least two views"):
+            loss_fn([teacher_out], [student_out])
+
 
 def test_center__equivalence() -> None:
     """Check that DINOLoss.update_center is equivalent to Center.update.


### PR DESCRIPTION
## What's broken

`DINOLoss` returns a silent `NaN` when called with a single teacher view and single student view — which is exactly the usage shown in the class docstring (`loss_fn([teacher_out], [student_out])`). NaN silently poisons training rather than surfacing an error.

```python
loss_fn = DINOLoss(output_dim=8)
loss_fn([torch.randn(4,8)], [torch.randn(4,8)]).item()   # nan
```

## Why it happens

With one view on each side the loss matrix is 1×1; `fill_diagonal_(0)` zeros its only entry, so `n_terms = numel - diagonal = 0`, and `loss.sum() / (n_terms * batch_size) = 0/0 = NaN`. Single-view DINO is genuinely degenerate (no cross-view distillation), but the code produces NaN instead of a clear error, and the docstring advertises this exact call.

## Fix

Raise a clear `ValueError` when there are no cross-view terms (matching the codebase's convention of raising on degenerate loss inputs), and correct the docstring example to use two views.

## Test

`test_single_view_raises` asserts the single-view call raises `ValueError`; the rest of the DINO loss suite is unchanged.
