### PR TITLE
examples: add FDA training examples (pytorch_lightning, pytorch_lightning_distributed)

### DIFF
--- a/examples/notebooks/pytorch_lightning/fda.ipynb
+++ b/examples/notebooks/pytorch_lightning/fda.ipynb
@@ -1,0 +1,168 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "This example requires the following dependencies to be installed:\n",
+    "pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Note: The model and training settings do not follow the reference settings\n",
+    "from the paper. The settings are chosen such that the example can easily be\n",
+    "run on a small dataset with a single GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pytorch_lightning as pl\n",
+    "import torch\n",
+    "import torchvision\n",
+    "from torch import nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightly.loss import NTXentLoss\n",
+    "from lightly.models.modules import SimCLRProjectionHead\n",
+    "from lightly.transforms.fda_transform import (\n",
+    "    FDATransform,\n",
+    "    FDAView1Transform,\n",
+    "    FDAView2Transform,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FDA(pl.LightningModule):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        resnet = torchvision.models.resnet18()\n",
+    "        self.backbone = nn.Sequential(*list(resnet.children())[:-1])\n",
+    "        self.projection_head = SimCLRProjectionHead(512, 512, 128)\n",
+    "        self.criterion = NTXentLoss()\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.backbone(x).flatten(start_dim=1)\n",
+    "        z = self.projection_head(x)\n",
+    "        return z\n",
+    "\n",
+    "    def training_step(self, batch, batch_index):\n",
+    "        (x0, x1) = batch[0]\n",
+    "        z0 = self.forward(x0)\n",
+    "        z1 = self.forward(x1)\n",
+    "        loss = self.criterion(z0, z1)\n",
+    "        return loss\n",
+    "\n",
+    "    def configure_optimizers(self):\n",
+    "        optim = torch.optim.SGD(self.parameters(), lr=0.06)\n",
+    "        return optim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = FDA()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform = FDATransform(\n",
+    "    view_1_transform=FDAView1Transform(input_size=32, gaussian_blur=0.0),\n",
+    "    view_2_transform=FDAView2Transform(input_size=32, gaussian_blur=0.0),\n",
+    ")\n",
+    "dataset = torchvision.datasets.CIFAR10(\n",
+    "    \"datasets/cifar10\", download=True, transform=transform\n",
+    ")\n",
+    "# or create a dataset from a folder containing images or videos:\n",
+    "# dataset = LightlyDataset(\"path/to/folder\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataloader = torch.utils.data.DataLoader(\n",
+    "    dataset,\n",
+    "    batch_size=256,\n",
+    "    shuffle=True,\n",
+    "    drop_last=True,\n",
+    "    num_workers=8,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accelerator = \"gpu\" if torch.cuda.is_available() else \"cpu\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer = pl.Trainer(max_epochs=10, devices=1, accelerator=accelerator)\n",
+    "trainer.fit(model=model, train_dataloaders=dataloader)"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/pytorch_lightning_distributed/fda.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/fda.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "This example requires the following dependencies to be installed:\n",
+    "pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Note: The model and training settings do not follow the reference settings\n",
+    "from the paper. The settings are chosen such that the example can easily be\n",
+    "run on a small dataset with a single GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pytorch_lightning as pl\n",
+    "import torch\n",
+    "import torchvision\n",
+    "from torch import nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightly.loss import NTXentLoss\n",
+    "from lightly.models.modules import SimCLRProjectionHead\n",
+    "from lightly.transforms.fda_transform import (\n",
+    "    FDATransform,\n",
+    "    FDAView1Transform,\n",
+    "    FDAView2Transform,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FDA(pl.LightningModule):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        resnet = torchvision.models.resnet18()\n",
+    "        self.backbone = nn.Sequential(*list(resnet.children())[:-1])\n",
+    "        self.projection_head = SimCLRProjectionHead(512, 512, 128)\n",
+    "\n",
+    "        # enable gather_distributed to gather features from all gpus\n",
+    "        # before calculating the loss\n",
+    "        self.criterion = NTXentLoss(gather_distributed=True)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = self.backbone(x).flatten(start_dim=1)\n",
+    "        z = self.projection_head(x)\n",
+    "        return z\n",
+    "\n",
+    "    def training_step(self, batch, batch_index):\n",
+    "        (x0, x1) = batch[0]\n",
+    "        z0 = self.forward(x0)\n",
+    "        z1 = self.forward(x1)\n",
+    "        loss = self.criterion(z0, z1)\n",
+    "        return loss\n",
+    "\n",
+    "    def configure_optimizers(self):\n",
+    "        optim = torch.optim.SGD(self.parameters(), lr=0.06)\n",
+    "        return optim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = FDA()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform = FDATransform(\n",
+    "    view_1_transform=FDAView1Transform(input_size=32, gaussian_blur=0.0),\n",
+    "    view_2_transform=FDAView2Transform(input_size=32, gaussian_blur=0.0),\n",
+    ")\n",
+    "dataset = torchvision.datasets.CIFAR10(\n",
+    "    \"datasets/cifar10\", download=True, transform=transform\n",
+    ")\n",
+    "# or create a dataset from a folder containing images or videos:\n",
+    "# dataset = LightlyDataset(\"path/to/folder\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataloader = torch.utils.data.DataLoader(\n",
+    "    dataset,\n",
+    "    batch_size=256,\n",
+    "    shuffle=True,\n",
+    "    drop_last=True,\n",
+    "    num_workers=8,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train with DDP and use Synchronized Batch Norm for a more accurate batch norm\n",
+    "# calculation. Distributed sampling is also enabled with replace_sampler_ddp=True.\n",
+    "if __name__ == \"__main__\":\n",
+    "    trainer = pl.Trainer(\n",
+    "        max_epochs=10,\n",
+    "        devices=\"auto\",\n",
+    "        accelerator=\"gpu\",\n",
+    "        strategy=\"ddp\",\n",
+    "        sync_batchnorm=True,\n",
+    "        use_distributed_sampler=True,  # or replace_sampler_ddp=True for PyTorch Lightning <2.0\n",
+    "    )\n",
+    "    trainer.fit(model=model, train_dataloaders=dataloader)"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/pytorch_lightning/fda.py
+++ b/examples/pytorch_lightning/fda.py
@@ -1,0 +1,70 @@
+# This example requires the following dependencies to be installed:
+# pip install lightly
+
+# Note: The model and training settings do not follow the reference settings
+# from the paper. The settings are chosen such that the example can easily be
+# run on a small dataset with a single GPU.
+
+import pytorch_lightning as pl
+import torch
+import torchvision
+from torch import nn
+
+from lightly.loss import NTXentLoss
+from lightly.models.modules import SimCLRProjectionHead
+from lightly.transforms.fda_transform import (
+    FDATransform,
+    FDAView1Transform,
+    FDAView2Transform,
+)
+
+
+class FDA(pl.LightningModule):
+    def __init__(self):
+        super().__init__()
+        resnet = torchvision.models.resnet18()
+        self.backbone = nn.Sequential(*list(resnet.children())[:-1])
+        self.projection_head = SimCLRProjectionHead(512, 512, 128)
+        self.criterion = NTXentLoss()
+
+    def forward(self, x):
+        x = self.backbone(x).flatten(start_dim=1)
+        z = self.projection_head(x)
+        return z
+
+    def training_step(self, batch, batch_index):
+        (x0, x1) = batch[0]
+        z0 = self.forward(x0)
+        z1 = self.forward(x1)
+        loss = self.criterion(z0, z1)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.parameters(), lr=0.06)
+        return optim
+
+
+model = FDA()
+
+transform = FDATransform(
+    view_1_transform=FDAView1Transform(input_size=32, gaussian_blur=0.0),
+    view_2_transform=FDAView2Transform(input_size=32, gaussian_blur=0.0),
+)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
+
+dataloader = torch.utils.data.DataLoader(
+    dataset,
+    batch_size=256,
+    shuffle=True,
+    drop_last=True,
+    num_workers=8,
+)
+
+accelerator = "gpu" if torch.cuda.is_available() else "cpu"
+
+trainer = pl.Trainer(max_epochs=10, devices=1, accelerator=accelerator)
+trainer.fit(model=model, train_dataloaders=dataloader)

--- a/examples/pytorch_lightning_distributed/fda.py
+++ b/examples/pytorch_lightning_distributed/fda.py
@@ -1,0 +1,81 @@
+# This example requires the following dependencies to be installed:
+# pip install lightly
+
+# Note: The model and training settings do not follow the reference settings
+# from the paper. The settings are chosen such that the example can easily be
+# run on a small dataset with a single GPU.
+
+import pytorch_lightning as pl
+import torch
+import torchvision
+from torch import nn
+
+from lightly.loss import NTXentLoss
+from lightly.models.modules import SimCLRProjectionHead
+from lightly.transforms.fda_transform import (
+    FDATransform,
+    FDAView1Transform,
+    FDAView2Transform,
+)
+
+
+class FDA(pl.LightningModule):
+    def __init__(self):
+        super().__init__()
+        resnet = torchvision.models.resnet18()
+        self.backbone = nn.Sequential(*list(resnet.children())[:-1])
+        self.projection_head = SimCLRProjectionHead(512, 512, 128)
+
+        # enable gather_distributed to gather features from all gpus
+        # before calculating the loss
+        self.criterion = NTXentLoss(gather_distributed=True)
+
+    def forward(self, x):
+        x = self.backbone(x).flatten(start_dim=1)
+        z = self.projection_head(x)
+        return z
+
+    def training_step(self, batch, batch_index):
+        (x0, x1) = batch[0]
+        z0 = self.forward(x0)
+        z1 = self.forward(x1)
+        loss = self.criterion(z0, z1)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.parameters(), lr=0.06)
+        return optim
+
+
+model = FDA()
+
+transform = FDATransform(
+    view_1_transform=FDAView1Transform(input_size=32, gaussian_blur=0.0),
+    view_2_transform=FDAView2Transform(input_size=32, gaussian_blur=0.0),
+)
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
+
+dataloader = torch.utils.data.DataLoader(
+    dataset,
+    batch_size=256,
+    shuffle=True,
+    drop_last=True,
+    num_workers=8,
+)
+
+# Train with DDP and use Synchronized Batch Norm for a more accurate batch norm
+# calculation. Distributed sampling is also enabled with replace_sampler_ddp=True.
+if __name__ == "__main__":
+    trainer = pl.Trainer(
+        max_epochs=10,
+        devices="auto",
+        accelerator="gpu",
+        strategy="ddp",
+        sync_batchnorm=True,
+        use_distributed_sampler=True,  # or replace_sampler_ddp=True for PyTorch Lightning <2.0
+    )
+    trainer.fit(model=model, train_dataloaders=dataloader)


### PR DESCRIPTION
Closes #1956

## Description
- [ ] My change is breaking

Adds `examples/pytorch_lightning/fda.py` and
`examples/pytorch_lightning_distributed/fda.py` following their respective
`simclr.py` templates. The model and loss are identical to SimCLR (`NTXentLoss` +
`SimCLRProjectionHead`); only the transform differs. `FDATransform` does not
accept `input_size` directly, so view transforms are passed explicitly — same
pattern as `byol.py` and `tico.py`.

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [ ] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

```
make format-check  # All checks passed
make lint          # All checks passed
```
Ran both examples on CIFAR-10; loss decreased across epochs.

## Documentation
- [ ] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation (`.rst` files).
- [ ] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.