### PR TITLE
examples: add FDA training example (pytorch)

### DIFF
--- a/examples/notebooks/pytorch/fda.ipynb
+++ b/examples/notebooks/pytorch/fda.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "This example requires the following dependencies to be installed:\n",
+    "pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Note: The model and training settings do not follow the reference settings\n",
+    "from the paper. The settings are chosen such that the example can easily be\n",
+    "run on a small dataset with a single GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torchvision\n",
+    "from torch import nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightly.loss import NTXentLoss\n",
+    "from lightly.models.modules import SimCLRProjectionHead\n",
+    "from lightly.transforms.fda_transform import (\n",
+    "    FDATransform,\n",
+    "    FDAView1Transform,\n",
+    "    FDAView2Transform,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FDA(nn.Module):\n",
+    "    def __init__(self, backbone):\n",
+    "        super().__init__()\n",
+    "        self.backbone = backbone\n",
+    "        self.projection_head = SimCLRProjectionHead(512, 512, 128)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.backbone(x).flatten(start_dim=1)\n",
+    "        z = self.projection_head(x)\n",
+    "        return z"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resnet = torchvision.models.resnet18()\n",
+    "backbone = nn.Sequential(*list(resnet.children())[:-1])\n",
+    "model = FDA(backbone)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "model.to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform = FDATransform(\n",
+    "    view_1_transform=FDAView1Transform(input_size=32, gaussian_blur=0.0),\n",
+    "    view_2_transform=FDAView2Transform(input_size=32, gaussian_blur=0.0),\n",
+    ")\n",
+    "dataset = torchvision.datasets.CIFAR10(\n",
+    "    \"datasets/cifar10\", download=True, transform=transform\n",
+    ")\n",
+    "# or create a dataset from a folder containing images or videos:\n",
+    "# dataset = LightlyDataset(\"path/to/folder\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataloader = torch.utils.data.DataLoader(\n",
+    "    dataset,\n",
+    "    batch_size=256,\n",
+    "    shuffle=True,\n",
+    "    drop_last=True,\n",
+    "    num_workers=8,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "criterion = NTXentLoss()\n",
+    "optimizer = torch.optim.SGD(model.parameters(), lr=0.06)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Starting Training\")\n",
+    "for epoch in range(10):\n",
+    "    total_loss = 0\n",
+    "    for batch in dataloader:\n",
+    "        x0, x1 = batch[0]\n",
+    "        x0 = x0.to(device)\n",
+    "        x1 = x1.to(device)\n",
+    "        z0 = model(x0)\n",
+    "        z1 = model(x1)\n",
+    "        loss = criterion(z0, z1)\n",
+    "        total_loss += loss.detach()\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "        optimizer.zero_grad()\n",
+    "    avg_loss = total_loss / len(dataloader)\n",
+    "    print(f\"epoch: {epoch:>02}, loss: {avg_loss:.5f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/pytorch/fda.py
+++ b/examples/pytorch/fda.py
@@ -1,0 +1,76 @@
+# This example requires the following dependencies to be installed:
+# pip install lightly
+
+# Note: The model and training settings do not follow the reference settings
+# from the paper. The settings are chosen such that the example can easily be
+# run on a small dataset with a single GPU.
+
+import torch
+import torchvision
+from torch import nn
+
+from lightly.loss import NTXentLoss
+from lightly.models.modules import SimCLRProjectionHead
+from lightly.transforms.fda_transform import (
+    FDATransform,
+    FDAView1Transform,
+    FDAView2Transform,
+)
+
+
+class FDA(nn.Module):
+    def __init__(self, backbone):
+        super().__init__()
+        self.backbone = backbone
+        self.projection_head = SimCLRProjectionHead(512, 512, 128)
+
+    def forward(self, x):
+        x = self.backbone(x).flatten(start_dim=1)
+        z = self.projection_head(x)
+        return z
+
+
+resnet = torchvision.models.resnet18()
+backbone = nn.Sequential(*list(resnet.children())[:-1])
+model = FDA(backbone)
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+model.to(device)
+
+transform = FDATransform(
+    view_1_transform=FDAView1Transform(input_size=32, gaussian_blur=0.0),
+    view_2_transform=FDAView2Transform(input_size=32, gaussian_blur=0.0),
+)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
+
+dataloader = torch.utils.data.DataLoader(
+    dataset,
+    batch_size=256,
+    shuffle=True,
+    drop_last=True,
+    num_workers=8,
+)
+
+criterion = NTXentLoss()
+optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
+
+print("Starting Training")
+for epoch in range(10):
+    total_loss = 0
+    for batch in dataloader:
+        x0, x1 = batch[0]
+        x0 = x0.to(device)
+        x1 = x1.to(device)
+        z0 = model(x0)
+        z1 = model(x1)
+        loss = criterion(z0, z1)
+        total_loss += loss.detach()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+    avg_loss = total_loss / len(dataloader)
+    print(f"epoch: {epoch:>02}, loss: {avg_loss:.5f}")


### PR DESCRIPTION
Part of #1956

## Description
- [ ] My change is breaking

Adds `examples/pytorch/fda.py` following `examples/pytorch/simclr.py` as a
template. The model and loss are identical to SimCLR (`NTXentLoss` +
`SimCLRProjectionHead`); only the transform differs. `FDATransform` does not
accept `input_size` directly, so view transforms are passed explicitly — same
pattern as `byol.py` and `tico.py`.

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [ ] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

```
make format-check  # All checks passed
make lint          # All checks passed
```
Ran the example on CIFAR-10; loss decreased over 4 epochs.

## Documentation
- [ ] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation (`.rst` files).
- [ ] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.