### PR TITLE
docs: align SimCLR transform docstrings with Google style

### DIFF
--- a/docs/source/lightly.transforms.rst
+++ b/docs/source/lightly.transforms.rst
@@ -77,7 +77,7 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.simclr_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.simsiam_transform
    :members:

--- a/lightly/transforms/simclr_transform.py
+++ b/lightly/transforms/simclr_transform.py
@@ -32,56 +32,6 @@ class SimCLRTransform(MultiViewTransform):
     - [0]: SimCLR v1, 2020, https://arxiv.org/abs/2002.05709
     - [1]: SimCLR v2, 2020, https://arxiv.org/abs/2006.10029
 
-    Input to this transform:
-        PIL Image or Tensor.
-
-    Output of this transform:
-        List of [tensor, tensor].
-
-    Attributes:
-        input_size:
-            Size of the input image in pixels.
-        cj_prob:
-            Probability that color jitter is applied.
-        cj_strength:
-            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
-            `cj_hue` are multiplied by this value. For datasets with small images,
-            such as CIFAR, it is recommended to set `cj_strength` to 0.5.
-        cj_bright:
-            How much to jitter brightness.
-        cj_contrast:
-            How much to jitter contrast.
-        cj_sat:
-            How much to jitter saturation.
-        cj_hue:
-            How much to jitter hue.
-        min_scale:
-            Minimum size of the randomized crop relative to the input_size.
-        random_gray_scale:
-            Probability of conversion to grayscale.
-        gaussian_blur:
-            Probability of Gaussian blur.
-        kernel_size:
-            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
-            Used to calculate sigma of gaussian blur with kernel_size * input_size.
-        sigmas:
-            Tuple of min and max value from which the std of the gaussian kernel is sampled.
-            Is ignored if `kernel_size` is set.
-        vf_prob:
-            Probability that vertical flip is applied.
-        hf_prob:
-            Probability that horizontal flip is applied.
-        rr_prob:
-            Probability that random rotation is applied.
-        rr_degrees:
-            Range of degrees to select from for random rotation. If rr_degrees is None,
-            images are rotated by 90 degrees. If rr_degrees is a (min, max) tuple,
-            images are rotated by a random angle in [min, max]. If rr_degrees is a
-            single number, images are rotated by a random angle in
-            [-rr_degrees, +rr_degrees]. All rotations are counter-clockwise.
-        normalize:
-            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
-
     """
 
     def __init__(
@@ -104,6 +54,40 @@ class SimCLRTransform(MultiViewTransform):
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes SimCLRTransform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value. For datasets
+                with small images, such as CIFAR, it is recommended to set
+                `cj_strength` to 0.5.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         view_transform = SimCLRViewTransform(
             input_size=input_size,
             cj_prob=cj_prob,
@@ -147,50 +131,6 @@ class SimCLRViewTransform:
     - [0]: SimCLR v1, 2020, https://arxiv.org/abs/2002.05709
     - [1]: SimCLR v2, 2020, https://arxiv.org/abs/2006.10029
 
-    Attributes:
-        input_size:
-            Size of the input image in pixels.
-        cj_prob:
-            Probability that color jitter is applied.
-        cj_strength:
-            Strength of the color jitter. `cj_bright`, `cj_contrast`, `cj_sat`, and
-            `cj_hue` are multiplied by this value. For datasets with small images,
-            such as CIFAR, it is recommended to set `cj_strength` to 0.5.
-        cj_bright:
-            How much to jitter brightness.
-        cj_contrast:
-            How much to jitter contrast.
-        cj_sat:
-            How much to jitter saturation.
-        cj_hue:
-            How much to jitter hue.
-        min_scale:
-            Minimum size of the randomized crop relative to the input_size.
-        random_gray_scale:
-            Probability of conversion to grayscale.
-        gaussian_blur:
-            Probability of Gaussian blur.
-        kernel_size:
-            Will be deprecated in favor of `sigmas` argument. If set, the old behavior applies and `sigmas` is ignored.
-            Used to calculate sigma of gaussian blur with kernel_size * input_size.
-        sigmas:
-            Tuple of min and max value from which the std of the gaussian kernel is sampled.
-            Is ignored if `kernel_size` is set.
-        vf_prob:
-            Probability that vertical flip is applied.
-        hf_prob:
-            Probability that horizontal flip is applied.
-        rr_prob:
-            Probability that random rotation is applied.
-        rr_degrees:
-            Range of degrees to select from for random rotation. If rr_degrees is None,
-            images are rotated by 90 degrees. If rr_degrees is a (min, max) tuple,
-            images are rotated by a random angle in [min, max]. If rr_degrees is a
-            single number, images are rotated by a random angle in
-            [-rr_degrees, +rr_degrees]. All rotations are counter-clockwise.
-        normalize:
-            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
-
     """
 
     def __init__(
@@ -213,6 +153,40 @@ class SimCLRViewTransform:
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes SimCLRViewTransform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value. For datasets
+                with small images, such as CIFAR, it is recommended to set
+                `cj_strength` to 0.5.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,
@@ -238,8 +212,7 @@ class SimCLRViewTransform:
         """Applies the transforms to the input image.
 
         Args:
-            image:
-                The input image to apply the transforms to.
+            image: The input image to apply the transforms to.
 
         Returns:
             The transformed image.


### PR DESCRIPTION
Part of #1942

## Description
- [ ] My change is breaking

Follow-up to the maintainer feedback in #1946: move constructor parameter
documentation from the class-level `Attributes:` section into compact same-line
Google-style `Args:` sections in each `__init__` docstring, matching the format
that landed in #1946 for the BYOL transforms.

Covers both classes in `simclr_transform.py`:
- `SimCLRViewTransform` — deletes `Attributes:`, adds `__init__` `Args:`
- `SimCLRTransform` — same treatment; also removes the duplicate Input/Output
  block that was left in the class docstring

Adds `:special-members: __init__` to the `simclr_transform` autodoc entry so
constructor parameters render in the Sphinx docs. Docs only — no runtime changes.

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [ ] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

```
make format-check          # All checks passed
make lint                  # All checks passed
make type-check            # Success: no issues found in 533 source files
python -m pytest tests/transforms  # 60 passed
```

## Documentation
- [x] I have added docstrings to all public functions/methods.
- [x] My change requires a change to the documentation ( `.rst` files).
- [x] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.

Constructor parameters now render under each class's `__init__` heading in
Sphinx, matching the BYOL transform pages from #1946.

## Implications / comments / further issues
- The remaining undocumented `*ViewTransform` classes from #1942 can follow the
  same `__init__` Args pattern once this format is confirmed.