### PR TITLE
ci: run distributed pool tests in a dedicated gloo job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,34 @@ jobs:
           source .venv/bin/activate
           export LIGHTLY_SERVER_LOCATION="localhost:-1"
           python -m pytest -s -v --runslow --ignore=./lightly/openapi_generated/
+
+  distributed-tests:
+    name: Distributed Tests
+    needs: detect-code-changes
+    if: needs.detect-code-changes.outputs.run-tests == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Hack to get setup-python to work on nektos/act
+        run: |
+          if [ ! -f "/etc/lsb-release" ] ; then
+            echo "DISTRIB_RELEASE=18.04" > /etc/lsb-release
+          fi
+      - name: Set Up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Set Up Environment
+        run: |
+          make install-uv reset-venv
+          source .venv/bin/activate
+          make install-pinned-extras-3.12
+      # Run the @pytest.mark.DDP tests on the shared gloo pool (real multi-rank
+      # collective, not mocked). USE_PYTEST_POOL enables it; off by default. See #1982.
+      - name: Run Distributed Tests (gloo pool)
+        run: |
+          source .venv/bin/activate
+          export LIGHTLY_SERVER_LOCATION="localhost:-1"
+          export USE_PYTEST_POOL=1
+          python -m pytest -s -v --runslow -m DDP --ignore=./lightly/openapi_generated/


### PR DESCRIPTION
Part of #1982.

## Description
- [ ] My change is breaking

The distributed test pool from #1983 is gated behind `USE_PYTEST_POOL`, which defaults to off, so its `@pytest.mark.DDP` tests never run in CI — they only execute when the flag is set manually. This adds a dedicated `distributed-tests` job that runs the DDP tests on the shared gloo (CPU) pool with `USE_PYTEST_POOL=1`, so real multi-rank collectives are exercised on every PR instead of relying on mocks (the gap that hid #1977 until #1980).

The flag stays off by default everywhere else, so local runs and the main 3.7/3.12 test matrix are unchanged — only this job enables the pool. It's a separate job (not a step in the existing `test` job) so a pool issue can't destabilise the main suite, and it runs on Python 3.12, the version I verified on Linux (below).

## Tests
- [x] My change is covered by existing tests.
- [ ] My change needs new tests.
- [ ] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

Before enabling it, I reproduced the CI runner in Docker (`python:3.12-slim`, CPU torch, gloo) to confirm the spawn path runs green on Linux — Linux defaults multiprocessing to `fork`, but the pool forces `spawn`, so it behaves like macOS:

```
# flag ON — exact CI command form
USE_PYTEST_POOL=1 python -m pytest -s -v --runslow -m DDP tests/loss/
  => 2 passed, 1055 deselected      # both BarlowTwins DDP tests run on the pool

# flag OFF (control)
python -m pytest tests/loss/test_barlow_twins_loss.py
  => 4 passed, 2 skipped            # DDP tests correctly skip
```

The job's collection scope matches the existing `test` job (whole repo, `--ignore=./lightly/openapi_generated/`), which already proves collection works with the full pinned deps.

## Documentation
- [ ] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation ( `.rst` files).
- [ ] I have updated the documentation accordingly.
- [ ] The autodocs update the documentation accordingly.

CI-only change — no public API or docs.

## Implications / comments / further issues
A few decisions I'd value your call on:
- **3.12 only** for now (the version I verified on Linux); happy to add 3.7 if you want it covered.
- **Dedicated job vs. a step in the existing 3.12 `test` job** — I chose a separate job for isolation; a step would be smaller but couples pool flakiness to the main suite.
- If you make this a **required** check, it's skipped on docs/examples/benchmarks-only PRs (same `detect-code-changes` gate as `test`), so it needs the same required-but-skippable handling — related to #2007.

Unrelated side-finding while testing on torch 2.13: `torch.distributed.nn.functional.all_reduce` (used by the #1980 BarlowTwins fix) now emits a `FutureWarning` (deprecated for `torch.distributed._functional_collectives.all_reduce`). Not touched here — flagging as a possible follow-up.
