### PR TITLE
feat: add CAPI clustering head and cross-attention predictor

### DIFF
--- a/lightly/models/modules/__init__.py
+++ b/lightly/models/modules/__init__.py
@@ -12,6 +12,7 @@ from lightly.models.modules.heads import (
     BarlowTwinsProjectionHead,
     BYOLPredictionHead,
     BYOLProjectionHead,
+    CAPIProjectionHead,
     DenseCLProjectionHead,
     DINOProjectionHead,
     DINOv2ProjectionHead,
@@ -45,6 +46,7 @@ if _dependency.torchvision_vit_available():
 
 if _dependency.timm_vit_available():
     # Requires timm >= 0.9.9
+    from lightly.models.modules.capi_predictor_timm import CAPIPredictorTIMM
     from lightly.models.modules.heads_timm import AIMPredictionHead
     from lightly.models.modules.ijepa_timm import IJEPAPredictorTIMM
     from lightly.models.modules.masked_autoencoder_timm import (

--- a/lightly/models/modules/capi_predictor_timm.py
+++ b/lightly/models/modules/capi_predictor_timm.py
@@ -1,0 +1,168 @@
+"""CAPI cross-attention predictor.
+
+- [0]: CAPI: Cluster and Predict Latent Patches for Improved Masked Image Modeling, 2025, https://arxiv.org/abs/2502.08769
+- [1]: https://github.com/facebookresearch/capi
+- [2]: RoFormer: Rotary Position Embedding, 2021, https://arxiv.org/abs/2104.09864
+"""
+
+from __future__ import annotations
+
+import torch
+from timm.layers import RotaryEmbeddingCat, apply_rot_embed_cat
+from torch import Tensor
+from torch.nn import GELU, LayerNorm, Linear, Module, ModuleList, Parameter, Sequential
+
+
+class _RoPECrossAttentionBlock(Module):
+    """Cross-attention block with rotary position embeddings on the queries and keys."""
+
+    def __init__(self, embed_dim: int, num_heads: int, mlp_ratio: float) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.query_norm = LayerNorm(embed_dim)
+        self.context_norm = LayerNorm(embed_dim)
+        self.to_query = Linear(embed_dim, embed_dim)
+        self.to_key_value = Linear(embed_dim, 2 * embed_dim)
+        self.projection = Linear(embed_dim, embed_dim)
+        self.mlp_norm = LayerNorm(embed_dim)
+        hidden_dim = int(embed_dim * mlp_ratio)
+        self.mlp = Sequential(
+            Linear(embed_dim, hidden_dim), GELU(), Linear(hidden_dim, embed_dim)
+        )
+
+    def forward(
+        self, queries: Tensor, context: Tensor, query_rope: Tensor, context_rope: Tensor
+    ) -> Tensor:
+        # queries: (batch_size, num_queries, embed_dim)
+        # context: (batch_size, num_context, embed_dim)
+        # query_rope: (batch_size, num_queries, 2 * head_dim)
+        # context_rope: (batch_size, num_context, 2 * head_dim)
+        batch_size, num_queries, embed_dim = queries.shape
+        num_context = context.shape[1]
+
+        q = self.to_query(self.query_norm(queries))
+        q = q.reshape(batch_size, num_queries, self.num_heads, self.head_dim).transpose(
+            1, 2
+        )
+        key_value = self.to_key_value(self.context_norm(context))
+        key_value = key_value.reshape(
+            batch_size, num_context, 2, self.num_heads, self.head_dim
+        ).permute(2, 0, 3, 1, 4)
+        keys, values = key_value[0], key_value[1]
+
+        # Rotate queries and keys by their grid positions. Unsqueeze to broadcast the
+        # rotary embedding over the attention heads.
+        q = apply_rot_embed_cat(q, query_rope.unsqueeze(1))
+        keys = apply_rot_embed_cat(keys, context_rope.unsqueeze(1))
+
+        attention = torch.softmax(
+            (q @ keys.transpose(-2, -1)) * self.head_dim**-0.5, dim=-1
+        )
+        out = (
+            (attention @ values)
+            .transpose(1, 2)
+            .reshape(batch_size, num_queries, embed_dim)
+        )
+        queries = queries + self.projection(out)
+        queries = queries + self.mlp(self.mlp_norm(queries))
+        return queries
+
+
+class CAPIPredictorTIMM(Module):
+    """Cross-attention predictor for CAPI [0] with rotary position embeddings [2].
+
+    A learned mask token is placed at every masked patch position and cross-attends
+    to the visible encoder tokens to predict the masked patches. Rotary position
+    embeddings encode the 2D grid positions of the query (masked) and context
+    (visible) tokens, so the predictor operates on token subsets without a separate
+    positional embedding table. This mirrors the reference implementation [1] and
+    differs from a masked-autoencoder decoder, which re-inserts mask tokens into the
+    full sequence and self-attends over everything.
+
+    This module requires TIMM to be installed.
+
+    - [0]: CAPI: Cluster and Predict Latent Patches for Improved Masked Image Modeling, 2025, https://arxiv.org/abs/2502.08769
+    - [1]: https://github.com/facebookresearch/capi
+    - [2]: RoFormer: Rotary Position Embedding, 2021, https://arxiv.org/abs/2104.09864
+
+    Attributes:
+        embed_dim:
+            Dimension of the input and output tokens.
+        grid_size:
+            Size of the patch grid as (height, width), or a single int for a square
+            grid. Used to build the rotary position embeddings.
+        depth:
+            Number of cross-attention blocks.
+        num_heads:
+            Number of attention heads.
+        mlp_ratio:
+            Ratio of the hidden dimension of the MLP to the embedding dimension.
+
+    Raises:
+        ValueError: If embed_dim is not divisible by num_heads.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        grid_size: int | tuple[int, int],
+        depth: int = 12,
+        num_heads: int = 6,
+        mlp_ratio: float = 4.0,
+    ) -> None:
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
+            )
+        head_dim = embed_dim // num_heads
+        feat_shape = (grid_size, grid_size) if isinstance(grid_size, int) else grid_size
+        self.rope = RotaryEmbeddingCat(
+            dim=head_dim, in_pixels=False, feat_shape=list(feat_shape)
+        )
+        self.mask_token = Parameter(torch.zeros(1, 1, embed_dim))
+        self.blocks = ModuleList(
+            [
+                _RoPECrossAttentionBlock(
+                    embed_dim=embed_dim, num_heads=num_heads, mlp_ratio=mlp_ratio
+                )
+                for _ in range(depth)
+            ]
+        )
+        self.norm = LayerNorm(embed_dim)
+        torch.nn.init.normal_(self.mask_token, std=0.02)
+
+    def forward(
+        self, context: Tensor, context_positions: Tensor, query_positions: Tensor
+    ) -> Tensor:
+        """Predicts the masked patches from the visible tokens.
+
+        Args:
+            context:
+                Visible encoder tokens with shape
+                (batch_size, num_context, embed_dim).
+            context_positions:
+                Row-major grid indices of the visible tokens with shape
+                (batch_size, num_context).
+            query_positions:
+                Row-major grid indices of the masked tokens to predict with shape
+                (batch_size, num_queries).
+
+        Returns:
+            The predicted tokens for the masked positions with shape
+            (batch_size, num_queries, embed_dim).
+        """
+        rope = self.rope.get_embed().to(context.device)  # (num_patches, 2 * head_dim)
+        context_rope = rope[context_positions]
+        query_rope = rope[query_positions]
+        queries = self.mask_token.expand(context.shape[0], query_positions.shape[1], -1)
+        for block in self.blocks:
+            queries = block(
+                queries=queries,
+                context=context,
+                query_rope=query_rope,
+                context_rope=context_rope,
+            )
+        predicted: Tensor = self.norm(queries)
+        return predicted

--- a/lightly/models/modules/heads.py
+++ b/lightly/models/modules/heads.py
@@ -1031,3 +1031,65 @@ class DenseCLProjectionHead(ProjectionHead):
                 (hidden_dim, output_dim, None, None),
             ]
         )
+
+
+class CAPIProjectionHead(nn.Module):
+    """Projection head for CAPI [0].
+
+    L2-normalizes the input features and projects them with a single linear layer
+    to cluster logits. The linear layer weights are the cluster prototypes. The
+    same head is used for the student and, with its own weights, for the teacher's
+    online clustering.
+
+    - [0]: CAPI: Cluster and Predict Latent Patches for Improved Masked Image Modeling, 2025, https://arxiv.org/abs/2502.08769
+
+    Attributes:
+        input_dim:
+            The input dimension of the head.
+        num_clusters:
+            Number of clusters, i.e. the number of output prototypes.
+        bias:
+            If True, the linear layer uses a bias term.
+        weight_norm:
+            If True, the prototypes are weight-normalized to unit norm with a
+            fixed scale, as used for the student head in the reference. The
+            teacher's clustering head leaves this disabled.
+
+    Examples:
+        >>> # project 384-dimensional features to 16384 cluster logits
+        >>> head = CAPIProjectionHead(input_dim=384, num_clusters=16384)
+        >>>
+        >>> # features has shape (batch_size, sequence_length, 384)
+        >>> logits = head(features)  # (batch_size, sequence_length, 16384)
+    """
+
+    def __init__(
+        self,
+        input_dim: int = 384,
+        num_clusters: int = 16384,
+        bias: bool = False,
+        weight_norm: bool = False,
+    ):
+        """Initializes the CAPIProjectionHead with the specified parameters."""
+        super().__init__()
+        self.layer = nn.Linear(input_dim, num_clusters, bias=bias)
+        if weight_norm:
+            # Weight-normalize the prototypes to unit norm with a fixed scale, as
+            # the reference uses for the student head.
+            self.layer = nn.utils.weight_norm(self.layer)
+            self.layer.weight_g.data.fill_(1)  # type: ignore[operator]
+            self.layer.weight_g.requires_grad = False  # type: ignore[operator]
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Projects L2-normalized features to cluster logits.
+
+        Args:
+            x:
+                Input features of shape (..., input_dim).
+
+        Returns:
+            Cluster logits of shape (..., num_clusters).
+        """
+        x = nn.functional.normalize(x, dim=-1, p=2)
+        logits: Tensor = self.layer(x)
+        return logits

--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -720,6 +720,117 @@ def random_grid_token_mask(
     return idx_keep, idx_mask
 
 
+def random_inverse_block_mask(
+    size: Tuple[int, int],
+    mask_ratio: float = 0.65,
+    num_prefix_tokens: int = 1,
+    min_aspect: float = 0.5,
+    max_aspect: Optional[float] = None,
+    roll: bool = True,
+    device: Optional[Union[torch.device, str]] = None,
+) -> Tuple[Tensor, Tensor]:
+    """Creates inverse-block token masks as used in CAPI [0].
+
+    A single contiguous, aspect-ratio-varying block of patches is kept visible and
+    the remaining patches are masked (the inverse of block masking). The visible
+    block is optionally rolled across the grid for positional coverage. The number
+    of masked patches is fixed at ``int(num_patches * mask_ratio)``.
+
+    - [0]: CAPI: Cluster and Predict Latent Patches for Improved Masked Image Modeling, 2025, https://arxiv.org/abs/2502.08769
+
+    Args:
+        size:
+            Size of the token batch, (batch_size, sequence_length). The sequence
+            length must equal num_prefix_tokens + num_patches where num_patches is a
+            perfect square.
+        mask_ratio:
+            Proportion of patches to mask.
+        num_prefix_tokens:
+            Number of prefix tokens (e.g. class or register tokens) that precede the
+            patch tokens. They are never masked and are always returned first in
+            idx_keep.
+        min_aspect:
+            Minimum aspect ratio of the visible block.
+        max_aspect:
+            Maximum aspect ratio of the visible block. Defaults to 1 / min_aspect.
+        roll:
+            If True, the visible block is randomly rolled across the grid.
+        device:
+            Device on which to create the index masks.
+
+    Returns:
+        An (idx_keep, idx_mask) tuple of int64 index tensors, where
+        num_masked = int(num_patches * mask_ratio):
+
+        - idx_keep, shape (batch_size, num_prefix_tokens + num_patches - num_masked):
+          the prefix token indices followed by the indices of the visible patches.
+        - idx_mask, shape (batch_size, num_masked): the indices of the masked patches.
+
+        Patch index p maps to token index p + num_prefix_tokens.
+
+    Raises:
+        ValueError: If sequence_length is not greater than num_prefix_tokens or the
+            number of patches is not a perfect square.
+    """
+    batch_size, sequence_length = size
+    num_patches = sequence_length - num_prefix_tokens
+    if num_patches <= 0:
+        raise ValueError(
+            f"sequence_length ({sequence_length}) must be greater than "
+            f"num_prefix_tokens ({num_prefix_tokens})."
+        )
+    height = width = int(num_patches**0.5)
+    if height * width != num_patches:
+        raise ValueError(
+            f"Number of patches ({num_patches}) must be a perfect square. Got "
+            f"sequence_length={sequence_length} and "
+            f"num_prefix_tokens={num_prefix_tokens}."
+        )
+    num_masked = int(num_patches * mask_ratio)
+    num_visible = num_patches - num_masked
+    max_aspect = max_aspect or 1.0 / min_aspect
+    log_aspect_ratio = (math.log(min_aspect), math.log(max_aspect))
+
+    # Masks are built per sample on the cpu and moved to the device once at the end.
+    prefix = torch.arange(num_prefix_tokens)
+    idx_keep_rows = []
+    idx_mask_rows = []
+    for _ in range(batch_size):
+        visible = torch.zeros(num_patches, dtype=torch.bool)
+        if num_visible > 0:
+            # Sample the aspect ratio of the visible block, clamped so it fits.
+            min_lar = max(log_aspect_ratio[0], math.log(num_visible / width**2))
+            max_lar = min(
+                log_aspect_ratio[1], math.log(height**2 / (num_visible + 1e-5))
+            )
+            aspect = math.exp(float(torch.empty(1).uniform_(min_lar, max_lar).item()))
+            block_h = min(height, math.ceil(math.sqrt(num_visible * aspect)))
+            block_w = min(width, math.ceil(math.sqrt(num_visible / aspect)))
+            top = int(torch.randint(0, height - block_h + 1, (1,)).item())
+            left = int(torch.randint(0, width - block_w + 1, (1,)).item())
+            grid = torch.zeros(height, width, dtype=torch.bool)
+            grid[top : top + block_h, left : left + block_w] = True
+            # Truncate to exactly num_visible patches, keeping row-major order.
+            block_ids = grid.flatten().nonzero().flatten()[:num_visible]
+            visible[block_ids] = True
+            if roll:
+                shift_x = int(torch.randint(0, height, (1,)).item())
+                shift_y = int(torch.randint(0, width, (1,)).item())
+                visible = torch.roll(
+                    visible.reshape(height, width),
+                    shifts=(shift_x, shift_y),
+                    dims=(0, 1),
+                ).flatten()
+        visible_patches = visible.nonzero().flatten()
+        masked_patches = (~visible).nonzero().flatten()
+        idx_keep_rows.append(torch.cat([prefix, visible_patches + num_prefix_tokens]))
+        idx_mask_rows.append(masked_patches + num_prefix_tokens)
+
+    idx_keep = torch.stack(idx_keep_rows).to(device)
+    idx_mask = torch.stack(idx_mask_rows).to(device)
+    return idx_keep, idx_mask
+
+
 def random_prefix_mask(
     size: Tuple[int, int],
     max_prefix_length: int,

--- a/tests/models/modules/test_capi_predictor_timm.py
+++ b/tests/models/modules/test_capi_predictor_timm.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from lightly.utils import dependency
+
+if not dependency.timm_vit_available():
+    # We do not use pytest.importorskip on module level because it makes mypy unhappy.
+    pytest.skip("TIMM vision transformer is not available", allow_module_level=True)
+
+
+from lightly.models.modules import CAPIPredictorTIMM
+
+
+class TestCAPIPredictorTIMM:
+    def test_forward__shape(self) -> None:
+        embed_dim, grid_size = 24, 4  # 4x4 = 16 patch positions
+        predictor = CAPIPredictorTIMM(
+            embed_dim=embed_dim, grid_size=grid_size, depth=2, num_heads=3
+        )
+        batch_size, num_context, num_queries = 2, 10, 6
+        context = torch.randn(batch_size, num_context, embed_dim)
+        context_positions = torch.randint(0, grid_size**2, (batch_size, num_context))
+        query_positions = torch.randint(0, grid_size**2, (batch_size, num_queries))
+        out = predictor(
+            context=context,
+            context_positions=context_positions,
+            query_positions=query_positions,
+        )
+        assert out.shape == (batch_size, num_queries, embed_dim)
+
+    def test_forward__is_differentiable(self) -> None:
+        predictor = CAPIPredictorTIMM(embed_dim=24, grid_size=4, depth=1, num_heads=3)
+        context = torch.randn(2, 8, 24, requires_grad=True)
+        context_positions = torch.randint(0, 16, (2, 8))
+        query_positions = torch.randint(0, 16, (2, 5))
+        out = predictor(
+            context=context,
+            context_positions=context_positions,
+            query_positions=query_positions,
+        )
+        out.sum().backward()
+        assert context.grad is not None
+        assert predictor.mask_token.grad is not None
+
+    def test_forward__is_position_dependent(self) -> None:
+        # Rotary embeddings make the prediction depend on the query grid position.
+        torch.manual_seed(0)
+        predictor = CAPIPredictorTIMM(embed_dim=24, grid_size=4, depth=2, num_heads=3)
+        context = torch.randn(1, 8, 24)
+        context_positions = torch.arange(8).unsqueeze(0)
+        out_a = predictor(
+            context=context,
+            context_positions=context_positions,
+            query_positions=torch.tensor([[0, 1]]),
+        )
+        out_b = predictor(
+            context=context,
+            context_positions=context_positions,
+            query_positions=torch.tensor([[10, 11]]),
+        )
+        assert not torch.allclose(out_a, out_b)
+
+    def test_init__raises_when_embed_dim_not_divisible(self) -> None:
+        with pytest.raises(ValueError, match="divisible"):
+            CAPIPredictorTIMM(embed_dim=25, grid_size=4, num_heads=4)

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -1077,6 +1077,54 @@ def test_random_grid_token_mask__prefix_ge_sequence_raises() -> None:
         )
 
 
+def test_random_inverse_block_mask__partition() -> None:
+    torch.manual_seed(0)
+    batch_size, num_prefix_tokens = 2, 1
+    sequence_length = num_prefix_tokens + 16  # 4x4 patch grid
+    idx_keep, idx_mask = utils.random_inverse_block_mask(
+        size=(batch_size, sequence_length),
+        mask_ratio=0.5,
+        num_prefix_tokens=num_prefix_tokens,
+    )
+    idx, _ = torch.cat([idx_keep, idx_mask], dim=1).sort(dim=1)
+    expected = torch.arange(sequence_length).expand(batch_size, sequence_length)
+    assert torch.equal(idx, expected)
+
+
+def test_random_inverse_block_mask__prefix_tokens_kept() -> None:
+    torch.manual_seed(0)
+    batch_size, num_prefix_tokens = 3, 8
+    sequence_length = num_prefix_tokens + 16
+    idx_keep, idx_mask = utils.random_inverse_block_mask(
+        size=(batch_size, sequence_length),
+        mask_ratio=0.75,
+        num_prefix_tokens=num_prefix_tokens,
+    )
+    prefix = torch.arange(num_prefix_tokens).expand(batch_size, num_prefix_tokens)
+    assert torch.equal(idx_keep[:, :num_prefix_tokens], prefix)
+    assert idx_mask.min().item() >= num_prefix_tokens
+
+
+def test_random_inverse_block_mask__fixed_count() -> None:
+    num_prefix_tokens = 1
+    sequence_length = num_prefix_tokens + 16  # 4x4 patch grid
+    idx_keep, idx_mask = utils.random_inverse_block_mask(
+        size=(4, sequence_length),
+        mask_ratio=0.75,
+        num_prefix_tokens=num_prefix_tokens,
+    )
+    # int(16 * 0.75) = 12 masked, 4 visible, + 1 prefix
+    assert idx_mask.shape == (4, 12)
+    assert idx_keep.shape == (4, num_prefix_tokens + 4)
+
+
+def test_random_inverse_block_mask__not_square_raises() -> None:
+    with pytest.raises(ValueError):
+        utils.random_inverse_block_mask(
+            size=(1, 1 + 15), mask_ratio=0.5, num_prefix_tokens=1
+        )
+
+
 def test_random_grid_token_mask__mask_ratio_extremes() -> None:
     num_prefix_tokens = 1
     sequence_length = num_prefix_tokens + 16  # 4 cells of 4 patches (grid=2)

--- a/tests/models/test_ProjectionHeads.py
+++ b/tests/models/test_ProjectionHeads.py
@@ -6,6 +6,7 @@ from lightly.models.modules.heads import (
     BarlowTwinsProjectionHead,
     BYOLPredictionHead,
     BYOLProjectionHead,
+    CAPIProjectionHead,
     DenseCLProjectionHead,
     DINOProjectionHead,
     DINOv2ProjectionHead,
@@ -322,3 +323,28 @@ class TestProjectionHeads:
                 output_dim=4,
                 num_layers=0,
             )
+
+
+def test_capi_projection_head() -> None:
+    head = CAPIProjectionHead(input_dim=16, num_clusters=32)
+    features = torch.randn(2, 5, 16)
+    logits = head(features)
+    assert logits.shape == (2, 5, 32)
+    # The input is L2-normalized, so the head is invariant to input scaling.
+    assert torch.allclose(logits, head(features * 3.0), atol=1e-5)
+    logits.sum().backward()
+    assert head.layer.weight.grad is not None
+
+
+def test_capi_projection_head__weight_norm() -> None:
+    head = CAPIProjectionHead(input_dim=16, num_clusters=32, weight_norm=True)
+    features = torch.randn(2, 5, 16)
+    logits = head(features)
+    assert logits.shape == (2, 5, 32)
+    # The prototypes are weight-normalized to unit norm.
+    prototype_norms = head.layer.weight.norm(dim=1)
+    assert torch.allclose(prototype_norms, torch.ones_like(prototype_norms), atol=1e-5)
+    # Still invariant to input scaling and differentiable.
+    assert torch.allclose(logits, head(features * 3.0), atol=1e-5)
+    logits.sum().backward()
+    assert any(p.grad is not None for p in head.parameters())


### PR DESCRIPTION
Adds the CAPI building blocks for #1985: `CAPIProjectionHead` in `heads.py` (L2-normalizes the input, then a linear layer to `num_clusters` prototypes; a `weight_norm` option gives the student head unit-norm prototypes, while the teacher clustering head leaves it off and uses a bias), `CAPIPredictorTIMM`, a cross-attention decoder with rotary position embeddings via `timm.layers.RotaryEmbeddingCat`, gated behind `timm_vit_available()` like the other `*_timm` modules, and `random_inverse_block_mask` in `models/utils.py` (inverse-block masking: a contiguous block is kept visible, the rest masked, with optional roll).

Head and predictor put in the library since it matches the existing pattern (`heads.py` already holds the method heads, and `MaskedVisionTransformerDecoder` is a library-level predictor), and the RoPE predictor is reusable rather than CAPI-only wiring. The masking util sits with the existing masking utilities, which all live in `models/utils.py`.

Follow up of #1994.