### PR TITLE
docs: add docstrings to BYOLView1Transform and BYOLView2Transform

### DIFF
--- a/docs/source/lightly.transforms.rst
+++ b/docs/source/lightly.transforms.rst
@@ -7,6 +7,10 @@ lightly.transforms
    :members:
    :special-members: __call__
 
+.. automodule:: lightly.transforms.byol_transform
+   :members:
+   :special-members: __call__, __init__
+
 .. automodule:: lightly.transforms.densecl_transform
    :members:
    :special-members: __call__

--- a/lightly/transforms/byol_transform.py
+++ b/lightly/transforms/byol_transform.py
@@ -31,52 +31,6 @@ class BYOLView1Transform:
 
     - [0]: Bootstrap Your Own Latent, 2020, https://arxiv.org/pdf/2006.07733.pdf
 
-    Attributes:
-        input_size:
-            Size of the input image in pixels.
-        cj_prob:
-            Probability that color jitter is applied.
-        cj_strength:
-            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
-            `cj_hue` are multiplied by this value. For datasets with small images,
-            such as CIFAR, it is recommended to set `cj_strength` to 0.5.
-        cj_bright:
-            How much to jitter brightness.
-        cj_contrast:
-            How much to jitter contrast.
-        cj_sat:
-            How much to jitter saturation.
-        cj_hue:
-            How much to jitter hue.
-        min_scale:
-            Minimum size of the randomized crop relative to the input_size.
-        random_gray_scale:
-            Probability of conversion to grayscale.
-        gaussian_blur:
-            Probability of Gaussian blur.
-        solarization_prob:
-            Probability of solarization.
-        kernel_size:
-            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
-            Used to calculate sigma of gaussian blur with kernel_size * input_size.
-        sigmas:
-            Tuple of min and max value from which the std of the gaussian kernel is sampled.
-            Is ignored if `kernel_size` is set.
-        vf_prob:
-            Probability that vertical flip is applied.
-        hf_prob:
-            Probability that horizontal flip is applied.
-        rr_prob:
-            Probability that random rotation is applied.
-        rr_degrees:
-            Range of degrees to select from for random rotation. If rr_degrees is None,
-            images are rotated by 90 degrees. If rr_degrees is a (min, max) tuple,
-            images are rotated by a random angle in [min, max]. If rr_degrees is a
-            single number, images are rotated by a random angle in
-            [-rr_degrees, +rr_degrees]. All rotations are counter-clockwise.
-        normalize:
-            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
-
     """
 
     def __init__(
@@ -100,6 +54,41 @@ class BYOLView1Transform:
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes BYOLView1Transform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value. For datasets
+                with small images, such as CIFAR, it is recommended to set
+                `cj_strength` to 0.5.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            solarization_prob: Probability of solarization.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,
@@ -126,8 +115,7 @@ class BYOLView1Transform:
         """Applies the transforms to the input image.
 
         Args:
-            image:
-                The input image to apply the transforms to.
+            image: The input image to apply the transforms to.
 
         Returns:
             The transformed image.
@@ -158,52 +146,6 @@ class BYOLView2Transform:
 
     - [0]: Bootstrap Your Own Latent, 2020, https://arxiv.org/pdf/2006.07733.pdf
 
-    Attributes:
-        input_size:
-            Size of the input image in pixels.
-        cj_prob:
-            Probability that color jitter is applied.
-        cj_strength:
-            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
-            `cj_hue` are multiplied by this value. For datasets with small images,
-            such as CIFAR, it is recommended to set `cj_strength` to 0.5.
-        cj_bright:
-            How much to jitter brightness.
-        cj_contrast:
-            How much to jitter contrast.
-        cj_sat:
-            How much to jitter saturation.
-        cj_hue:
-            How much to jitter hue.
-        min_scale:
-            Minimum size of the randomized crop relative to the input_size.
-        random_gray_scale:
-            Probability of conversion to grayscale.
-        gaussian_blur:
-            Probability of Gaussian blur.
-        solarization_prob:
-            Probability of solarization.
-        kernel_size:
-            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
-            Used to calculate sigma of gaussian blur with kernel_size * input_size.
-        sigmas:
-            Tuple of min and max value from which the std of the gaussian kernel is sampled.
-            Is ignored if `kernel_size` is set.
-        vf_prob:
-            Probability that vertical flip is applied.
-        hf_prob:
-            Probability that horizontal flip is applied.
-        rr_prob:
-            Probability that random rotation is applied.
-        rr_degrees:
-            Range of degrees to select from for random rotation. If rr_degrees is None,
-            images are rotated by 90 degrees. If rr_degrees is a (min, max) tuple,
-            images are rotated by a random angle in [min, max]. If rr_degrees is a
-            single number, images are rotated by a random angle in
-            [-rr_degrees, +rr_degrees]. All rotations are counter-clockwise.
-        normalize:
-            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
-
     """
 
     def __init__(
@@ -227,6 +169,41 @@ class BYOLView2Transform:
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes BYOLView2Transform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value. For datasets
+                with small images, such as CIFAR, it is recommended to set
+                `cj_strength` to 0.5.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            solarization_prob: Probability of solarization.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,
@@ -253,8 +230,7 @@ class BYOLView2Transform:
         """Applies the transforms to the input image.
 
         Args:
-            image:
-                The input image to apply the transforms to.
+            image: The input image to apply the transforms to.
 
         Returns:
             The transformed image.

--- a/lightly/transforms/byol_transform.py
+++ b/lightly/transforms/byol_transform.py
@@ -12,6 +12,73 @@ from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
 class BYOLView1Transform:
+    """Transforms an image into the first view for BYOL [0].
+
+    Used by BYOLTransform to create the first view of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - ImageNet normalization
+
+    - [0]: Bootstrap Your Own Latent, 2020, https://arxiv.org/pdf/2006.07733.pdf
+
+    Attributes:
+        input_size:
+            Size of the input image in pixels.
+        cj_prob:
+            Probability that color jitter is applied.
+        cj_strength:
+            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
+            `cj_hue` are multiplied by this value. For datasets with small images,
+            such as CIFAR, it is recommended to set `cj_strength` to 0.5.
+        cj_bright:
+            How much to jitter brightness.
+        cj_contrast:
+            How much to jitter contrast.
+        cj_sat:
+            How much to jitter saturation.
+        cj_hue:
+            How much to jitter hue.
+        min_scale:
+            Minimum size of the randomized crop relative to the input_size.
+        random_gray_scale:
+            Probability of conversion to grayscale.
+        gaussian_blur:
+            Probability of Gaussian blur.
+        solarization_prob:
+            Probability of solarization.
+        kernel_size:
+            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
+            Used to calculate sigma of gaussian blur with kernel_size * input_size.
+        sigmas:
+            Tuple of min and max value from which the std of the gaussian kernel is sampled.
+            Is ignored if `kernel_size` is set.
+        vf_prob:
+            Probability that vertical flip is applied.
+        hf_prob:
+            Probability that horizontal flip is applied.
+        rr_prob:
+            Probability that random rotation is applied.
+        rr_degrees:
+            Range of degrees to select from for random rotation. If rr_degrees is None,
+            images are rotated by 90 degrees. If rr_degrees is a (min, max) tuple,
+            images are rotated by a random angle in [min, max]. If rr_degrees is a
+            single number, images are rotated by a random angle in
+            [-rr_degrees, +rr_degrees]. All rotations are counter-clockwise.
+        normalize:
+            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
+
+    """
+
     def __init__(
         self,
         input_size: int = 224,
@@ -71,6 +138,74 @@ class BYOLView1Transform:
 
 
 class BYOLView2Transform:
+    """Transforms an image into the second view for BYOL [0].
+
+    Used by BYOLTransform to create the second view of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - Solarization
+        - ImageNet normalization
+
+    - [0]: Bootstrap Your Own Latent, 2020, https://arxiv.org/pdf/2006.07733.pdf
+
+    Attributes:
+        input_size:
+            Size of the input image in pixels.
+        cj_prob:
+            Probability that color jitter is applied.
+        cj_strength:
+            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
+            `cj_hue` are multiplied by this value. For datasets with small images,
+            such as CIFAR, it is recommended to set `cj_strength` to 0.5.
+        cj_bright:
+            How much to jitter brightness.
+        cj_contrast:
+            How much to jitter contrast.
+        cj_sat:
+            How much to jitter saturation.
+        cj_hue:
+            How much to jitter hue.
+        min_scale:
+            Minimum size of the randomized crop relative to the input_size.
+        random_gray_scale:
+            Probability of conversion to grayscale.
+        gaussian_blur:
+            Probability of Gaussian blur.
+        solarization_prob:
+            Probability of solarization.
+        kernel_size:
+            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
+            Used to calculate sigma of gaussian blur with kernel_size * input_size.
+        sigmas:
+            Tuple of min and max value from which the std of the gaussian kernel is sampled.
+            Is ignored if `kernel_size` is set.
+        vf_prob:
+            Probability that vertical flip is applied.
+        hf_prob:
+            Probability that horizontal flip is applied.
+        rr_prob:
+            Probability that random rotation is applied.
+        rr_degrees:
+            Range of degrees to select from for random rotation. If rr_degrees is None,
+            images are rotated by 90 degrees. If rr_degrees is a (min, max) tuple,
+            images are rotated by a random angle in [min, max]. If rr_degrees is a
+            single number, images are rotated by a random angle in
+            [-rr_degrees, +rr_degrees]. All rotations are counter-clockwise.
+        normalize:
+            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
+
+    """
+
     def __init__(
         self,
         input_size: int = 224,


### PR DESCRIPTION
Part of #1942

## Description
- [ ] My change is breaking

Follow-up to the review on this PR (raised by @liopeer): align the BYOL
view-transform docstrings with the Google style we want to standardise on.

- Move the constructor parameter docs out of the class-level `Attributes:`
  section into an `Args:` section inside each `__init__` docstring.
  `Attributes:` is for public instance variables, which these classes don't
  expose (only the internal `self.transform`), so the parameters belong under
  `__init__`.
- Use compact Google style: argument name and description on the same line
  (also applied to the two `__call__` docstrings so the file is internally
  consistent).
- Register `lightly.transforms.byol_transform` in
  `docs/source/lightly.transforms.rst` — it was missing entirely — with
  `:special-members: __call__, __init__` so the `__init__` docstrings render
  under autodoc.

Docs only — no runtime behaviour changes.

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [x] I have manually tested the change.

No code change, so existing tests apply. Verified:
- `make format-check` — clean
- `make lint` — clean
- `make type-check` — clean (533 source files)
- `python -m pytest tests/transforms` — 60 passed
- `make html-noplot` (in `docs/`) — build succeeded; the 17 warnings are
  pre-existing on master and unrelated to this file. Confirmed the rendered
  `build/html/lightly.transforms.html` now shows the `BYOLView1Transform` and
  `BYOLView2Transform` `__init__` parameters.

## Documentation
- [x] I have added docstrings to all public functions/methods.
- [x] My change requires a change to the documentation (`.rst` files).
- [x] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.

## Implications / comments / further issues
- The remaining undocumented `*ViewTransform` classes (#1942) follow in separate
  PRs grouped by method family, using this same format.
- `SimCLRViewTransform` (#1943) merged with the old `Attributes:` style; I'll
  update it to match in a follow-up, as agreed in the review thread.
