### PR TITLE
Add PatchKernelAlignmentLoss (PaKa paper)

### DIFF
--- a/docs/source/lightly.loss.rst
+++ b/docs/source/lightly.loss.rst
@@ -56,6 +56,9 @@ lightly.loss
 .. autoclass:: lightly.loss.ntx_ent_loss.NTXentLoss
    :members:
 
+.. autoclass:: lightly.loss.patch_kernel_alignment_loss.PatchKernelAlignmentLoss
+   :members:
+
 .. autoclass:: lightly.loss.pmsn_loss.PMSNLoss
    :members:
 

--- a/lightly/loss/__init__.py
+++ b/lightly/loss/__init__.py
@@ -4,6 +4,7 @@
 # All Rights Reserved
 from lightly.loss.barlow_twins_loss import BarlowTwinsLoss
 from lightly.loss.dcl_loss import DCLLoss, DCLWLoss
+from lightly.loss.dense_relational_utils import roi_resample_to_grid
 from lightly.loss.detcon_loss import DetConBLoss, DetConSLoss
 from lightly.loss.dino_loss import DINOLoss
 from lightly.loss.directclr_loss import DirectCLRLoss
@@ -16,6 +17,7 @@ from lightly.loss.mmcr_loss import MMCRLoss
 from lightly.loss.msn_loss import MSNLoss
 from lightly.loss.negative_cosine_similarity import NegativeCosineSimilarity
 from lightly.loss.ntx_ent_loss import NTXentLoss
+from lightly.loss.patch_kernel_alignment_loss import PatchKernelAlignmentLoss
 from lightly.loss.pmsn_loss import PMSNCustomLoss, PMSNLoss
 from lightly.loss.swav_loss import SwaVLoss
 from lightly.loss.sym_neg_cos_sim_loss import SymNegCosineSimilarityLoss

--- a/lightly/loss/dense_relational_utils.py
+++ b/lightly/loss/dense_relational_utils.py
@@ -1,0 +1,231 @@
+"""Helpers for the dense relational PatchKernelAlignmentLoss.
+
+These utilities back :class:`~lightly.loss.PatchKernelAlignmentLoss`. The loss
+compares the pairwise similarity (kernel) structure of student and teacher dense
+features of shape ``(B, N, D)``. The helpers here cover:
+
+- validating dense-feature inputs,
+- optionally subsampling tokens to bound the ``O(N^2)`` kernel cost,
+- mask-aware double-centering of a kernel matrix.
+
+All math is local to each image, so the helpers are AMP-, CUDA- and DDP-safe
+without any cross-rank communication.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+def _validate_dense_inputs(
+    student_features: Tensor,
+    teacher_features: Tensor,
+    mask: Tensor | None,
+) -> None:
+    """Validates the shapes and dtypes of dense relational loss inputs.
+
+    Raises:
+        ValueError: If any input has an invalid shape or dtype.
+    """
+    if student_features.dim() != 3:
+        raise ValueError(
+            f"student_features must have shape (B, N, D) but has shape "
+            f"{tuple(student_features.shape)}."
+        )
+    if teacher_features.dim() != 3:
+        raise ValueError(
+            f"teacher_features must have shape (B, N, D) but has shape "
+            f"{tuple(teacher_features.shape)}."
+        )
+    if student_features.shape != teacher_features.shape:
+        raise ValueError(
+            f"student_features and teacher_features must have the same shape "
+            f"but have {tuple(student_features.shape)} and "
+            f"{tuple(teacher_features.shape)}."
+        )
+    if mask is not None:
+        batch_size, n_tokens, _ = student_features.shape
+        if mask.shape != (batch_size, n_tokens):
+            raise ValueError(
+                f"mask must have shape {(batch_size, n_tokens)} but has shape "
+                f"{tuple(mask.shape)}."
+            )
+        if mask.dtype != torch.bool:
+            raise ValueError(
+                f"mask must have dtype torch.bool but has dtype {mask.dtype}."
+            )
+
+
+def _prepare_features(
+    student_features: Tensor,
+    teacher_features: Tensor,
+    mask: Tensor | None,
+    max_tokens: int | None,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Prepares student/teacher features for kernel comparison.
+
+    Detaches the teacher and optionally subsamples a fixed number of (preferably
+    valid) tokens per image to bound the ``O(N^2)`` kernel cost.
+
+    Args:
+        student_features: Student dense features with shape ``(B, N, D)``.
+        teacher_features: Teacher dense features with shape ``(B, N, D)``.
+            Detached internally.
+        mask: Optional boolean tensor ``(B, N)`` where ``True`` marks tokens to
+            ignore (e.g. iBOT-masked positions). ``None`` keeps all tokens.
+        max_tokens: If not None and ``N > max_tokens``, randomly subsample
+            ``max_tokens`` tokens per image, preferring valid ones.
+
+    Returns:
+        A tuple ``(student, teacher, valid)`` where ``student`` and ``teacher``
+        have shape ``(B, M, D)`` and ``valid`` is a float tensor ``(B, M)`` with
+        ``1.0`` for valid tokens and ``0.0`` for ignored ones (``M = N`` unless
+        subsampled).
+    """
+    student = student_features
+    teacher = teacher_features.detach()
+
+    batch_size, n_tokens, _ = student.shape
+    if mask is None:
+        valid = student.new_ones(batch_size, n_tokens)
+    else:
+        # mask=True marks tokens to ignore, so valid tokens are ~mask.
+        valid = (~mask).to(student.dtype)
+
+    if max_tokens is not None and n_tokens > max_tokens:
+        # Sample max_tokens columns per image, preferring valid rows: invalid
+        # tokens get +inf scores so they are picked last.
+        scores = torch.rand(batch_size, n_tokens, device=student.device).masked_fill(
+            valid == 0, torch.inf
+        )
+        indices = scores.topk(max_tokens, dim=1, largest=False).indices  # (B, M)
+        student = torch.gather(
+            student, 1, indices.unsqueeze(-1).expand(-1, -1, student.shape[-1])
+        )
+        teacher = torch.gather(
+            teacher, 1, indices.unsqueeze(-1).expand(-1, -1, teacher.shape[-1])
+        )
+        valid = torch.gather(valid, 1, indices)
+
+    return student, teacher, valid
+
+
+def roi_resample_to_grid(
+    feature_map: Tensor,
+    boxes: Tensor,
+    out_h: int,
+    out_w: int,
+) -> Tensor:
+    """Resamples a per-sample ROI of a dense feature map onto a common grid.
+
+    Used by the cross-view variant of the loss: two views of the same image
+    (e.g. a teacher and a student crop) are each resampled over their shared
+    region onto an identical ``out_h x out_w`` grid so that token ``i`` describes
+    the same spatial location in both views, as required for a meaningful CKA
+    comparison. Thin, model-agnostic wrapper around
+    :func:`torchvision.ops.roi_align` (``aligned=True``, the pixel-center
+    convention for a continuous box mapping); differentiable w.r.t.
+    ``feature_map``.
+
+    Args:
+        feature_map: Dense features with shape ``(B, C, H, W)`` (e.g. ViT patch
+            tokens reshaped back to the patch grid).
+        boxes: ROI boxes ``(B, 4)`` as ``(x0, y0, x1, y1)`` in feature-grid
+            coordinates (``x`` in ``[0, W]``, ``y`` in ``[0, H]``), one per
+            sample, with ``x0 <= x1`` and ``y0 <= y1``.
+        out_h: Output grid height.
+        out_w: Output grid width.
+
+    Returns:
+        Resampled features ``(B, out_h * out_w, C)`` in row-major token order.
+
+    Raises:
+        ValueError: If shapes are invalid.
+    """
+    from torchvision.ops import roi_align
+
+    if feature_map.dim() != 4:
+        raise ValueError(
+            f"feature_map must have shape (B, C, H, W) but has shape "
+            f"{tuple(feature_map.shape)}."
+        )
+    if boxes.dim() != 2 or boxes.shape[1] != 4:
+        raise ValueError(
+            f"boxes must have shape (B, 4) but has shape {tuple(boxes.shape)}."
+        )
+    if boxes.shape[0] != feature_map.shape[0]:
+        raise ValueError(
+            f"boxes batch size {boxes.shape[0]} does not match feature_map "
+            f"batch size {feature_map.shape[0]}."
+        )
+    batch_index = torch.arange(
+        feature_map.shape[0], device=feature_map.device, dtype=feature_map.dtype
+    ).unsqueeze(1)
+    rois = torch.cat([batch_index, boxes.to(feature_map.dtype)], dim=1)  # (B, 5)
+    # roi_align is untyped (returns Any); annotate so the return type checks.
+    pooled: Tensor = roi_align(
+        feature_map,
+        rois,
+        output_size=(out_h, out_w),
+        spatial_scale=1.0,
+        aligned=True,
+    )  # (B, C, out_h, out_w)
+    return pooled.flatten(2).permute(0, 2, 1).contiguous()  # (B, out_h*out_w, C)
+
+
+def _linear_kernel(features: Tensor) -> Tensor:
+    """Returns the linear kernel ``features @ features^T`` with shape (B, N, N)."""
+    return features @ features.transpose(-2, -1)
+
+
+def _double_center(kernel: Tensor, valid: Tensor) -> Tensor:
+    """Mask-aware double-centering of a batch of kernel matrices.
+
+    Computes ``H K H`` with ``H = I - (1/n) 11^T`` restricted to valid tokens,
+    i.e. row/column/total means are taken over valid entries only. Entries
+    involving an invalid token are zeroed in the output.
+
+    Args:
+        kernel: Kernel matrices with shape ``(B, N, N)``.
+        valid: Float validity weights with shape ``(B, N)`` (1.0 valid, 0.0
+            ignored).
+
+    Returns:
+        Centered kernel matrices with shape ``(B, N, N)``.
+    """
+    w = valid.to(kernel.dtype)
+    n = w.sum(dim=-1).clamp(min=1.0)  # (B,)
+    # Row means over valid columns (mean over j for each row i).
+    row_mean = (kernel * w[:, None, :]).sum(dim=-1) / n[:, None]  # (B, N)
+    # Column means over valid rows (mean over i for each column j).
+    col_mean = (kernel * w[:, :, None]).sum(dim=1) / n[:, None]  # (B, N)
+    total = (kernel * w[:, None, :] * w[:, :, None]).sum(dim=(1, 2)) / (n * n)  # (B,)
+    centered = (
+        kernel - row_mean[:, :, None] - col_mean[:, None, :] + total[:, None, None]
+    )
+    return centered * w[:, :, None] * w[:, None, :]
+
+
+def _reduce_per_image(
+    loss_per_image: Tensor,
+    valid_image: Tensor,
+    reference: Tensor,
+) -> Tensor:
+    """Mean of the per-image loss over images with enough valid tokens.
+
+    Args:
+        loss_per_image: Per-image loss with shape ``(B,)``.
+        valid_image: Boolean tensor ``(B,)``; images with too few valid tokens
+            are excluded.
+        reference: A tensor connected to the student graph, used to build a
+            differentiable zero when no image is valid.
+
+    Returns:
+        The mean loss. A differentiable zero is returned if no image is valid.
+    """
+    valid_f = valid_image.to(loss_per_image.dtype)
+    loss_per_image = loss_per_image * valid_f
+    if not bool(valid_image.any()):
+        return (reference * 0.0).sum()
+    return loss_per_image.sum() / valid_f.sum().clamp(min=1.0)

--- a/lightly/loss/dense_relational_utils.py
+++ b/lightly/loss/dense_relational_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import torch
 from torch import Tensor
+from torchvision.ops import roi_align
 
 
 def _validate_dense_inputs(
@@ -91,7 +92,7 @@ def _prepare_features(
         valid = student.new_ones(batch_size, n_tokens)
     else:
         # mask=True marks tokens to ignore, so valid tokens are ~mask.
-        valid = (~mask).to(student.dtype)
+        valid = (~mask).to(device=student.device, dtype=student.dtype)
 
     if max_tokens is not None and n_tokens > max_tokens:
         # Sample max_tokens columns per image, preferring valid rows: invalid
@@ -119,14 +120,31 @@ def roi_resample_to_grid(
 ) -> Tensor:
     """Resamples a per-sample ROI of a dense feature map onto a common grid.
 
-    Used by the cross-view variant of the loss: two views of the same image
-    (e.g. a teacher and a student crop) are each resampled over their shared
-    region onto an identical ``out_h x out_w`` grid so that token ``i`` describes
-    the same spatial location in both views, as required for a meaningful CKA
-    comparison. Thin, model-agnostic wrapper around
-    :func:`torchvision.ops.roi_align` (``aligned=True``, the pixel-center
-    convention for a continuous box mapping); differentiable w.r.t.
-    ``feature_map``.
+    This helper is only needed for the **cross-view** variant of
+    :class:`~lightly.loss.PatchKernelAlignmentLoss`. When the student and teacher
+    see different (but overlapping) crops of the same image, token ``i`` of one
+    view does not describe the same spatial location as token ``i`` of the other,
+    so the kernels are not comparable. Resampling each view over its shared region
+    onto an identical ``out_h x out_w`` grid restores that correspondence, after
+    which the resampled features are passed to the loss as ``(B, N, D)`` with
+    ``N = out_h * out_w``. For the **same-view** case (both views already aligned,
+    e.g. iBOT-style masking) you call the loss directly and do not need this
+    helper.
+
+    Thin, model-agnostic wrapper around :func:`torchvision.ops.roi_align`
+    (``aligned=True``, the pixel-center convention for a continuous box mapping);
+    differentiable w.r.t. ``feature_map``.
+
+    Example (cross-view):
+        >>> import torch
+        >>> from lightly.loss import PatchKernelAlignmentLoss, roi_resample_to_grid
+        >>> # Patch tokens reshaped back to the (B, C, H, W) patch grid per view.
+        >>> student_map = student_tokens.transpose(1, 2).reshape(B, C, H, W)
+        >>> teacher_map = teacher_tokens.transpose(1, 2).reshape(B, C, H, W)
+        >>> # Shared region of both crops, in feature-grid coordinates (B, 4).
+        >>> student = roi_resample_to_grid(student_map, student_boxes, 7, 7)
+        >>> teacher = roi_resample_to_grid(teacher_map, teacher_boxes, 7, 7)
+        >>> loss = PatchKernelAlignmentLoss()(student, teacher)  # (B, 49, C)
 
     Args:
         feature_map: Dense features with shape ``(B, C, H, W)`` (e.g. ViT patch
@@ -143,8 +161,6 @@ def roi_resample_to_grid(
     Raises:
         ValueError: If shapes are invalid.
     """
-    from torchvision.ops import roi_align
-
     if feature_map.dim() != 4:
         raise ValueError(
             f"feature_map must have shape (B, C, H, W) but has shape "

--- a/lightly/loss/patch_kernel_alignment_loss.py
+++ b/lightly/loss/patch_kernel_alignment_loss.py
@@ -41,18 +41,33 @@ class PatchKernelAlignmentLoss(Module):
     internally. Geometry/ROI alignment for a cross-view variant is the caller's
     responsibility; the loss receives already aligned dense features.
 
+    Reference:
+        - [0]: Patch-Level Kernel Alignment for Dense Self-Supervised Learning
+          (PaKa), 2025, https://arxiv.org/abs/2509.05606
+
     Args:
         max_tokens:
             If not None and ``N > max_tokens``, randomly subsample
             ``max_tokens`` tokens per image (preferring valid ones) before
             forming the kernel, to bound the ``O(B N^2 D)`` cost.
 
-    Example:
+    Example (same view, e.g. iBOT-style masking):
         >>> criterion = PatchKernelAlignmentLoss(max_tokens=512)
         >>> loss = criterion(
         ...     student_features=student_features,  # (B, N, D)
         ...     teacher_features=teacher_features,  # (B, N, D)
         ... )
+
+    Example (cross view, student and teacher see different crops):
+        >>> from lightly.loss import roi_resample_to_grid
+        >>> # Reshape patch tokens back to the (B, C, H, W) patch grid per view.
+        >>> student_map = student_tokens.transpose(1, 2).reshape(B, C, H, W)
+        >>> teacher_map = teacher_tokens.transpose(1, 2).reshape(B, C, H, W)
+        >>> # Resample the shared region of both crops onto a common 7x7 grid so
+        >>> # token i refers to the same location in both views.
+        >>> student = roi_resample_to_grid(student_map, student_boxes, 7, 7)
+        >>> teacher = roi_resample_to_grid(teacher_map, teacher_boxes, 7, 7)
+        >>> loss = PatchKernelAlignmentLoss()(student, teacher)  # (B, 49, C)
     """
 
     def __init__(self, max_tokens: int | None = None) -> None:

--- a/lightly/loss/patch_kernel_alignment_loss.py
+++ b/lightly/loss/patch_kernel_alignment_loss.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from torch import Tensor
+from torch.nn import Module
+
+from lightly.loss.dense_relational_utils import (
+    _double_center,
+    _linear_kernel,
+    _prepare_features,
+    _reduce_per_image,
+    _validate_dense_inputs,
+)
+
+# Clamp before sqrt in the CKA denominator so the gradient stays finite when an
+# image's kernel is (near-)constant (HSIC -> 0); for non-degenerate images this
+# is a no-op.
+_EPS = 1e-6
+
+
+class PatchKernelAlignmentLoss(Module):
+    """Patch kernel alignment loss for dense self-supervised learning.
+
+    Aligns the *relational* structure of student and teacher dense features
+    rather than asking for exact patch correspondence. For each image it builds
+    the pairwise linear kernels of the student and teacher tokens and maximizes
+    their Centered Kernel Alignment (CKA):
+
+        K_s = Z_s Z_s^T,  K_t = Z_t Z_t^T
+        CKA = <H K_s H, H K_t H>_F / (||H K_s H||_F * ||H K_t H||_F)
+        L = 1 - CKA
+
+    where ``H = I - (1/N) 11^T`` is the centering matrix. CKA is invariant to
+    isotropic scaling and orthogonal transforms of the features, so the loss
+    captures region grouping and object-level organization without requiring
+    nearest-neighbour sorting, clustering, prototypes, or geometric patch
+    identity. This makes it well suited to detection and segmentation.
+
+    The loss is model-agnostic: it operates on dense features ``(B, N, D)``
+    where ``N`` is the number of ViT patch tokens (ConvNet features must be
+    flattened to ``(B, N, D)`` by the caller). Teacher features are detached
+    internally. Geometry/ROI alignment for a cross-view variant is the caller's
+    responsibility; the loss receives already aligned dense features.
+
+    Args:
+        max_tokens:
+            If not None and ``N > max_tokens``, randomly subsample
+            ``max_tokens`` tokens per image (preferring valid ones) before
+            forming the kernel, to bound the ``O(B N^2 D)`` cost.
+
+    Example:
+        >>> criterion = PatchKernelAlignmentLoss(max_tokens=512)
+        >>> loss = criterion(
+        ...     student_features=student_features,  # (B, N, D)
+        ...     teacher_features=teacher_features,  # (B, N, D)
+        ... )
+    """
+
+    def __init__(self, max_tokens: int | None = None) -> None:
+        """Initializes the PatchKernelAlignmentLoss module.
+
+        Raises:
+            ValueError: If ``max_tokens`` is not ``None`` and ``< 2``.
+        """
+        super().__init__()
+        if max_tokens is not None and max_tokens < 2:
+            raise ValueError(f"max_tokens must be >= 2 or None but is {max_tokens}.")
+        self.max_tokens = max_tokens
+
+    def forward(
+        self,
+        student_features: Tensor,
+        teacher_features: Tensor,
+        mask: Tensor | None = None,
+    ) -> Tensor:
+        """Computes the patch kernel alignment loss.
+
+        Args:
+            student_features:
+                Student dense features with shape ``(B, N, D)``.
+            teacher_features:
+                Teacher dense features with shape ``(B, N, D)``. Detached
+                internally.
+            mask:
+                Optional boolean tensor ``(B, N)`` where ``True`` marks tokens
+                to ignore. Images with fewer than two valid tokens do not
+                contribute to the loss.
+
+        Returns:
+            The mean loss over images with enough valid tokens, as a scalar
+            tensor. A differentiable zero is returned if no image qualifies.
+
+        Raises:
+            ValueError: If any input has an invalid shape or dtype.
+        """
+        _validate_dense_inputs(student_features, teacher_features, mask)
+
+        student, teacher, valid = _prepare_features(
+            student_features=student_features,
+            teacher_features=teacher_features,
+            mask=mask,
+            max_tokens=self.max_tokens,
+        )
+
+        # Compute the kernels and CKA in float32. Under bf16/fp16 the HSIC terms
+        # (sums of products of small centered-kernel entries) can underflow to 0,
+        # and the backward of sqrt(0) is +inf -> NaN gradients. This bites the
+        # cross-view variant where ROI-aligned regions can be small/near-constant.
+        student = student.float()
+        teacher = teacher.float()
+        valid_f = valid.float()
+        k_s = _double_center(_linear_kernel(student), valid_f)
+        k_t = _double_center(_linear_kernel(teacher), valid_f)
+
+        hsic_st = (k_s * k_t).sum(dim=(1, 2))
+        hsic_ss = (k_s * k_s).sum(dim=(1, 2))
+        hsic_tt = (k_t * k_t).sum(dim=(1, 2))
+        denom = hsic_ss.clamp_min(_EPS).sqrt() * hsic_tt.clamp_min(_EPS).sqrt()
+        cka = hsic_st / denom
+        loss_per_image = 1.0 - cka
+
+        valid_image = valid.sum(dim=-1) >= 2
+        return _reduce_per_image(
+            loss_per_image=loss_per_image,
+            valid_image=valid_image,
+            reference=student_features,
+        )

--- a/tests/loss/test_dense_relational_utils.py
+++ b/tests/loss/test_dense_relational_utils.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import torch
+
+from lightly.loss.dense_relational_utils import roi_resample_to_grid
+
+
+class TestRoiResampleToGrid:
+    def test_output_shape(self) -> None:
+        feat = torch.randn(2, 8, 16, 16)
+        boxes = torch.tensor([[0.0, 0.0, 16.0, 16.0], [4.0, 4.0, 12.0, 12.0]])
+        out = roi_resample_to_grid(feat, boxes, out_h=16, out_w=16)
+        assert out.shape == (2, 16 * 16, 8)
+
+    def test_subregion_matches_manual_crop(self) -> None:
+        # A box on exact cell boundaries resamples the corresponding sub-grid.
+        feat = torch.arange(4 * 4, dtype=torch.float32).reshape(1, 1, 4, 4)
+        # Top-left 2x2 region onto a 2x2 grid.
+        boxes = torch.tensor([[0.0, 0.0, 2.0, 2.0]])
+        out = roi_resample_to_grid(feat, boxes, out_h=2, out_w=2)
+        out_map = out.reshape(1, 2, 2, 1).permute(0, 3, 1, 2)
+        assert torch.allclose(out_map, feat[:, :, :2, :2], atol=1e-4)

--- a/tests/loss/test_patch_kernel_alignment_loss.py
+++ b/tests/loss/test_patch_kernel_alignment_loss.py
@@ -1,0 +1,44 @@
+import pytest
+import torch
+
+from lightly.loss.patch_kernel_alignment_loss import PatchKernelAlignmentLoss
+
+
+class TestPatchKernelAlignmentLoss:
+    def test_forward_returns_finite_scalar(self) -> None:
+        torch.manual_seed(0)
+        criterion = PatchKernelAlignmentLoss()
+        loss = criterion(
+            student_features=torch.randn(2, 16, 8),
+            teacher_features=torch.randn(2, 16, 8),
+        )
+        assert loss.shape == ()
+        assert torch.isfinite(loss)
+
+    def test_identical_features_give_near_zero_loss(self) -> None:
+        # CKA of a feature set with itself is 1, so the loss (1 - CKA) is ~0.
+        torch.manual_seed(0)
+        criterion = PatchKernelAlignmentLoss()
+        features = torch.randn(3, 16, 8)
+        loss = criterion(
+            student_features=features,
+            teacher_features=features.clone(),
+        )
+        assert loss.item() == pytest.approx(0.0, abs=1e-4)
+
+    def test_permuted_teacher_increases_loss(self) -> None:
+        # Shuffling the teacher tokens breaks patch-wise alignment, so CKA drops
+        # and the loss rises above the aligned baseline.
+        torch.manual_seed(0)
+        criterion = PatchKernelAlignmentLoss()
+        features = torch.randn(2, 16, 8)
+        loss_aligned = criterion(
+            student_features=features,
+            teacher_features=features.clone(),
+        )
+        permutation = torch.randperm(16)
+        loss_permuted = criterion(
+            student_features=features,
+            teacher_features=features[:, permutation].clone(),
+        )
+        assert loss_permuted > loss_aligned


### PR DESCRIPTION
## Changes

 - This PR adds a new loss for dense representations based on [Patch-Level Kernel Alignment for Dense Self-Supervised Learning](https://arxiv.org/abs/2509.05606)