### PR TITLE
docs: add docstrings to FDAView1Transform, FDAView2Transform, and DetConSViewTransform

### DIFF
--- a/docs/source/lightly.transforms.rst
+++ b/docs/source/lightly.transforms.rst
@@ -17,7 +17,7 @@ lightly.transforms
 
 .. automodule:: lightly.transforms.detcon_transform
    :members:
-   :special-members: __call__
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.dino_transform
    :members:
@@ -26,6 +26,10 @@ lightly.transforms
 .. automodule:: lightly.transforms.fast_siam_transform
    :members:
    :special-members: __call__
+
+.. automodule:: lightly.transforms.fda_transform
+   :members:
+   :special-members: __call__, __init__
 
 .. automodule:: lightly.transforms.gaussian_blur
    :members:

--- a/lightly/transforms/detcon_transform.py
+++ b/lightly/transforms/detcon_transform.py
@@ -165,6 +165,29 @@ class DetConSTransform(MultiViewTransformV2):
 
 
 class DetConSViewTransform:
+    """Transforms an image into a view for DetConS [0, 1].
+
+    Used by DetConSTransform to create the views of an image.
+
+    Input to this transform:
+        Arbitrary data structure containing images and masks compatible with
+        torchvision transforms v2.
+    Output of this transform:
+        Transformed data structure of the same type as the input.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - ImageNet normalization
+
+    - [0]: DetCon, 2021, https://arxiv.org/abs/2103.10957
+    - [1]: SimCLR, 2020, https://arxiv.org/abs/2002.05709
+
+    """
+
     def __init__(
         self,
         input_size: Union[Tuple[int, int], int] = 224,
@@ -185,6 +208,37 @@ class DetConSViewTransform:
         rr_degrees: Union[float, Tuple[float, float]] = 0.0,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ) -> None:
+        """Initializes DetConSViewTransform.
+
+        Args:
+            input_size: Size of the desired model input in pixels.
+            cj_prob: Probability that color jitter is applied.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value. For datasets
+                with small images, such as CIFAR, it is recommended to set
+                `cj_strength` to 0.5.
+            cj_bright: How much to jitter brightness.
+            cj_contrast: How much to jitter contrast.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            kernel_size: Size of the Gaussian kernel for Gaussian blur.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is a (min, max) tuple, images are rotated by a random
+                angle in [min, max]. If rr_degrees is a single number, images are
+                rotated by a random angle in [-rr_degrees, +rr_degrees]. All
+                rotations are counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,

--- a/lightly/transforms/fda_transform.py
+++ b/lightly/transforms/fda_transform.py
@@ -20,6 +20,35 @@ from lightly.transforms.utils import IMAGENET_NORMALIZE
 
 
 class FDAView1Transform:
+    """Transforms an image into the first view for FDA [0].
+
+    Used by FDATransform to create the first view of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - RFFT 2D transform
+        - Amplitude rescale transform
+        - Phase shift transform
+        - Random frequency mask transform
+        - Gaussian mixture mask
+        - IRFFT 2D transform
+        - Random horizontal flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - ImageNet normalization
+
+    - [0]: Disentangling the Effects of Data Augmentation and Format Transform in
+        Self-Supervised Learning of Image Representations, 2023,
+        https://arxiv.org/pdf/2312.02205
+
+    """
+
     def __init__(
         self,
         # Random resized crop
@@ -59,6 +88,51 @@ class FDAView1Transform:
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes FDAView1Transform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            cj_prob: Probability that color jitter is applied.
+            cj_contrast: How much to jitter contrast.
+            cj_bright: How much to jitter brightness.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            ampl_rescale_range: Range of the amplitude rescaling factor for
+                frequency domain augmentation.
+            ampl_rescale_prob: Probability of applying amplitude rescaling.
+            phase_shift_range: Range of the phase shift for frequency domain
+                augmentation.
+            phase_shift_prob: Probability of applying phase shifting.
+            rand_freq_mask_range: Range for the random frequency mask.
+            rand_freq_mask_prob: Probability of applying random frequency masking.
+            gmm_num_gaussians: Number of Gaussians in the Gaussian mixture mask.
+            gmm_std_range: Range of the standard deviation for the Gaussian mixture
+                mask in pixels.
+            gmm_prob: Probability of applying the Gaussian mixture mask.
+            solarization_prob: Probability of solarization.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,
@@ -120,6 +194,34 @@ class FDAView1Transform:
 
 
 class FDAView2Transform:
+    """Transforms an image into the second view for FDA [0].
+
+    Used by FDATransform to create the second view of an image.
+
+    Input to this transform:
+        PIL Image. (Tensor inputs are supported when torchvision transforms v2 are available.)
+    Output of this transform:
+        Tensor.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - RFFT 2D transform
+        - Amplitude rescale transform
+        - Phase shift transform
+        - Random frequency mask transform
+        - IRFFT 2D transform
+        - Random horizontal flip
+        - Color jitter
+        - Random gray scale
+        - Gaussian blur
+        - ImageNet normalization
+
+    - [0]: Disentangling the Effects of Data Augmentation and Format Transform in
+        Self-Supervised Learning of Image Representations, 2023,
+        https://arxiv.org/pdf/2312.02205
+
+    """
+
     def __init__(
         self,
         # Random resized crop
@@ -159,6 +261,51 @@ class FDAView2Transform:
         rr_degrees: Optional[Union[float, Tuple[float, float]]] = None,
         normalize: Union[None, Dict[str, List[float]]] = IMAGENET_NORMALIZE,
     ):
+        """Initializes FDAView2Transform.
+
+        Args:
+            input_size: Size of the input image in pixels.
+            min_scale: Minimum size of the randomized crop relative to the input_size.
+            cj_prob: Probability that color jitter is applied.
+            cj_contrast: How much to jitter contrast.
+            cj_bright: How much to jitter brightness.
+            cj_sat: How much to jitter saturation.
+            cj_hue: How much to jitter hue.
+            cj_strength: Strength of the color jitter. `cj_bright`, `cj_contrast`,
+                `cj_sat`, and `cj_hue` are multiplied by this value.
+            random_gray_scale: Probability of conversion to grayscale.
+            gaussian_blur: Probability of Gaussian blur.
+            sigmas: Tuple of min and max value from which the std of the gaussian
+                kernel is sampled. Is ignored if `kernel_size` is set.
+            kernel_size: Will be deprecated in favor of `sigmas` argument. If set,
+                the old behavior applies and `sigmas` is ignored. Used to calculate
+                sigma of gaussian blur with kernel_size * input_size.
+            ampl_rescale_range: Range of the amplitude rescaling factor for
+                frequency domain augmentation.
+            ampl_rescale_prob: Probability of applying amplitude rescaling.
+            phase_shift_range: Range of the phase shift for frequency domain
+                augmentation.
+            phase_shift_prob: Probability of applying phase shifting.
+            rand_freq_mask_range: Range for the random frequency mask.
+            rand_freq_mask_prob: Probability of applying random frequency masking.
+            gmm_num_gaussians: Number of Gaussians in the Gaussian mixture mask.
+            gmm_std_range: Range of the standard deviation for the Gaussian mixture
+                mask in pixels.
+            gmm_prob: Probability of applying the Gaussian mixture mask.
+            solarization_prob: Probability of solarization.
+            vf_prob: Probability that vertical flip is applied.
+            hf_prob: Probability that horizontal flip is applied.
+            rr_prob: Probability that random rotation is applied.
+            rr_degrees: Range of degrees to select from for random rotation. If
+                rr_degrees is None, images are rotated by 90 degrees. If rr_degrees
+                is a (min, max) tuple, images are rotated by a random angle in
+                [min, max]. If rr_degrees is a single number, images are rotated by
+                a random angle in [-rr_degrees, +rr_degrees]. All rotations are
+                counter-clockwise.
+            normalize: Dictionary with 'mean' and 'std' for
+                torchvision.transforms.Normalize.
+
+        """
         color_jitter = T.ColorJitter(
             brightness=cj_strength * cj_bright,
             contrast=cj_strength * cj_contrast,


### PR DESCRIPTION
Part of #1942

## Description
- [ ] My change is breaking

Adds class and `__init__` docstrings to `FDAView1Transform`, `FDAView2Transform`,
and `DetConSViewTransform`, following the format established in #1946 and #1948:
compact same-line Google-style `Args:` in `__init__`, no `Attributes:` on the view
class.

This PR:
- `FDAView1Transform` / `FDAView2Transform` — adds class docstrings and `__init__`
  `Args:`. The two views have different augmentation lists: View1 includes Gaussian
  mixture mask (`gmm_prob=0.2`); View2 omits it (`gmm_prob=0.0` by default). Both
  omit vertical flip, random rotation, and solarization (all default to prob 0.0).
- `DetConSViewTransform` — adds class docstring and `__init__` `Args:`. The Input
  section differs from other view transforms: this class accepts arbitrary data
  structures containing images and masks (torchvision transforms v2 compatible), not
  just PIL images, matching how `DetConSTransform` uses it.
- Adds a new `automodule` entry for `lightly.transforms.fda_transform` to
  `docs/source/lightly.transforms.rst` — it was missing entirely (same situation as
  `byol_transform` in #1946). Adds `:special-members: __init__` to the existing
  `detcon_transform` entry.

Docs only — no runtime behaviour changes.

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [ ] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

```
make format-check          # All checks passed
make lint                  # All checks passed
make type-check            # Success: no issues found in 533 source files
python -m pytest tests/transforms  # 60 passed
```

## Documentation
- [x] I have added docstrings to all public functions/methods.
- [x] My change requires a change to the documentation (`.rst` files).
- [x] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.

Constructor parameters now render under each class's `__init__` heading in Sphinx.
The `fda_transform` module page is new.

## Implications / comments / further issues
- This is the final PR in #1942 — all 14 `*ViewTransform` classes now have
  `__init__` docstrings.