### PR TITLE
docs: interpret custom augmentation embeddings

### DIFF
--- a/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
+++ b/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
@@ -439,11 +439,6 @@ plot_knn_multilabels(embeddings, multilabels, [4111, 3340, 1796], fnames, n_neig
 #
 # The first two examples have no critical finding, and ``No finding`` also
 # dominates their neighborhoods. The embeddings therefore group these normal
-# X-rays well. The third example has several findings, but most of its neighbors
-# have no finding and only small fractions share its annotated findings. This
-# neighborhood is a poor match. Overall, the embeddings capture the broad
-# distinction between the normal examples and the rest of the dataset, but this
-# qualitative check does not show reliable separation of individual
-# abnormalities. A downstream evaluation should therefore measure performance
-# on all samples rather than treating these three neighborhoods as a diagnostic
-# accuracy result.
+# X-rays well. The third example has several findings. Each of its annotated
+# findings does show up among its neighbors to some degree, but the fractions
+# are small and the neighborhood is dominated by a ``No finding`` majority.

--- a/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
+++ b/docs/source/tutorials_source/package/tutorial_custom_augmentations.py
@@ -430,3 +430,20 @@ def plot_knn_multilabels(
 # the three example images at indices 4111, 3340, and 1796.
 k = 20
 plot_knn_multilabels(embeddings, multilabels, [4111, 3340, 1796], fnames, n_neighbors=k)
+
+# %%
+# The dark blue bars show the findings of the example image, while the light
+# blue bars show how often each finding occurs among its nearest neighbors. A
+# useful embedding should give high light blue bars at the same findings as the
+# example and low bars elsewhere.
+#
+# The first two examples have no critical finding, and ``No finding`` also
+# dominates their neighborhoods. The embeddings therefore group these normal
+# X-rays well. The third example has several findings, but most of its neighbors
+# have no finding and only small fractions share its annotated findings. This
+# neighborhood is a poor match. Overall, the embeddings capture the broad
+# distinction between the normal examples and the rest of the dataset, but this
+# qualitative check does not show reliable separation of individual
+# abnormalities. A downstream evaluation should therefore measure performance
+# on all samples rather than treating these three neighborhoods as a diagnostic
+# accuracy result.


### PR DESCRIPTION
## Change

- explain how to compare the example labels with their nearest-neighbor label
  distributions
- interpret all three rendered neighborhoods
- distinguish the strong normal-image grouping from the weak multi-label
  abnormal match
- state the limitation of drawing an accuracy conclusion from three examples

## Why

The tutorial says the plots evaluate representation quality but previously
stopped immediately after rendering them. The added interpretation answers
whether the displayed embeddings are good or bad, points readers to the
evidence in each plot, and frames this as a qualitative check rather than a
diagnostic metric.

## Checks

- `uvx ruff check docs/source/tutorials_source/package/tutorial_custom_augmentations.py`
- `git diff --check`

Fixes #581
