### PR TITLE
examples: add DetConS training examples (pytorch_lightning, pytorch_lightning_distributed)

### DIFF
--- a/examples/notebooks/pytorch_lightning/detcon.ipynb
+++ b/examples/notebooks/pytorch_lightning/detcon.ipynb
@@ -1,0 +1,241 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "This example requires the following dependencies to be installed:\n",
+    "pip install lightly\n",
+    "Note: This example requires torchvision >= 0.17 for tv_tensors support.\n",
+    "To run with unsupervised segmentation masks instead of a grid:\n",
+    "pip install lightly scikit-image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Note: The model and training settings do not follow the reference settings\n",
+    "from the paper. The settings are chosen such that the example can easily be\n",
+    "run on a small dataset with a single GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pytorch_lightning as pl\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision\n",
+    "from torch import nn\n",
+    "from torchvision.transforms.v2 import ToImage\n",
+    "from torchvision.tv_tensors import Mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightly.loss import DetConSLoss\n",
+    "from lightly.models import utils\n",
+    "from lightly.models.modules import SimCLRProjectionHead\n",
+    "from lightly.transforms import DetConSTransform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from skimage.segmentation import felzenszwalb\n",
+    "\n",
+    "    SCIKIT_IMAGE_INSTALLED = True\n",
+    "except ImportError:\n",
+    "    print(\"scikit-image is not installed, running with grid masks.\")\n",
+    "    SCIKIT_IMAGE_INSTALLED = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DetConS(pl.LightningModule):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        resnet = torchvision.models.resnet18()\n",
+    "        self.backbone = nn.Sequential(*list(resnet.children())[:-2])\n",
+    "        self.projection_head = SimCLRProjectionHead(512, 512, 128)\n",
+    "        self.num_cls = 25\n",
+    "        self.criterion = DetConSLoss(gather_distributed=False)\n",
+    "\n",
+    "    def forward(self, x, mask):\n",
+    "        features = self.backbone(x)\n",
+    "        h, w = features.shape[2], features.shape[3]\n",
+    "        mask_down = (\n",
+    "            F.interpolate(mask.float(), size=(h, w), mode=\"nearest\").long().squeeze(1)\n",
+    "        )\n",
+    "        pooled = utils.pool_masked(features, mask_down, num_cls=self.num_cls)\n",
+    "        pooled = pooled.permute(0, 2, 1)\n",
+    "        b, m, d = pooled.shape\n",
+    "        z = self.projection_head(pooled.reshape(b * m, d))\n",
+    "        return z.reshape(b, m, -1)\n",
+    "\n",
+    "    def training_step(self, batch, batch_idx):\n",
+    "        (x0, mask0), (x1, mask1) = batch[0]\n",
+    "        z0 = self.forward(x0, mask0)\n",
+    "        z1 = self.forward(x1, mask1)\n",
+    "        idx = (\n",
+    "            torch.arange(self.num_cls, device=self.device)\n",
+    "            .unsqueeze(0)\n",
+    "            .expand(x0.shape[0], -1)\n",
+    "        )\n",
+    "        loss = self.criterion(z0, z1, idx, idx)\n",
+    "        return loss\n",
+    "\n",
+    "    def configure_optimizers(self):\n",
+    "        optim = torch.optim.SGD(self.parameters(), lr=0.06)\n",
+    "        return optim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = DetConS()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_cls = 25\n",
+    "if SCIKIT_IMAGE_INSTALLED:\n",
+    "    _detcons_transform = DetConSTransform(input_size=96)\n",
+    "else:\n",
+    "    _detcons_transform = DetConSTransform(grid_size=(5, 5), input_size=96)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_to_image = ToImage()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def transform(pil_img):\n",
+    "    tv_img = _to_image(pil_img)\n",
+    "    if SCIKIT_IMAGE_INSTALLED:\n",
+    "        segments = felzenszwalb(\n",
+    "            np.array(pil_img), scale=100, sigma=0.5, min_size=20\n",
+    "        ).astype(np.int64)\n",
+    "        segments = np.clip(segments, 0, num_cls - 1)\n",
+    "        mask = Mask(torch.from_numpy(segments).unsqueeze(0))\n",
+    "    else:\n",
+    "        mask = Mask(torch.zeros(1, *tv_img.shape[-2:], dtype=torch.int64))\n",
+    "    return _detcons_transform(tv_img, mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = torchvision.datasets.CIFAR10(\n",
+    "    \"datasets/cifar10\", download=True, transform=transform\n",
+    ")\n",
+    "# or create a dataset from a folder containing images or videos:\n",
+    "# dataset = LightlyDataset(\"path/to/folder\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataloader = torch.utils.data.DataLoader(\n",
+    "    dataset,\n",
+    "    batch_size=256,\n",
+    "    shuffle=True,\n",
+    "    drop_last=True,\n",
+    "    num_workers=8,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accelerator = \"gpu\" if torch.cuda.is_available() else \"cpu\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer = pl.Trainer(max_epochs=10, devices=1, accelerator=accelerator)\n",
+    "trainer.fit(model=model, train_dataloaders=dataloader)"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/pytorch_lightning_distributed/detcon.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/detcon.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "This example requires the following dependencies to be installed:\n",
+    "pip install lightly\n",
+    "Note: This example requires torchvision >= 0.17 for tv_tensors support.\n",
+    "To run with unsupervised segmentation masks instead of a grid:\n",
+    "pip install lightly scikit-image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install lightly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Note: The model and training settings do not follow the reference settings\n",
+    "from the paper. The settings are chosen such that the example can easily be\n",
+    "run on a small dataset with a single GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pytorch_lightning as pl\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision\n",
+    "from torch import nn\n",
+    "from torchvision.transforms.v2 import ToImage\n",
+    "from torchvision.tv_tensors import Mask"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightly.loss import DetConSLoss\n",
+    "from lightly.models import utils\n",
+    "from lightly.models.modules import SimCLRProjectionHead\n",
+    "from lightly.transforms import DetConSTransform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from skimage.segmentation import felzenszwalb\n",
+    "\n",
+    "    SCIKIT_IMAGE_INSTALLED = True\n",
+    "except ImportError:\n",
+    "    print(\"scikit-image is not installed, running with grid masks.\")\n",
+    "    SCIKIT_IMAGE_INSTALLED = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class DetConS(pl.LightningModule):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        resnet = torchvision.models.resnet18()\n",
+    "        self.backbone = nn.Sequential(*list(resnet.children())[:-2])\n",
+    "        self.projection_head = SimCLRProjectionHead(512, 512, 128)\n",
+    "        self.num_cls = 25\n",
+    "        self.criterion = DetConSLoss(gather_distributed=True)\n",
+    "\n",
+    "    def forward(self, x, mask):\n",
+    "        features = self.backbone(x)\n",
+    "        h, w = features.shape[2], features.shape[3]\n",
+    "        mask_down = (\n",
+    "            F.interpolate(mask.float(), size=(h, w), mode=\"nearest\").long().squeeze(1)\n",
+    "        )\n",
+    "        pooled = utils.pool_masked(features, mask_down, num_cls=self.num_cls)\n",
+    "        pooled = pooled.permute(0, 2, 1)\n",
+    "        b, m, d = pooled.shape\n",
+    "        z = self.projection_head(pooled.reshape(b * m, d))\n",
+    "        return z.reshape(b, m, -1)\n",
+    "\n",
+    "    def training_step(self, batch, batch_idx):\n",
+    "        (x0, mask0), (x1, mask1) = batch[0]\n",
+    "        z0 = self.forward(x0, mask0)\n",
+    "        z1 = self.forward(x1, mask1)\n",
+    "        idx = (\n",
+    "            torch.arange(self.num_cls, device=self.device)\n",
+    "            .unsqueeze(0)\n",
+    "            .expand(x0.shape[0], -1)\n",
+    "        )\n",
+    "        loss = self.criterion(z0, z1, idx, idx)\n",
+    "        return loss\n",
+    "\n",
+    "    def configure_optimizers(self):\n",
+    "        optim = torch.optim.SGD(self.parameters(), lr=0.06)\n",
+    "        return optim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = DetConS()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_cls = 25\n",
+    "if SCIKIT_IMAGE_INSTALLED:\n",
+    "    _detcons_transform = DetConSTransform(input_size=96)\n",
+    "else:\n",
+    "    _detcons_transform = DetConSTransform(grid_size=(5, 5), input_size=96)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_to_image = ToImage()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def transform(pil_img):\n",
+    "    tv_img = _to_image(pil_img)\n",
+    "    if SCIKIT_IMAGE_INSTALLED:\n",
+    "        segments = felzenszwalb(\n",
+    "            np.array(pil_img), scale=100, sigma=0.5, min_size=20\n",
+    "        ).astype(np.int64)\n",
+    "        segments = np.clip(segments, 0, num_cls - 1)\n",
+    "        mask = Mask(torch.from_numpy(segments).unsqueeze(0))\n",
+    "    else:\n",
+    "        mask = Mask(torch.zeros(1, *tv_img.shape[-2:], dtype=torch.int64))\n",
+    "    return _detcons_transform(tv_img, mask)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = torchvision.datasets.CIFAR10(\n",
+    "    \"datasets/cifar10\", download=True, transform=transform\n",
+    ")\n",
+    "# or create a dataset from a folder containing images or videos:\n",
+    "# dataset = LightlyDataset(\"path/to/folder\", transform=transform)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataloader = torch.utils.data.DataLoader(\n",
+    "    dataset,\n",
+    "    batch_size=256,\n",
+    "    shuffle=True,\n",
+    "    drop_last=True,\n",
+    "    num_workers=8,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train with DDP and use Synchronized Batch Norm for a more accurate batch norm\n",
+    "# calculation. Distributed sampling is also enabled with replace_sampler_ddp=True.\n",
+    "trainer = pl.Trainer(\n",
+    "    max_epochs=10,\n",
+    "    devices=\"auto\",\n",
+    "    accelerator=\"gpu\",\n",
+    "    strategy=\"ddp\",\n",
+    "    sync_batchnorm=True,\n",
+    "    use_distributed_sampler=True,  # or replace_sampler_ddp=True for PyTorch Lightning <2.0\n",
+    ")\n",
+    "trainer.fit(model=model, train_dataloaders=dataloader)"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/pytorch_lightning/detcon.py
+++ b/examples/pytorch_lightning/detcon.py
@@ -1,0 +1,112 @@
+# This example requires the following dependencies to be installed:
+# pip install lightly
+# Note: This example requires torchvision >= 0.17 for tv_tensors support.
+# To run with unsupervised segmentation masks instead of a grid:
+# pip install lightly scikit-image
+
+# Note: The model and training settings do not follow the reference settings
+# from the paper. The settings are chosen such that the example can easily be
+# run on a small dataset with a single GPU.
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+import torch.nn.functional as F
+import torchvision
+from torch import nn
+from torchvision.transforms.v2 import ToImage
+from torchvision.tv_tensors import Mask
+
+from lightly.loss import DetConSLoss
+from lightly.models import utils
+from lightly.models.modules import SimCLRProjectionHead
+from lightly.transforms import DetConSTransform
+
+try:
+    from skimage.segmentation import felzenszwalb
+
+    SCIKIT_IMAGE_INSTALLED = True
+except ImportError:
+    print("scikit-image is not installed, running with grid masks.")
+    SCIKIT_IMAGE_INSTALLED = False
+
+
+class DetConS(pl.LightningModule):
+    def __init__(self):
+        super().__init__()
+        resnet = torchvision.models.resnet18()
+        self.backbone = nn.Sequential(*list(resnet.children())[:-2])
+        self.projection_head = SimCLRProjectionHead(512, 512, 128)
+        self.num_cls = 25
+        self.criterion = DetConSLoss(gather_distributed=False)
+
+    def forward(self, x, mask):
+        features = self.backbone(x)
+        h, w = features.shape[2], features.shape[3]
+        mask_down = (
+            F.interpolate(mask.float(), size=(h, w), mode="nearest").long().squeeze(1)
+        )
+        pooled = utils.pool_masked(features, mask_down, num_cls=self.num_cls)
+        pooled = pooled.permute(0, 2, 1)
+        b, m, d = pooled.shape
+        z = self.projection_head(pooled.reshape(b * m, d))
+        return z.reshape(b, m, -1)
+
+    def training_step(self, batch, batch_idx):
+        (x0, mask0), (x1, mask1) = batch[0]
+        z0 = self.forward(x0, mask0)
+        z1 = self.forward(x1, mask1)
+        idx = (
+            torch.arange(self.num_cls, device=self.device)
+            .unsqueeze(0)
+            .expand(x0.shape[0], -1)
+        )
+        loss = self.criterion(z0, z1, idx, idx)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.parameters(), lr=0.06)
+        return optim
+
+
+model = DetConS()
+
+if SCIKIT_IMAGE_INSTALLED:
+    _detcons_transform = DetConSTransform(input_size=96)
+else:
+    _detcons_transform = DetConSTransform(grid_size=(5, 5), input_size=96)
+
+_to_image = ToImage()
+
+
+def transform(pil_img):
+    tv_img = _to_image(pil_img)
+    if SCIKIT_IMAGE_INSTALLED:
+        segments = felzenszwalb(
+            np.array(pil_img), scale=100, sigma=0.5, min_size=20
+        ).astype(np.int64)
+        segments = np.clip(segments, 0, model.num_cls - 1)
+        mask = Mask(torch.from_numpy(segments).unsqueeze(0))
+    else:
+        mask = Mask(torch.zeros(1, *tv_img.shape[-2:], dtype=torch.int64))
+    return _detcons_transform(tv_img, mask)
+
+
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
+
+dataloader = torch.utils.data.DataLoader(
+    dataset,
+    batch_size=256,
+    shuffle=True,
+    drop_last=True,
+    num_workers=8,
+)
+
+accelerator = "gpu" if torch.cuda.is_available() else "cpu"
+
+trainer = pl.Trainer(max_epochs=10, devices=1, accelerator=accelerator)
+trainer.fit(model=model, train_dataloaders=dataloader)

--- a/examples/pytorch_lightning_distributed/detcon.py
+++ b/examples/pytorch_lightning_distributed/detcon.py
@@ -1,0 +1,119 @@
+# This example requires the following dependencies to be installed:
+# pip install lightly
+# Note: This example requires torchvision >= 0.17 for tv_tensors support.
+# To run with unsupervised segmentation masks instead of a grid:
+# pip install lightly scikit-image
+
+# Note: The model and training settings do not follow the reference settings
+# from the paper. The settings are chosen such that the example can easily be
+# run on a small dataset with a single GPU.
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+import torch.nn.functional as F
+import torchvision
+from torch import nn
+from torchvision.transforms.v2 import ToImage
+from torchvision.tv_tensors import Mask
+
+from lightly.loss import DetConSLoss
+from lightly.models import utils
+from lightly.models.modules import SimCLRProjectionHead
+from lightly.transforms import DetConSTransform
+
+try:
+    from skimage.segmentation import felzenszwalb
+
+    SCIKIT_IMAGE_INSTALLED = True
+except ImportError:
+    print("scikit-image is not installed, running with grid masks.")
+    SCIKIT_IMAGE_INSTALLED = False
+
+
+class DetConS(pl.LightningModule):
+    def __init__(self):
+        super().__init__()
+        resnet = torchvision.models.resnet18()
+        self.backbone = nn.Sequential(*list(resnet.children())[:-2])
+        self.projection_head = SimCLRProjectionHead(512, 512, 128)
+        self.num_cls = 25
+        self.criterion = DetConSLoss(gather_distributed=True)
+
+    def forward(self, x, mask):
+        features = self.backbone(x)
+        h, w = features.shape[2], features.shape[3]
+        mask_down = (
+            F.interpolate(mask.float(), size=(h, w), mode="nearest").long().squeeze(1)
+        )
+        pooled = utils.pool_masked(features, mask_down, num_cls=self.num_cls)
+        pooled = pooled.permute(0, 2, 1)
+        b, m, d = pooled.shape
+        z = self.projection_head(pooled.reshape(b * m, d))
+        return z.reshape(b, m, -1)
+
+    def training_step(self, batch, batch_idx):
+        (x0, mask0), (x1, mask1) = batch[0]
+        z0 = self.forward(x0, mask0)
+        z1 = self.forward(x1, mask1)
+        idx = (
+            torch.arange(self.num_cls, device=self.device)
+            .unsqueeze(0)
+            .expand(x0.shape[0], -1)
+        )
+        loss = self.criterion(z0, z1, idx, idx)
+        return loss
+
+    def configure_optimizers(self):
+        optim = torch.optim.SGD(self.parameters(), lr=0.06)
+        return optim
+
+
+model = DetConS()
+
+if SCIKIT_IMAGE_INSTALLED:
+    _detcons_transform = DetConSTransform(input_size=96)
+else:
+    _detcons_transform = DetConSTransform(grid_size=(5, 5), input_size=96)
+
+_to_image = ToImage()
+
+
+def transform(pil_img):
+    tv_img = _to_image(pil_img)
+    if SCIKIT_IMAGE_INSTALLED:
+        segments = felzenszwalb(
+            np.array(pil_img), scale=100, sigma=0.5, min_size=20
+        ).astype(np.int64)
+        segments = np.clip(segments, 0, model.num_cls - 1)
+        mask = Mask(torch.from_numpy(segments).unsqueeze(0))
+    else:
+        mask = Mask(torch.zeros(1, *tv_img.shape[-2:], dtype=torch.int64))
+    return _detcons_transform(tv_img, mask)
+
+
+dataset = torchvision.datasets.CIFAR10(
+    "datasets/cifar10", download=True, transform=transform
+)
+# or create a dataset from a folder containing images or videos:
+# dataset = LightlyDataset("path/to/folder", transform=transform)
+
+dataloader = torch.utils.data.DataLoader(
+    dataset,
+    batch_size=256,
+    shuffle=True,
+    drop_last=True,
+    num_workers=8,
+)
+
+# Train with DDP and use Synchronized Batch Norm for a more accurate batch norm
+# calculation. Distributed sampling is also enabled with replace_sampler_ddp=True.
+trainer = pl.Trainer(
+    max_epochs=10,
+    devices="auto",
+    accelerator="gpu",
+    strategy="ddp",
+    sync_batchnorm=True,
+    use_distributed_sampler=True,  # or replace_sampler_ddp=True for PyTorch Lightning <2.0
+)
+trainer.fit(model=model, train_dataloaders=dataloader)


### PR DESCRIPTION
Part of #1957

## Description
- [ ] My change is breaking

Adds `examples/pytorch_lightning/detcon.py` and
`examples/pytorch_lightning_distributed/detcon.py` following their respective
`densecl.py` templates. Uses `DetConSTransform` with Felzenszwalb segmentation
(scikit-image) as the primary mask path and the 5×5 grid as fallback — same
mask generation pattern as #1969. `gather_distributed=True` is set for the
distributed variant to sync embeddings across GPUs.

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [ ] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

```
make format-check  # All checks passed
make lint          # All checks passed
make generate-example-notebooks
```

## Documentation
- [ ] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation (`.rst` files).
- [ ] I have updated the documentation accordingly.
- [x] The autodocs update the documentation accordingly.