### PR TITLE
Add DetConS pytorch training example

### DIFF
--- a/examples/notebooks/pytorch/detcon.ipynb
+++ b/examples/notebooks/pytorch/detcon.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "This example requires the following dependencies to be installed:\n",
+    "pip install lightly\n",
+    "Note: This example requires torchvision >= 0.17 for tv_tensors support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Note: The model and training settings do not follow the reference settings\n",
+    "from the paper. The settings are chosen such that the example can easily be\n",
+    "run on a small dataset with a single GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision\n",
+    "from torch import nn\n",
+    "from torchvision.transforms.v2 import ToImage\n",
+    "from torchvision.tv_tensors import Mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightly.loss import DetConSLoss\n",
+    "from lightly.models import utils\n",
+    "from lightly.models.modules import SimCLRProjectionHead\n",
+    "from lightly.transforms import DetConSTransform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DetConS(nn.Module):\n",
+    "    def __init__(self, backbone):\n",
+    "        super().__init__()\n",
+    "        self.backbone = backbone\n",
+    "        self.projection_head = SimCLRProjectionHead(512, 512, 128)\n",
+    "\n",
+    "    def forward(self, x, mask):\n",
+    "        features = self.backbone(x)\n",
+    "        h, w = features.shape[2], features.shape[3]\n",
+    "        mask_down = (\n",
+    "            F.interpolate(mask.float(), size=(h, w), mode=\"nearest\").long().squeeze(1)\n",
+    "        )\n",
+    "        pooled = utils.pool_masked(features, mask_down, num_cls=25)\n",
+    "        pooled = pooled.permute(0, 2, 1)\n",
+    "        b, m, d = pooled.shape\n",
+    "        z = self.projection_head(pooled.reshape(b * m, d))\n",
+    "        return z.reshape(b, m, -1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resnet = torchvision.models.resnet18()\n",
+    "backbone = nn.Sequential(*list(resnet.children())[:-2])\n",
+    "model = DetConS(backbone)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "model.to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_detcons_transform = DetConSTransform(grid_size=(5, 5), input_size=96)\n",
+    "_to_image = ToImage()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def transform(pil_img):\n",
+    "    tv_img = _to_image(pil_img)\n",
+    "    dummy_mask = Mask(torch.zeros(1, *tv_img.shape[-2:], dtype=torch.int64))\n",
+    "    return _detcons_transform(tv_img, dummy_mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = torchvision.datasets.CIFAR10(\n",
+    "    \"datasets/cifar10\", download=True, transform=transform\n",
+    ")\n",
+    "# or create a dataset from a folder containing images or videos:\n",
+    "# dataset = LightlyDataset(\"path/to/folder\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataloader = torch.utils.data.DataLoader(\n",
+    "    dataset,\n",
+    "    batch_size=256,\n",
+    "    shuffle=True,\n",
+    "    drop_last=True,\n",
+    "    num_workers=8,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "criterion = DetConSLoss(gather_distributed=False)\n",
+    "optimizer = torch.optim.SGD(model.parameters(), lr=0.06)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = 10\n",
+    "mask_indices = torch.arange(25, device=device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Starting Training\")\n",
+    "for epoch in range(epochs):\n",
+    "    total_loss = 0\n",
+    "    for batch in dataloader:\n",
+    "        (x0, mask0), (x1, mask1) = batch[0]\n",
+    "        x0 = x0.to(device)\n",
+    "        mask0 = mask0.to(device)\n",
+    "        x1 = x1.to(device)\n",
+    "        mask1 = mask1.to(device)\n",
+    "        z0 = model(x0, mask0)\n",
+    "        z1 = model(x1, mask1)\n",
+    "        idx = mask_indices.unsqueeze(0).expand(x0.shape[0], -1)\n",
+    "        loss = criterion(z0, z1, idx, idx)\n",
+    "        total_loss += loss.detach()\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "        optimizer.zero_grad()\n",
+    "    avg_loss = total_loss / len(dataloader)\n",
+    "    print(f\"epoch: {epoch:>02}, loss: {avg_loss:.5f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/pytorch/detcon.py
+++ b/examples/pytorch/detcon.py
@@ -1,0 +1,96 @@
+# This example requires the following dependencies to be installed:
+# pip install lightly
+# Note: This example requires torchvision >= 0.17 for tv_tensors support.
+
+# Note: The model and training settings do not follow the reference settings
+# from the paper. The settings are chosen such that the example can easily be
+# run on a small dataset with a single GPU.
+
+import torch
+import torch.nn.functional as F
+import torchvision
+from torch import nn
+from torchvision.transforms.v2 import ToImage
+from torchvision.tv_tensors import Mask
+
+from lightly.loss import DetConSLoss
+from lightly.models import utils
+from lightly.models.modules import SimCLRProjectionHead
+from lightly.transforms import DetConSTransform
+
+
+class DetConS(nn.Module):
+    def __init__(self, backbone):
+        super().__init__()
+        self.backbone = backbone
+        self.projection_head = SimCLRProjectionHead(512, 512, 128)
+
+    def forward(self, x, mask):
+        features = self.backbone(x)
+        h, w = features.shape[2], features.shape[3]
+        mask_down = (
+            F.interpolate(mask.float(), size=(h, w), mode="nearest").long().squeeze(1)
+        )
+        pooled = utils.pool_masked(features, mask_down, num_cls=25)
+        pooled = pooled.permute(0, 2, 1)
+        b, m, d = pooled.shape
+        z = self.projection_head(pooled.reshape(b * m, d))
+        return z.reshape(b, m, -1)
+
+
+resnet = torchvision.models.resnet18()
+backbone = nn.Sequential(*list(resnet.children())[:-2])
+model = DetConS(backbone)
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+model.to(device)
+
+_detcons_transform = DetConSTransform(grid_size=(5, 5), input_size=96)
+_to_image = ToImage()
+
+
+def transform(pil_img):
+    tv_img = _to_image(pil_img)
+    dummy_mask = Mask(torch.zeros(1, *tv_img.shape[-2:], dtype=torch.int64))
+    return _detcons_transform(tv_img, dummy_mask)
+
+
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
+
+dataloader = torch.utils.data.DataLoader(
+    dataset,
+    batch_size=256,
+    shuffle=True,
+    drop_last=True,
+    num_workers=8,
+)
+
+criterion = DetConSLoss(gather_distributed=False)
+optimizer = torch.optim.SGD(model.parameters(), lr=0.06)
+
+epochs = 10
+mask_indices = torch.arange(25, device=device)
+
+print("Starting Training")
+for epoch in range(epochs):
+    total_loss = 0
+    for batch in dataloader:
+        (x0, mask0), (x1, mask1) = batch[0]
+        x0 = x0.to(device)
+        mask0 = mask0.to(device)
+        x1 = x1.to(device)
+        mask1 = mask1.to(device)
+        z0 = model(x0, mask0)
+        z1 = model(x1, mask1)
+        idx = mask_indices.unsqueeze(0).expand(x0.shape[0], -1)
+        loss = criterion(z0, z1, idx, idx)
+        total_loss += loss.detach()
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+    avg_loss = total_loss / len(dataloader)
+    print(f"epoch: {epoch:>02}, loss: {avg_loss:.5f}")


### PR DESCRIPTION
Part of #1957

## Summary

- Adds `examples/pytorch/detcon.py` for DetConS (SimCLR-based contrastive detection).
- Uses `DetConSTransform(grid_size=(5, 5))` with the built-in `AddGridTransform` — no
  external segmentation dependency (no scikit-image needed).

## Testing

- `make format`
- `make generate-example-notebooks`
- `make all-checks` *(fails locally in `tests/utils/test_dist__gather__losses.py::TestGatherLayer_Losses::test_loss_dcl` and 3 others; all pre-exist on upstream master)*
- Trained the example for 5 epochs on CIFAR-10; loss went from 18.5 to 15.3.