### PR TITLE
chore: add codespell pre-commit hook and fix typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
   - id: detect-private-key      # check for private keys
   - id: check-added-large-files # prevent commit of files >500kB
     args: ['--maxkb=500']
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.2
+  hooks:
+  - id: codespell
+    additional_dependencies: [tomli]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.7
   hooks:

--- a/docs/source/examples/byol.rst
+++ b/docs/source/examples/byol.rst
@@ -18,9 +18,9 @@ to achieve state-of-the-art performance on several semi-supervised and transfer 
 Key Components
 --------------
 
-- **Data Augmentations**: BYOL [0]_ uses the same augmentations as SimCLR [2]_, namely random resized crop, random horizontal flip, color distortions, Gaussian blur and solarization. The color distortion consists of a random sequence of brightness, constrast, saturation, hue adjustments and an optional grayscale conversion. However the hyperparameters for the augmentations are different from SimCLR [2]_.
+- **Data Augmentations**: BYOL [0]_ uses the same augmentations as SimCLR [2]_, namely random resized crop, random horizontal flip, color distortions, Gaussian blur and solarization. The color distortion consists of a random sequence of brightness, contrast, saturation, hue adjustments and an optional grayscale conversion. However the hyperparameters for the augmentations are different from SimCLR [2]_.
 - **Backbone**: BYOL [0]_ uses ResNet-type convolutional backbones as the online and target networks. They do not evaluate the performance of other architectures.
-- **Projection & Prediction Head**: A projection head is used to map the output of the backbone to a lower-dimensional space. For this, the target network once again relies on an EMA of the online network. A notable architectureal choice is the use of an additional prediction head, a secondary MLP appended to only the online network's projection head.
+- **Projection & Prediction Head**: A projection head is used to map the output of the backbone to a lower-dimensional space. For this, the target network once again relies on an EMA of the online network. A notable architectural choice is the use of an additional prediction head, a secondary MLP appended to only the online network's projection head.
 - **Loss Function**: BYOL [0]_ uses a negative cosine similarity loss between the representations of the online's prediction output and the target's projection output.
 
 Good to Know

--- a/docs/source/getting_started/benchmarks/imagenette_benchmark.py
+++ b/docs/source/getting_started/benchmarks/imagenette_benchmark.py
@@ -1221,7 +1221,7 @@ class VICRegLModel(BenchmarkModule):
 
         # The train_backbone variable is introduced in order to fit with the
         # structure of BenchmarkModule. During training, train_backbone is used
-        # to extract local and global features. Durig evaluation, backbone is used
+        # to extract local and global features. During evaluation, backbone is used
         # to evaluate global features.
         self.train_backbone = nn.Sequential(*list(resnet.children())[:-2])
         self.projection_head = heads.BarlowTwinsProjectionHead(512, 2048, 2048)

--- a/docs/source/getting_started/main_concepts.rst
+++ b/docs/source/getting_started/main_concepts.rst
@@ -26,7 +26,7 @@ below.
 
 * **Transform**
    In self-supervised learning, the input images are often randomly transformed into
-   *views* of the orignal images. The views and their underlying transforms are
+   *views* of the original images. The views and their underlying transforms are
    important as they define the properties of the model and the image embeddings.
    You can either use our pre-defined :py:mod:`~lightly.transforms` or write your own.
    For more information, check out the following pages:

--- a/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
+++ b/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
@@ -322,7 +322,7 @@ trainer.fit(model, dataloader_train)
 # Evaluate the results
 # ------------------------
 # It's always a good idea to evaluate how good the learned representations really
-# are. How to do this depends on the available data and metdata. Luckily, in our case,
+# are. How to do this depends on the available data and metadata. Luckily, in our case,
 # we have annotations of critical findings on the X-ray images. We can use this information
 # to see, whether images with similar annotations are grouped together.
 #

--- a/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
+++ b/docs/source/tutorials_source/package/tutorial_simclr_clothing.py
@@ -237,7 +237,7 @@ def plot_knn_examples(embeddings, filenames, n_neighbors=3, num_examples=6):
         for plot_x_offset, neighbor_idx in enumerate(indices[idx]):
             # add the subplot
             ax = fig.add_subplot(1, len(indices[idx]), plot_x_offset + 1)
-            # get the correponding filename for the current index
+            # get the corresponding filename for the current index
             fname = os.path.join(path_to_data, filenames[neighbor_idx])
             # plot the image
             plt.imshow(get_image_as_np_array(fname))
@@ -250,7 +250,7 @@ def plot_knn_examples(embeddings, filenames, n_neighbors=3, num_examples=6):
 # %%
 # Let's do the plot of the images. The leftmost image is the query image whereas
 # the ones next to it on the same row are the nearest neighbors.
-# In the title we see the distance of the neigbor.
+# In the title we see the distance of the neighbor.
 plot_knn_examples(embeddings, filenames)
 
 # %%

--- a/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
+++ b/docs/source/tutorials_source/package/tutorial_simsiam_esa.py
@@ -11,7 +11,7 @@ You can read up on the model in the paper
 `Exploring Simple Siamese Representation Learning <https://arxiv.org/abs/2011.10566>`_.
 
 We will be using a dataset of satellite images from ESAs Sentinel-2 satellite over Italy.
-If you're interested, you can get your own data from the `Copernicus Open Acces Hub <https://scihub.copernicus.eu/>`_.
+If you're interested, you can get your own data from the `Copernicus Open Access Hub <https://scihub.copernicus.eu/>`_.
 The original images have been cropped into smaller tiles due to their immense size and
 the dataset has been balanced based on a simple clustering of the mean RGB color values
 to prevent a surplus of images of the sea.

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,5 +21,5 @@ The examples should also run on [Google Colab](https://colab.research.google.com
 You can find additional information for each model in our [Documentation](https://docs.lightly.ai//examples/models.html#)
 
 > [!IMPORTANT]
-> The examples notebooks are generated using the [`create_example_nbs.py`](./create_example_nbs.py) script and should not be modified manually. All changes must be made to the respecitve example.
+> The examples notebooks are generated using the [`create_example_nbs.py`](./create_example_nbs.py) script and should not be modified manually. All changes must be made to the respective example.
 

--- a/examples/create_example_nbs.py
+++ b/examples/create_example_nbs.py
@@ -32,7 +32,7 @@ def covert_to_nbs(scripts_dir: Path, notebooks_dir: Path) -> None:
         print(f"Converting {py_file_path} to notebook...")
         notebook = jupytext.read(py_file_path)
         notebook = add_installation_cell(notebook, py_file_path)
-        # Make cell ids deterministic to avoid changing ids everytime a notebook is (re)generated.
+        # Make cell ids deterministic to avoid changing ids every time a notebook is (re)generated.
         for i, cell in enumerate(notebook.cells):
             cell.id = str(i)
         jupytext.write(notebook, notebook_path)

--- a/lightly/api/api_workflow_client.py
+++ b/lightly/api/api_workflow_client.py
@@ -79,7 +79,7 @@ class ApiWorkflowClient(
             see: https://docs.lightly.ai/docs/install-lightly#api-token
         dataset_id:
             The id of the dataset. If it is not set, but used by a workflow, the last
-            modfied dataset is taken by default.
+            modified dataset is taken by default.
         embedding_id:
             The id of the embedding to use. If it is not set, but used by a workflow,
             the newest embedding is taken by default

--- a/lightly/api/api_workflow_compute_worker.py
+++ b/lightly/api/api_workflow_compute_worker.py
@@ -66,7 +66,7 @@ class ComputeWorkerRunInfo:
         ]
 
     def ended_successfully(self) -> bool:
-        """Checkes whether the Lightly Worker run ended successfully or failed.
+        """Checks whether the Lightly Worker run ended successfully or failed.
 
         Returns:
             A boolean value indicating if the Lightly Worker run was successful.
@@ -279,7 +279,7 @@ class _ComputeWorkerMixin:
                 Selection configuration.
             runs_on:
                 The required labels the Lightly Worker must have to take the job.
-                See our docs for more information regarding the runs_on paramter:
+                See our docs for more information regarding the runs_on parameter:
                 https://docs.lightly.ai/docs/assign-scheduled-runs-to-specific-workers
 
         Returns:
@@ -485,7 +485,7 @@ class _ComputeWorkerMixin:
                 The ID with which the run was scheduled.
 
         Returns:
-            Defails of the scheduled run.
+            Details of the scheduled run.
 
         """
         try:

--- a/lightly/api/patch.py
+++ b/lightly/api/patch.py
@@ -40,7 +40,7 @@ def _Configuration__setstate__(self: Type, state: Dict[str, Any]) -> None:
     )
     self.logger["urllib3_logger"] = logging.getLogger("urllib3")
 
-    # Set logger_format and logger_file explicitly because they have setter decoraters
+    # Set logger_format and logger_file explicitly because they have setter decorators
     # defined on the Configuration class. These decorates have side effects and create
     # self.__logger_format, self.logger_formatter, self.__logger_file,
     # self.logger_file_handler, and self.logger_stream_handler under the hood.

--- a/lightly/api/utils.py
+++ b/lightly/api/utils.py
@@ -50,7 +50,7 @@ class Paginated(Iterator):
             self.offset += 1
             self.last_chunk_size = len(chunk)
             # Handle the case where the chunk is a string. In this case we want
-            # to return the whole page as a single string instead of an interable
+            # to return the whole page as a single string instead of an iterable
             # of characters.
             chunk = chunk if not isinstance(chunk, str) else [chunk]
             self.entries.extend(chunk)

--- a/lightly/cli/_cli_simclr.py
+++ b/lightly/cli/_cli_simclr.py
@@ -14,7 +14,7 @@ from lightly.models.modules import SimCLRProjectionHead
 class _SimCLR(nn.Module):
     """Implementation of SimCLR used by the command-line interface.
 
-    Provides backwards compatability with old checkpoints.
+    Provides backwards compatibility with old checkpoints.
     """
 
     def __init__(self, backbone: nn.Module, num_ftrs: int = 32, out_dim: int = 128):

--- a/lightly/cli/_helpers.py
+++ b/lightly/cli/_helpers.py
@@ -34,10 +34,10 @@ def fix_input_path(path):
 
 
 def fix_hydra_arguments(config_path: str = "config", config_name: str = "config"):
-    """Helper to make hydra arugments adaptive to installed hydra version
+    """Helper to make hydra arguments adaptive to installed hydra version
 
     Hydra introduced the `version_base` argument in version 1.2.0
-    We use this helper to provide backwards compatibility to older hydra verisons.
+    We use this helper to provide backwards compatibility to older hydra versions.
     """
     hydra_args = {"config_path": config_path, "config_name": config_name}
 
@@ -119,7 +119,7 @@ def _filter_state_dict(state_dict, remove_model_prefix_offset: int = 1):
     """Makes the state_dict compatible with the model.
 
     Prevents unexpected key error when loading PyTorch-Lightning checkpoints.
-    Allows backwards compatability to checkpoints before v1.0.6.
+    Allows backwards compatibility to checkpoints before v1.0.6.
 
     """
     prev_backbone = "features"
@@ -130,7 +130,7 @@ def _filter_state_dict(state_dict, remove_model_prefix_offset: int = 1):
         # remove the "model." prefix from the state dict key
         key_parts = key.split(".")[remove_model_prefix_offset:]
         # with v1.0.6 the backbone of the models will be renamed from
-        # "features" to "backbone", ensure compatability with old ckpts
+        # "features" to "backbone", ensure compatibility with old ckpts
         key_parts = [k if k != prev_backbone else curr_backbone for k in key_parts]
 
         new_key = ".".join(key_parts)

--- a/lightly/cli/crop_cli.py
+++ b/lightly/cli/crop_cli.py
@@ -92,7 +92,7 @@ def crop_cli(cfg):
         output_dir:
             Path to the directory where the cropped images are stored. They are stored in one directory per input image.
         crop_padding: Optional
-            The additonal padding about the bounding box. This makes the crops include the context of the object.
+            The additional padding about the bounding box. This makes the crops include the context of the object.
             The padding is relative and added to the width and height.
         label_names_file: Optional
             A yaml file including the names of the classes. If it is given, the filenames of the cropped images include

--- a/lightly/core.py
+++ b/lightly/core.py
@@ -80,7 +80,7 @@ def train_model_and_embed_images(
 ) -> Tuple[np.ndarray, List[int], List[str]]:
     """Train a self-supervised model and use it to embed images.
 
-    First trains a modle using the _train_cli(),
+    First trains a model using the _train_cli(),
     then embeds with the _embed_cli().
     All arguments passed to the CLI functions
     can also be passed to this function (see below for an example).
@@ -153,7 +153,7 @@ def train_embedding_model(config_path: str = None, **kwargs):
         >>>     input_dir='path/to/data', config_path=my_config_path)
         >>>
         >>> # train a model with default settings and overwrites: large batch
-        >>> # sizes are benefitial for self-supervised training and more
+        >>> # sizes are beneficial for self-supervised training and more
         >>> # workers speed up the dataloading process.
         >>> my_loader = {
         >>>     batch_size: 100,

--- a/lightly/data/_video.py
+++ b/lightly/data/_video.py
@@ -406,7 +406,7 @@ class VideoDataset(datasets.VisionDataset):
         self._video_index = None
 
         # Keep unique reference of dataloader worker. We need this to avoid
-        # accidentaly sharing VideoLoader instances between workers.
+        # accidentally sharing VideoLoader instances between workers.
         self._worker_ref = None
 
         # Lock to prevent multiple threads creating a new VideoLoader at the

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -109,7 +109,7 @@ class ImageCollateFunction(BaseCollateFunction):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:
@@ -598,7 +598,7 @@ class DINOCollateFunction(MultiViewCollateFunction):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:
@@ -787,7 +787,7 @@ class PIRLCollateFunction(nn.Module):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:
@@ -1092,7 +1092,7 @@ class VICRegCollateFunction(BaseCollateFunction):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/loss/dcl_loss.py
+++ b/lightly/loss/dcl_loss.py
@@ -86,7 +86,7 @@ class DCLLoss(nn.Module):
         weight_fn: Optional[Callable[[Tensor, Tensor], Tensor]] = None,
         gather_distributed: bool = False,
     ):
-        """Initialzes the DCLoss module.
+        """Initializes the DCLoss module.
 
         Args:
             temperature:

--- a/lightly/loss/detcon_loss.py
+++ b/lightly/loss/detcon_loss.py
@@ -236,7 +236,7 @@ class DetConBLoss(Module):
         labels_ab = labels_local * same_mask_ab
         labels_ba = labels_local * same_mask_ba
 
-        ### Remove Logits And Lables Between The Same View ###
+        ### Remove Logits And Labels Between The Same View ###
         logits_aa = logits_aa - infinity_proxy * labels_aa
         logits_bb = logits_bb - infinity_proxy * labels_bb
         labels_aa = 0.0 * labels_aa

--- a/lightly/loss/emp_ssl_loss.py
+++ b/lightly/loss/emp_ssl_loss.py
@@ -32,7 +32,7 @@ def tcr_loss(z: Tensor, eps: float) -> Tensor:
 
 
 def invariance_loss(z: Tensor) -> Tensor:
-    """Calculates the invariance loss, representing the similiarity between the patch embeddings and the average of
+    """Calculates the invariance loss, representing the similarity between the patch embeddings and the average of
     the patch embeddings.
 
     Args:

--- a/lightly/loss/hypersphere_loss.py
+++ b/lightly/loss/hypersphere_loss.py
@@ -15,13 +15,13 @@ class HypersphereLoss(Module):
     [0] Tongzhou Wang. et.al, 2020, ... https://arxiv.org/abs/2005.10242
 
     Note:
-        In order for this loss to function as advertized, an L1-normalization to the hypersphere is required.
+        In order for this loss to function as advertised, an L1-normalization to the hypersphere is required.
         This loss function applies this L1-normalization internally in the loss layer.
         However, it is recommended that the same normalization is also applied in your architecture,
         considering that this L1-loss is also intended to be applied during inference.
-        Perhaps there may be merit in leaving it out of the inferrence pathway, but this use has not been tested.
+        Perhaps there may be merit in leaving it out of the inference pathway, but this use has not been tested.
 
-        Moreover it is recommended that the layers preceeding this loss function are either a linear layer without activation,
+        Moreover it is recommended that the layers preceding this loss function are either a linear layer without activation,
         a batch-normalization layer, or both. The directly upstream architecture can have a large influence
         on the ability of this loss to achieve its stated aim of promoting uniformity on the hypersphere;
         and if by contrast the last layer going into the embedding is a RELU or similar nonlinearity,

--- a/lightly/loss/msn_loss.py
+++ b/lightly/loss/msn_loss.py
@@ -121,7 +121,7 @@ class MSNLoss(nn.Module):
             Weight factor lambda by which the regularization loss is scaled. Set to 0
             to disable regularization.
         me_max_weight:
-            Deprecated, use `regularization_weight` instead. Takes precendence over
+            Deprecated, use `regularization_weight` instead. Takes precedence over
             `regularization_weight` if not None. Weight factor lambda by which the mean
             entropy maximization regularization loss is scaled. Set to 0 to disable
             mean entropy maximization reguliarization.

--- a/lightly/loss/regularizer/co2.py
+++ b/lightly/loss/regularizer/co2.py
@@ -37,7 +37,7 @@ class CO2Regularizer(Module):
         >>> # initialize CO2 regularizer
         >>> co2 = CO2Regularizer(alpha=1.0, memory_bank_size=(4096, 128))
         >>>
-        >>> # generate two random trasnforms of images
+        >>> # generate two random transforms of images
         >>> t0 = transforms(images)
         >>> t1 = transforms(images)
         >>>
@@ -66,7 +66,7 @@ class CO2Regularizer(Module):
         """
         super().__init__()
         self.memory_bank = MemoryBankModule(size=memory_bank_size)
-        # Try-catch the KLDivLoss construction for backwards compatability
+        # Try-catch the KLDivLoss construction for backwards compatibility
         self.log_target = True
         try:
             self.kl_div = torch.nn.KLDivLoss(reduction="batchmean", log_target=True)

--- a/lightly/models/byol.py
+++ b/lightly/models/byol.py
@@ -77,7 +77,7 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
         """Forward pass through the encoder and the momentum encoder.
 
         Performs the momentum update, extracts features with the backbone and
-        applies the projection (and prediciton) head to the output space. If
+        applies the projection (and prediction) head to the output space. If
         x1 is None, only x0 will be processed otherwise, x0 is processed with
         the encoder and x1 with the momentum encoder.
 
@@ -88,7 +88,7 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
                 Tensor of shape bsz x channels x W x H.
 
         Returns:
-            The output proejction of x0 and (if x1 is not None) the output
+            The output projection of x0 and (if x1 is not None) the output
             projection of x1.
 
         Examples:

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -578,7 +578,7 @@ class SwaVPrototypes(nn.Module):
         n_prototypes: Union[List[int], int] = 3000,
         n_steps_frozen_prototypes: int = 0,
     ):
-        """Intializes the SwaVPrototypes module with the specified parameters"""
+        """Initializes the SwaVPrototypes module with the specified parameters"""
         super(SwaVPrototypes, self).__init__()
 
         # Default to a list of 1 if n_prototypes is an int.

--- a/lightly/models/modules/masked_autoencoder.py
+++ b/lightly/models/modules/masked_autoencoder.py
@@ -202,7 +202,7 @@ class MAEBackbone(vision_transformer.VisionTransformer):
         norm_layer:
             Callable that creates a normalization layer.
         conv_stem_configs:
-            If specified, a convolutional stem is added at the beggining of the
+            If specified, a convolutional stem is added at the beginning of the
             network following [2]. Not used in the original Masked Autoencoder
             paper [0].
 

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -1055,7 +1055,7 @@ def initialize_positional_embedding(
             f"{strategies}."
         )
 
-    # Initialize the positional embedding based on the startegy
+    # Initialize the positional embedding based on the strategy
     if strategy == "learn":
         initialize_learnable_positional_embedding(pos_embedding)
     elif strategy == "sincos":

--- a/lightly/transforms/densecl_transform.py
+++ b/lightly/transforms/densecl_transform.py
@@ -34,7 +34,7 @@ class DenseCLTransform(MoCoV2Transform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/detcon_transform.py
+++ b/lightly/transforms/detcon_transform.py
@@ -54,7 +54,7 @@ class DetConSTransform(MultiViewTransformV2):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -67,7 +67,7 @@ class DINOTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/fast_siam_transform.py
+++ b/lightly/transforms/fast_siam_transform.py
@@ -36,7 +36,7 @@ class FastSiamTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/ibot_transform.py
+++ b/lightly/transforms/ibot_transform.py
@@ -56,7 +56,7 @@ class IBOTTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/moco_transform.py
+++ b/lightly/transforms/moco_transform.py
@@ -31,7 +31,7 @@ class MoCoV1Transform(SimCLRTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:
@@ -140,7 +140,7 @@ class MoCoV2Transform(SimCLRTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/msn_transform.py
+++ b/lightly/transforms/msn_transform.py
@@ -53,7 +53,7 @@ class MSNTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/multi_view_transform_v2.py
+++ b/lightly/transforms/multi_view_transform_v2.py
@@ -22,7 +22,7 @@ class MultiViewTransformV2:
 
         Args:
             *args:
-                Arbitary positional arguments consisting of arbitrary data structures
+                Arbitrary positional arguments consisting of arbitrary data structures
                 containing images, bounding boxes and masks.
 
         Returns:

--- a/lightly/transforms/pirl_transform.py
+++ b/lightly/transforms/pirl_transform.py
@@ -36,7 +36,7 @@ class PIRLTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/simsiam_transform.py
+++ b/lightly/transforms/simsiam_transform.py
@@ -39,7 +39,7 @@ class SimSiamTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/smog_transform.py
+++ b/lightly/transforms/smog_transform.py
@@ -55,7 +55,7 @@ class SMoGTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/swav_transform.py
+++ b/lightly/transforms/swav_transform.py
@@ -56,7 +56,7 @@ class SwaVTransform(MultiCropTranform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/vicreg_transform.py
+++ b/lightly/transforms/vicreg_transform.py
@@ -42,7 +42,7 @@ class VICRegTransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/vicregl_transform.py
+++ b/lightly/transforms/vicregl_transform.py
@@ -85,7 +85,7 @@ class VICRegLTransform(ImageGridTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/transforms/wmse_transform.py
+++ b/lightly/transforms/wmse_transform.py
@@ -41,7 +41,7 @@ class WMSETransform(MultiViewTransform):
         cj_bright:
             How much to jitter brightness.
         cj_contrast:
-            How much to jitter constrast.
+            How much to jitter contrast.
         cj_sat:
             How much to jitter saturation.
         cj_hue:

--- a/lightly/utils/benchmarking/knn_classifier.py
+++ b/lightly/utils/benchmarking/knn_classifier.py
@@ -56,7 +56,7 @@ class KNNClassifier(LightningModule):
             >>> from torch import nn
             >>> import torchvision
             >>> from lightly.models import LinearClassifier
-            >>> from lightly.modles.modules import SimCLRProjectionHead
+            >>> from lightly.models.modules import SimCLRProjectionHead
             >>>
             >>> class SimCLR(nn.Module):
             >>>     def __init__(self):
@@ -162,7 +162,7 @@ class KNNClassifier(LightningModule):
         containing the kNN top-k accuracy metrics.
         """
         if self.model is None:
-            # We recieve the features directly
+            # We receive the features directly
             features, targets = batch
             features = self._prepare_features(features)
         else:

--- a/lightly/utils/benchmarking/linear_classifier.py
+++ b/lightly/utils/benchmarking/linear_classifier.py
@@ -45,7 +45,7 @@ class BaseClassifier(LightningModule, ABC):
             >>> from torch import nn
             >>> import torchvision
             >>> from lightly.models import LinearClassifier
-            >>> from lightly.modles.modules import SimCLRProjectionHead
+            >>> from lightly.models.modules import SimCLRProjectionHead
             >>>
             >>> class SimCLR(nn.Module):
             >>>     def __init__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,3 +342,7 @@ ignore_errors = true
 [tool.jupytext]
 notebook_metadata_filter="-all"
 cell_metadata_filter="-all"
+
+[tool.codespell]
+skip = "*.ipynb,*/openapi_generated/*"
+ignore-words-list = "nce,inpt,nd,wirth"

--- a/tests/api/test_swagger_api_client.py
+++ b/tests/api/test_swagger_api_client.py
@@ -32,6 +32,6 @@ def test_pickle(mocker: MockerFixture) -> None:
     assert isinstance(
         new_client.__dict__["rest_client"], LightlySwaggerRESTClientObject
     )
-    # Last reponse is completely removed from client object and is only dynamically
+    # Last response is completely removed from client object and is only dynamically
     # reassigned in the ApiClient.__call_api method.
     assert not hasattr(new_client, "last_response")

--- a/tests/api_workflow/mocked_api_workflow_client.py
+++ b/tests/api_workflow/mocked_api_workflow_client.py
@@ -401,7 +401,7 @@ class MockedTagsApi(TagsApi):
         return [
             FilenameAndReadUrl(
                 file_name="export-basic-test-sample-0.png",
-                read_url="https://storage.googleapis.com/somwhere/export-basic-test-sample-0.png?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=CENSORED",
+                read_url="https://storage.googleapis.com/somewhere/export-basic-test-sample-0.png?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=CENSORED",
             ).to_dict()  # temporary until we have a proper openapi generator
         ]
 

--- a/tests/api_workflow/test_api_workflow_client.py
+++ b/tests/api_workflow/test_api_workflow_client.py
@@ -35,7 +35,7 @@ class TestApiWorkflowClient(unittest.TestCase):
     def test_upload_file_with_signed_url_session_sse(self):
         session = mock.Mock()
         file = mock.Mock()
-        signed_write_url = "http://somwhere.s3.amazonaws.com/someimage.png"
+        signed_write_url = "http://somewhere.s3.amazonaws.com/someimage.png"
         client = ApiWorkflowClient(token="")
         # set the environment var to enable SSE
         os.environ[LIGHTLY_S3_SSE_KMS_KEY] = "True"
@@ -51,7 +51,7 @@ class TestApiWorkflowClient(unittest.TestCase):
     def test_upload_file_with_signed_url_session_sse_kms(self):
         session = mock.Mock()
         file = mock.Mock()
-        signed_write_url = "http://somwhere.s3.amazonaws.com/someimage.png"
+        signed_write_url = "http://somewhere.s3.amazonaws.com/someimage.png"
         client = ApiWorkflowClient(token="")
         # set the environment var to enable SSE with KMS
         sseKMSKey = "arn:aws:kms:us-west-2:123456789000:key/1234abcd-12ab-34cd-56ef-1234567890ab"

--- a/tests/api_workflow/test_api_workflow_tags.py
+++ b/tests/api_workflow/test_api_workflow_tags.py
@@ -91,7 +91,7 @@ def test_create_tag_from_filenames__file_not_found(mocker: MockerFixture) -> Non
             fnames_new_tag=["some-file"], new_tag_name="some-tag"
         )
         assert str(exception.value) == (
-            "An error occured when creating the new subset! "
+            "An error occurred when creating the new subset! "
             "Out of the 1 filenames you provided "
             "to create a new tag, only 0 have been found on the server. "
             "Make sure you use the correct filenames. "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def pytest_collection_modifyitems(config, items):
 def mock_versioning_api():
     """Fixture that is applied to all tests and mocks the versioning API.
 
-    This is necessary because everytime an ApiWorkflowClient instance is created, a call
+    This is necessary because every time an ApiWorkflowClient instance is created, a call
     to the versioning API is made. This fixture makes sure that these calls succeed
     while not actually sending any requests to the API.
 

--- a/tests/utils/benchmarking/test_benchmark_module.py
+++ b/tests/utils/benchmarking/test_benchmark_module.py
@@ -68,7 +68,7 @@ class TestBenchmarkModule:
         )  # accuracy is <1.0 because train val are different
 
 
-# Type ignore becaue of "Class cannot subclass "BenchmarkModule" (has type "Any")"
+# Type ignore because of "Class cannot subclass "BenchmarkModule" (has type "Any")"
 class _DummyModel(BenchmarkModule):  # type: ignore[misc]
     def __init__(
         self,


### PR DESCRIPTION
This pull request primarily addresses a wide range of minor spelling and typographical errors throughout the codebase and documentation to improve clarity and professionalism. Additionally, it introduces a new pre-commit hook for spell checking to help maintain code quality in the future.

**Quality assurance and tooling improvements:**

* Added the `codespell` pre-commit hook to `.pre-commit-config.yaml` to automatically detect and prevent spelling mistakes in future commits.

**Documentation and code comment corrections:**

* Fixed numerous spelling and typographical errors in documentation, code comments, and docstrings across the project, such as correcting "compatability" to "compatibility," "constrast" to "contrast," and other similar issues. [[1]](diffhunk://#diff-e2f83518c23b664c216776532cacb9e871484f480f81bb2b41631685d984628fL21-R23) [[2]](diffhunk://#diff-10d99adf7efc59f11a5c8ebf0b929020732a241f6f619b51533efc0c207bd098L1224-R1224) [[3]](diffhunk://#diff-422ab280e02c2edc4621a8633173e39da3176598a03c4aad3f4a2696fbbcb09bL29-R29) [[4]](diffhunk://#diff-fc049c8ef32482cc2609eb3aeb6332a2305a4e6247b43bc87bdc7dee730f1578L325-R325) [[5]](diffhunk://#diff-b54854d15a77d56736cf3997818558d539044e5fa521fa96f6e020e349772f17L240-R240) [[6]](diffhunk://#diff-b54854d15a77d56736cf3997818558d539044e5fa521fa96f6e020e349772f17L253-R253) [[7]](diffhunk://#diff-593d1e989c518b28597fb01810521061fe38815bf71024750fc36150a2a51732L14-R14) [[8]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L24-R24) [[9]](diffhunk://#diff-4ea80fea3000a98e1502a2e451b1af58d4e66556397be5f73b1f9cb79f876103L82-R82) [[10]](diffhunk://#diff-78a22c6a0731e070b19b9f35ad2fa9c831d2d3de228cd1ef85f3092274e9aba7L69-R69) [[11]](diffhunk://#diff-78a22c6a0731e070b19b9f35ad2fa9c831d2d3de228cd1ef85f3092274e9aba7L282-R282) [[12]](diffhunk://#diff-78a22c6a0731e070b19b9f35ad2fa9c831d2d3de228cd1ef85f3092274e9aba7L488-R488) [[13]](diffhunk://#diff-2ed1da1e93e1469fe1c59ee8c82821f4b14b7e75723b5e1f4bb7dc6751eeef21L43-R43) [[14]](diffhunk://#diff-78e0907ae28b8f815e82bccfe51ce46a5f6fc2251132acaa439d77c04c07c61dL53-R53) [[15]](diffhunk://#diff-ae71731d287b3bdfbd00e6159f78744c84fb5611b3fd1f627254c6ba13c376baL17-R17) [[16]](diffhunk://#diff-a7ccdea3879c4b310d3f9e12c06046f295880a5c57c3a54f5592616e72997705L37-R40) [[17]](diffhunk://#diff-a7ccdea3879c4b310d3f9e12c06046f295880a5c57c3a54f5592616e72997705L122-R122) [[18]](diffhunk://#diff-a7ccdea3879c4b310d3f9e12c06046f295880a5c57c3a54f5592616e72997705L133-R133) [[19]](diffhunk://#diff-c7512fd3457e7cde6a8860964d5f989c194eca4083735b3030d5a23b334d2f04L95-R95) [[20]](diffhunk://#diff-577d811da2a2e5e90a4847ef8999d65678142280e6cea034e0f65a4e3659fc16L83-R83) [[21]](diffhunk://#diff-577d811da2a2e5e90a4847ef8999d65678142280e6cea034e0f65a4e3659fc16L156-R156) [[22]](diffhunk://#diff-4bb17e004c846c55984590334464045b748859d9c86659638fdad2dc71667cadL409-R409) [[23]](diffhunk://#diff-bacf9bc1dab9e318873d7e84b2dff4fa5d1a46fa0479aabca52ef7c343872a5eL112-R112) [[24]](diffhunk://#diff-bacf9bc1dab9e318873d7e84b2dff4fa5d1a46fa0479aabca52ef7c343872a5eL601-R601) [[25]](diffhunk://#diff-bacf9bc1dab9e318873d7e84b2dff4fa5d1a46fa0479aabca52ef7c343872a5eL790-R790) [[26]](diffhunk://#diff-bacf9bc1dab9e318873d7e84b2dff4fa5d1a46fa0479aabca52ef7c343872a5eL1095-R1095) [[27]](diffhunk://#diff-2790dd8a0445d34aeb715294d4a0685b35d08c2146316fadcb415d3125b23830L89-R89)

---

- Add codespell v2.4.2 to .pre-commit-config.yaml with tomli dependency
- Add [tool.codespell] config to pyproject.toml: skip openapi_generated and *.ipynb, ignore-words-list for technical terms (nce, inpt, nd, wirth)
- Fix ~50 spelling errors across lightly/, tests/, docs/, examples/

closes #1770