### PR TITLE
docs: add docstrings to MSN, SimSiam, VICReg, and VICRegL view transforms

### DIFF
--- a/docs/source/lightly.transforms.rst
+++ b/docs/source/lightly.transforms.rst
@@ -49,7 +49,7 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.msn_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.multi_crop_transform
    :members:
@@ -81,7 +81,7 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.simsiam_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.smog_transform
    :members:
@@ -101,8 +101,8 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.vicreg_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.vicregl_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__

--- a/lightly/transforms/msn_transform.py
+++ b/lightly/transforms/msn_transform.py
@@ -134,6 +134,28 @@ class MSNTransform(MultiViewTransform):
 
 
 class MSNViewTransform:
+    """Transforms an image into a single view for MSN [0].
+
+    Used by MSNTransform to create the random and focal views of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Random vertical flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - ImageNet normalization
+
+    - [0]: Masked Siamese Networks, 2022: https://arxiv.org/abs/2204.07141
+
+    """
+
     def __init__(
         self,
         crop_size: int = 224,
@@ -152,6 +174,31 @@ class MSNViewTransform:
         vf_prob: float = 0.0,
         normalize: Dict[str, List[float]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes MSNViewTransform.
+
+        Args:
+            crop_size: Size of the cropped image in pixels.
+            crop_scale: Tuple of min and max scales relative to crop_size.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            gaussian_blur: Probability of Gaussian blur.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            random_gray_scale: Probability of conversion to grayscale.
+            hf_prob: Probability that horizontal flip is applied.
+            vf_prob: Probability that vertical flip is applied.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,

--- a/lightly/transforms/simsiam_transform.py
+++ b/lightly/transforms/simsiam_transform.py
@@ -116,6 +116,27 @@ class SimSiamTransform(MultiViewTransform):
 
 
 class SimSiamViewTransform:
+    """Transforms an image into a single view for SimSiam.
+
+    Used by SimSiamTransform to create the views of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Random vertical flip
+        - Random rotation
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - ImageNet normalization
+
+    """
+
     def __init__(
         self,
         input_size: int = 224,
@@ -136,6 +157,40 @@ class SimSiamViewTransform:
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes SimSiamViewTransform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value. For datasets
+                with small images, such as CIFAR, it is recommended to set
+                `cj_strength` to 0.5.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,

--- a/lightly/transforms/vicreg_transform.py
+++ b/lightly/transforms/vicreg_transform.py
@@ -123,6 +123,28 @@ class VICRegTransform(MultiViewTransform):
 
 
 class VICRegViewTransform:
+    """Transforms an image into a single view for VICReg.
+
+    Used by VICRegTransform to create the views of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Random vertical flip
+        - Random rotation
+        - Color jitter
+        - Random gray scale
+        - Random solarization
+        - Gaussian blur
+        - ImageNet normalization
+
+    """
+
     def __init__(
         self,
         input_size: int = 224,
@@ -144,6 +166,39 @@ class VICRegViewTransform:
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes VICRegViewTransform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            random_gray_scale: Probability of conversion to grayscale.
+            solarize_prob: Probability of solarization.
+            gaussian_blur: Probability of Gaussian blur.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -176,6 +176,28 @@ class VICRegLTransform(ImageGridTransform):
 
 
 class VICRegLViewTransform:
+    """Transforms an image into a single view for VICRegL [0].
+
+    Used by VICRegLTransform to create the global and local views of an image.
+    The crop and flip augmentations are applied separately by VICRegLTransform;
+    this transform applies the remaining photometric augmentations.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - Random solarization
+        - ImageNet normalization
+
+    - [0]: VICRegL, 2022, https://arxiv.org/abs/2210.01571
+
+    """
+
     def __init__(
         self,
         gaussian_blur_prob: float = 0.5,
@@ -191,6 +213,30 @@ class VICRegLViewTransform:
         random_gray_scale: float = 0.2,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes VICRegLViewTransform.
+
+        Args:
+            gaussian_blur_prob: Probability of Gaussian blur.
+            gaussian_blur_kernel_size: Will be deprecated in favor of
+                `gaussian_blur_sigmas` argument. If set, the old behavior applies
+                and `gaussian_blur_sigmas` is ignored. Used to calculate sigma of
+                gaussian blur with gaussian_blur_kernel_size * input_size.
+            gaussian_blur_sigmas: Tuple of min and max value from which the std of
+                the gaussian kernel is sampled. Is ignored if
+                `gaussian_blur_kernel_size` is set.
+            solarize_prob: Probability of solarization.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            random_gray_scale: Probability of conversion to grayscale.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,


### PR DESCRIPTION
Part of #1942

This PR:
- Adds Google-style docstrings to `MSNViewTransform`, `SimSiamViewTransform`,
  `VICRegViewTransform`, and `VICRegLViewTransform`, following the format agreed
  in #1946: an `Args:` block in `__init__` (name and description on the same line)
  rather than an `Attributes:` block on the class
- Adds `__init__` to `:special-members:` for these four modules in
  `docs/source/lightly.transforms.rst` so the new docstrings render in HTML

This PR does not:
- Change any runtime behavior (docs only)
- Touch the parent `MSNTransform` / `SimSiamTransform` / `VICRegTransform` /
  `VICRegLTransform` docstrings, which still use the older `Attributes:` style —
  those are out of scope for #1942

Notes:
- Each view docstring mirrors its parent transform's reference: `MSNViewTransform`
  and `VICRegLViewTransform` cite the method paper; `SimSiamViewTransform` and
  `VICRegViewTransform` do not, since their parents don't either
- `VICRegLViewTransform` only applies the photometric augmentations (color jitter,
  grayscale, blur, solarization, normalize) — the crop and flip are applied
  separately by `VICRegLTransform`, which the docstring calls out explicitly
- `:special-members: __init__` applies to all classes in each module, so the
  parent transforms' `__init__` signatures now render too; their parameters are
  still documented in their class-level `Attributes:` blocks

Tested with:
```
make format-check
make lint
make type-check
python -m pytest tests/transforms
```
All pass. Docstring augmentation lists were checked against each transform's
actual augmentation pipeline.