### PR TITLE
Use InterpolationMode.BICUBIC in transforms

### DIFF
--- a/lightly/transforms/capi_transform.py
+++ b/lightly/transforms/capi_transform.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from PIL.Image import Image
 from torch import Tensor
-from torchvision.transforms import InterpolationMode
 
 from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
@@ -44,7 +43,7 @@ class CAPITransform:
             T.RandomResizedCrop(
                 input_size,
                 scale=(min_scale, 1.0),
-                interpolation=InterpolationMode.BICUBIC,
+                interpolation=T.InterpolationMode.BICUBIC,
             ),
             T.RandomHorizontalFlip(),
             T.ToTensor(),

--- a/lightly/transforms/dino_transform.py
+++ b/lightly/transforms/dino_transform.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import PIL
 from PIL.Image import Image
 from torch import Tensor
 
@@ -279,8 +278,7 @@ class DINOViewTransform:
             T.RandomResizedCrop(
                 size=crop_size,
                 scale=crop_scale,
-                # Type ignore needed because BICUBIC is not recognized as an attribute.
-                interpolation=PIL.Image.BICUBIC,  # type: ignore[attr-defined]
+                interpolation=T.InterpolationMode.BICUBIC,
             ),
             T.RandomHorizontalFlip(p=hf_prob),
             T.RandomVerticalFlip(p=vf_prob),

--- a/lightly/transforms/ibot_transform.py
+++ b/lightly/transforms/ibot_transform.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, Optional, Tuple, Union
 
-import PIL
 from PIL.Image import Image
 from torch import Tensor
 
@@ -243,8 +242,7 @@ class IBOTViewTransform:
             T.RandomResizedCrop(
                 size=crop_size,
                 scale=crop_scale,
-                # Type ignore needed because BICUBIC is not recognized as an attribute.
-                interpolation=PIL.Image.BICUBIC,  # type: ignore[attr-defined]
+                interpolation=T.InterpolationMode.BICUBIC,
             ),
             T.RandomHorizontalFlip(p=hf_prob),
             T.RandomApply(

--- a/lightly/transforms/ijepa_transform.py
+++ b/lightly/transforms/ijepa_transform.py
@@ -34,8 +34,10 @@ class IJEPATransform:
     ):
         transforms = [
             T.RandomResizedCrop(
-                input_size, scale=(min_scale, 1.0), interpolation=3
-            ),  # 3 is bicubic
+                input_size,
+                scale=(min_scale, 1.0),
+                interpolation=T.InterpolationMode.BICUBIC,
+            ),
             T.RandomHorizontalFlip(),
             T.ToTensor(),
         ]

--- a/lightly/transforms/mae_transform.py
+++ b/lightly/transforms/mae_transform.py
@@ -40,8 +40,10 @@ class MAETransform:
     ):
         transforms = [
             T.RandomResizedCrop(
-                input_size, scale=(min_scale, 1.0), interpolation=3
-            ),  # 3 is bicubic
+                input_size,
+                scale=(min_scale, 1.0),
+                interpolation=T.InterpolationMode.BICUBIC,
+            ),
             T.RandomHorizontalFlip(),
             T.ToTensor(),
         ]

--- a/lightly/transforms/wmse_transform.py
+++ b/lightly/transforms/wmse_transform.py
@@ -92,7 +92,7 @@ class WMSETransform(MultiViewTransform):
                 T.RandomResizedCrop(
                     input_size,
                     scale=(min_scale, 1.0),
-                    interpolation=3,
+                    interpolation=T.InterpolationMode.BICUBIC,
                 ),
                 T.RandomHorizontalFlip(p=hf_prob),
                 GaussianBlur(


### PR DESCRIPTION
## Summary

- standardize the crop interpolation in MAE, I-JEPA, WMSE, CAPI, DINO, and iBOT on the torchvision compatibility alias `T.InterpolationMode.BICUBIC`
- remove numeric/PIL constants, obsolete type-ignore comments, and imports that are no longer needed
- align CAPI's existing direct `InterpolationMode` usage with the same compatibility alias as the other transforms

Closes #2009

## Testing

- `make format`
- `make format-check`
- `make lint`
- `make type-check`
- targeted MAE, CAPI, DINO, iBOT, and WMSE transform tests (`12 passed`)
- I-JEPA PIL smoke test with a `(3, 32, 32)` output assertion
- source checks for exactly six compatibility-alias usages and no legacy interpolation constants
- `GITHUB_ACTIONS=1 make all-checks` (`1764 passed, 241 skipped`)

Running `make all-checks` without the GitHub Actions environment additionally executes the repository's locally enabled distributed tests. Its existing `test_loss_dcl` golden-value assertion fails identically on a clean `upstream/master`; that test class is explicitly skipped in GitHub Actions and is unrelated to these transform-only changes.

## Compatibility

This is not a breaking change and does not change public APIs or runtime behavior. No documentation changes are required.
