### PR TITLE
ci: run required checks for merge groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_api_deps_only.yml
+++ b/.github/workflows/test_api_deps_only.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_code_format.yml
+++ b/.github/workflows/test_code_format.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_minimal_deps.yml
+++ b/.github/workflows/test_minimal_deps.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add merge_group triggers to the workflows that supply master’s required checks.