### PR TITLE
feat: add CAPI transform

### DIFF
--- a/lightly/transforms/__init__.py
+++ b/lightly/transforms/__init__.py
@@ -15,6 +15,7 @@ from lightly.transforms.byol_transform import (
     BYOLView1Transform,
     BYOLView2Transform,
 )
+from lightly.transforms.capi_transform import CAPITransform
 from lightly.transforms.densecl_transform import DenseCLTransform
 from lightly.transforms.dino_transform import DINOTransform, DINOViewTransform
 from lightly.transforms.fast_siam_transform import FastSiamTransform

--- a/lightly/transforms/capi_transform.py
+++ b/lightly/transforms/capi_transform.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from PIL.Image import Image
+from torch import Tensor
+from torchvision.transforms import InterpolationMode
+
+from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
+from lightly.transforms.utils import IMAGENET_NORMALIZE
+
+
+class CAPITransform:
+    """Implements the view augmentation for CAPI [0].
+
+    Input to this transform:
+        PIL Image or Tensor.
+
+    Output of this transform:
+        List of Tensor of length 1.
+
+    Applies the following augmentations by default:
+        - Random resized crop
+        - Random horizontal flip
+
+    - [0]: CAPI: Cluster and Predict Latent Patches for Improved Masked Image Modeling, 2025, https://arxiv.org/abs/2502.08769
+
+    Attributes:
+        input_size:
+            Size of the input image in pixels.
+        min_scale:
+            Minimum size of the randomized crop relative to the input_size.
+        normalize:
+            Dictionary with 'mean' and 'std' for torchvision.transforms.Normalize.
+            If None, no normalization is applied.
+
+    """
+
+    def __init__(
+        self,
+        input_size: int | tuple[int, int] = 224,
+        min_scale: float = 0.6,
+        normalize: dict[str, list[float]] | None = IMAGENET_NORMALIZE,
+    ):
+        transforms = [
+            T.RandomResizedCrop(
+                input_size,
+                scale=(min_scale, 1.0),
+                interpolation=InterpolationMode.BICUBIC,
+            ),
+            T.RandomHorizontalFlip(),
+            T.ToTensor(),
+        ]
+        if normalize:
+            transforms.append(T.Normalize(mean=normalize["mean"], std=normalize["std"]))
+
+        self.transform = T.Compose(transforms)
+
+    def __call__(self, image: Tensor | Image) -> list[Tensor]:
+        """Applies the transforms to the input image.
+
+        Args:
+            image:
+                The input image to apply the transforms to.
+
+        Returns:
+            A list containing the transformed image.
+
+        """
+        return [self.transform(image)]

--- a/tests/transforms/test_capi_transform.py
+++ b/tests/transforms/test_capi_transform.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import torch
+from PIL import Image
+
+from lightly.transforms import CAPITransform
+from lightly.transforms.utils import IMAGENET_NORMALIZE
+
+
+def test_view_on_pil_image() -> None:
+    transform = CAPITransform(input_size=32)
+    output = transform(Image.new("RGB", (100, 100)))
+    assert len(output) == 1
+    assert output[0].shape == (3, 32, 32)
+
+
+def test_default_input_size() -> None:
+    transform = CAPITransform()
+    output = transform(Image.new("RGB", (256, 256)))
+    assert output[0].shape == (3, 224, 224)
+
+
+def test_normalize_none() -> None:
+    transform = CAPITransform(input_size=32, normalize=None)
+    output = transform(Image.new("RGB", (100, 100), color=(255, 255, 255)))[0]
+    # Without normalization a white image stays at 1.0 after ToTensor.
+    assert torch.allclose(output, torch.ones_like(output), atol=1e-6)
+
+
+def test_normalize_default() -> None:
+    transform = CAPITransform(input_size=32, normalize=IMAGENET_NORMALIZE)
+    output = transform(Image.new("RGB", (100, 100), color=(255, 255, 255)))[0]
+    # A white image is 1.0 after ToTensor; ImageNet normalization maps each
+    # channel c to (1 - mean[c]) / std[c].
+    mean = torch.tensor(IMAGENET_NORMALIZE["mean"]).view(3, 1, 1)
+    std = torch.tensor(IMAGENET_NORMALIZE["std"]).view(3, 1, 1)
+    expected = (1.0 - mean) / std
+    assert torch.allclose(output, expected.expand_as(output), atol=1e-6)


### PR DESCRIPTION
Adds `CAPITransform` for CAPI (#1985): random resized crop (scale 0.6 to 1.0), horizontal flip, and normalization, matching the reference augmentation.

Follow up of #1993. 