### PR TITLE
docs: add docstrings to SwaVViewTransform and SmoGViewTransform

### DIFF
--- a/docs/source/lightly.transforms.rst
+++ b/docs/source/lightly.transforms.rst
@@ -89,7 +89,7 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.smog_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.solarize
    :members:
@@ -97,7 +97,7 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.swav_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.utils
    :members:

--- a/lightly/transforms/smog_transform.py
+++ b/lightly/transforms/smog_transform.py
@@ -120,6 +120,26 @@ class SMoGTransform(MultiViewTransform):
 
 
 class SmoGViewTransform:
+    """Transforms an image into a view for SMoG.
+
+    Used by SMoGTransform to create the views of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - Random solarization
+        - ImageNet normalization
+
+    """
+
     def __init__(
         self,
         crop_size: int = 224,
@@ -139,6 +159,32 @@ class SmoGViewTransform:
         random_gray_scale: float = 0.2,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes SmoGViewTransform.
+
+        Args:
+            crop_size: Size of the input image in pixels.
+            crop_min_scale: Minimum size of the randomized crop relative to the input_size.
+            crop_max_scale: Maximum size of the randomized crop relative to the input_size.
+            gaussian_blur_prob: Probability of Gaussian blur.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            solarize_prob: Probability of solarization.
+            hf_prob: Probability that horizontal flip is applied.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            random_gray_scale: Probability of conversion to grayscale.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,

--- a/lightly/transforms/swav_transform.py
+++ b/lightly/transforms/swav_transform.py
@@ -126,6 +126,26 @@ class SwaVTransform(MultiCropTranform):
 
 
 class SwaVViewTransform:
+    """Transforms an image into a view for SwaV.
+
+    Used by SwaVTransform to create the views of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random horizontal flip
+        - Random vertical flip
+        - Random rotation
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - ImageNet normalization
+
+    """
+
     def __init__(
         self,
         hf_prob: float = 0.5,
@@ -144,6 +164,36 @@ class SwaVViewTransform:
         sigmas: Tuple[float, float] = (0.1, 2),
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes SwaVViewTransform.
+
+        Args:
+            hf_prob: Probability that horizontal flip is applied.
+            vf_prob: Probability that vertical flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,


### PR DESCRIPTION
Part of #1942

## Description
- [ ] My change is breaking

Adds class and `__init__` docstrings to `SwaVViewTransform` and `SmoGViewTransform`
following the format established in #1946 (BYOL) and confirmed in #1948 (SimCLR):
compact same-line Google-style `Args:` in `__init__`, no `Attributes:` on the view
class.

This PR:
- `SwaVViewTransform` — adds class docstring and `__init__` `Args:`. The augmentation
  list omits random resized crop because the crop is applied externally by the
  `MultiCropTransform` base class, not by the view transform itself.
- `SmoGViewTransform` — adds class docstring and `__init__` `Args:`, including random
  resized crop which this transform applies directly.
- Adds `:special-members: __init__` to the `smog_transform` and `swav_transform`
  autodoc entries in `docs/source/lightly.transforms.rst` (both entries already
  existed; only the `__init__` toggle was missing).

Docs only — no runtime behaviour changes.

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [ ] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

```
make format-check          # All checks passed
make lint                  # All checks passed
make type-check            # Success: no issues found in 533 source files
python -m pytest tests/transforms  # 60 passed
```

## Documentation
- [x] I have added docstrings to all public functions/methods.
- [x] My change requires a change to the documentation (`.rst` files).
- [x] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.

Constructor parameters now render under each class's `__init__` heading in Sphinx.

## Implications / comments / further issues
- One family remains in #1942: `FDAView1Transform`, `FDAView2Transform`, and
  `DetConSViewTransform`. Note that `fda_transform` is currently missing from
  `lightly.transforms.rst` entirely and will need a new `automodule` entry (same
  situation as `byol_transform` in #1946).