### PR TITLE
feat(utils): standardise deprecations on single helper (#2019)

### DIFF
--- a/lightly/active_learning/__init__.py
+++ b/lightly/active_learning/__init__.py
@@ -1,11 +1,13 @@
-import warnings
+from lightly.utils.deprecation import warn_deprecated
 
 
-def raise_active_learning_deprecation_warning():
-    warnings.warn(
-        "Using active learning via the lightly package is deprecated and will be removed soon. "
-        "Please use the Lightly Solution instead. "
-        "See https://docs.lightly.ai for more information and tutorials on doing active learning.",
-        DeprecationWarning,
-        stacklevel=2,
+def raise_active_learning_deprecation_warning() -> None:
+    warn_deprecated(
+        name="Using active learning via the lightly package is",
+        alternative=(
+            "Please use the Lightly Solution instead. See https://docs.lightly.ai "
+            "for more information and tutorials on doing active learning."
+        ),
+        removed_in="1.6.0",
+        stacklevel=3,
     )

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -6,7 +6,6 @@
 import math
 from multiprocessing import Value
 from typing import List, Optional, Tuple, Union
-from warnings import warn
 
 import torch
 import torch.nn as nn
@@ -18,6 +17,7 @@ from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropA
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
+from lightly.utils.deprecation import warn_deprecated
 
 imagenet_normalize = IMAGENET_NORMALIZE
 # Kept for backwards compatibility
@@ -1512,8 +1512,12 @@ class IJEPAMaskCollator:
 
 
 def _deprecation_warning_collate_functions() -> None:
-    warn(
-        "Collate functions are deprecated and will be removed in favor of transforms in v1.4.0.\n"
-        "See https://docs.lightly.ai/self-supervised-learning/examples/models.html for examples.",
-        category=DeprecationWarning,
+    warn_deprecated(
+        name="Collate functions are",
+        alternative=(
+            "Use transforms instead. See "
+            "https://docs.lightly.ai/self-supervised-learning/examples/models.html "
+            "for examples."
+        ),
+        removed_in="1.6.0",
     )

--- a/lightly/models/barlowtwins.py
+++ b/lightly/models/barlowtwins.py
@@ -5,12 +5,11 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import BarlowTwinsProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class BarlowTwins(nn.Module):
@@ -53,13 +52,14 @@ class BarlowTwins(nn.Module):
             num_ftrs, proj_hidden_dim, out_dim
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block BarlowTwins will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+        warn_deprecated(
+            name="The high-level building block BarlowTwins",
+            alternative=(
+                "Use low-level building blocks instead. See "
+                "https://docs.lightly.ai/self-supervised-learning/lightly.models.html "
+                "for more information"
             ),
-            DeprecationWarning,
+            removed_in="1.6.0",
         )
 
     def forward(

--- a/lightly/models/byol.py
+++ b/lightly/models/byol.py
@@ -3,13 +3,12 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models._momentum import _MomentumEncoderMixin
 from lightly.models.modules import BYOLProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 def _get_byol_mlp(num_ftrs: int, hidden_dim: int, out_dim: int):
@@ -64,13 +63,14 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
         self._init_momentum_encoder()
         self.m = m
 
-        warnings.warn(
-            Warning(
-                "The high-level building block BYOL will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+        warn_deprecated(
+            name="The high-level building block BYOL",
+            alternative=(
+                "Use low-level building blocks instead. See "
+                "https://docs.lightly.ai/self-supervised-learning/lightly.models.html "
+                "for more information"
             ),
-            DeprecationWarning,
+            removed_in="1.6.0",
         )
 
     def _forward(self, x0: torch.Tensor, x1: torch.Tensor = None):

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -3,13 +3,12 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models._momentum import _MomentumEncoderMixin
 from lightly.models.modules import MoCoProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class MoCo(nn.Module, _MomentumEncoderMixin):
@@ -53,13 +52,14 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
         # initialize momentum features and momentum projection head
         self._init_momentum_encoder()
 
-        warnings.warn(
-            Warning(
-                "The high-level building block MoCo will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+        warn_deprecated(
+            name="The high-level building block MoCo",
+            alternative=(
+                "Use low-level building blocks instead. See "
+                "https://docs.lightly.ai/self-supervised-learning/lightly.models.html "
+                "for more information"
             ),
-            DeprecationWarning,
+            removed_in="1.6.0",
         )
 
     def forward(

--- a/lightly/models/nnclr.py
+++ b/lightly/models/nnclr.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import NNCLRPredictionHead, NNCLRProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 def _prediction_mlp(in_dims: int, h_dims: int, out_dims: int) -> nn.Sequential:
@@ -149,13 +148,14 @@ class NNCLR(nn.Module):
             out_dim,
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block NNCLR will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+        warn_deprecated(
+            name="The high-level building block NNCLR",
+            alternative=(
+                "Use low-level building blocks instead. See "
+                "https://docs.lightly.ai/self-supervised-learning/lightly.models.html "
+                "for more information"
             ),
-            DeprecationWarning,
+            removed_in="1.6.0",
         )
 
     def forward(

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import SimCLRProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class SimCLR(nn.Module):
@@ -36,13 +35,14 @@ class SimCLR(nn.Module):
             num_ftrs, num_ftrs, out_dim, batch_norm=False
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block SimCLR will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+        warn_deprecated(
+            name="The high-level building block SimCLR",
+            alternative=(
+                "Use low-level building blocks instead. See "
+                "https://docs.lightly.ai/self-supervised-learning/lightly.models.html "
+                "for more information"
             ),
-            DeprecationWarning,
+            removed_in="1.6.0",
         )
 
     def forward(

--- a/lightly/models/simsiam.py
+++ b/lightly/models/simsiam.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class SimSiam(nn.Module):
@@ -62,13 +61,14 @@ class SimSiam(nn.Module):
             out_dim,
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block SimSiam will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
+        warn_deprecated(
+            name="The high-level building block SimSiam",
+            alternative=(
+                "Use low-level building blocks instead. See "
+                "https://docs.lightly.ai/self-supervised-learning/lightly.models.html "
+                "for more information"
             ),
-            DeprecationWarning,
+            removed_in="1.6.0",
         )
 
     def forward(

--- a/lightly/utils/__init__.py
+++ b/lightly/utils/__init__.py
@@ -1,0 +1,3 @@
+from lightly.utils.deprecation import warn_deprecated
+
+__all__ = ["warn_deprecated"]

--- a/lightly/utils/deprecation.py
+++ b/lightly/utils/deprecation.py
@@ -1,0 +1,36 @@
+import warnings
+
+
+def warn_deprecated(
+    name: str,
+    alternative: str = "",
+    removed_in: str = "",
+    stacklevel: int = 3,
+) -> None:
+    """Warns that a feature is deprecated using a FutureWarning.
+
+    Args:
+        name:
+            Name or description of the deprecated feature (e.g., "BYOL").
+        alternative:
+            Suggested alternative to use instead.
+        removed_in:
+            Version when the feature will be removed.
+        stacklevel:
+            Stack level passed to warnings.warn.
+    """
+    if "deprecated" in name.lower():
+        msg = name
+    elif name.endswith(" is") or name.endswith(" are"):
+        msg = f"{name} deprecated"
+    else:
+        msg = f"{name} is deprecated"
+
+    if removed_in:
+        msg += f" and will be removed in version {removed_in}"
+    msg += "."
+
+    if alternative:
+        msg += f" {alternative}"
+
+    warnings.warn(msg, category=FutureWarning, stacklevel=stacklevel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,7 @@ ignore_errors = true
 # workers re-import the test module, which deadlocks under the default prepend
 # import mode. It is a no-op for the rest of the suite.
 addopts = "--import-mode=importlib"
+filterwarnings = ["error::FutureWarning"]
 
 [tool.jupytext]
 notebook_metadata_filter="-all"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,8 @@ def mock_versioning_api():
         should be compatible with all future versions.
     """
 
+    import lightly.api._version_checking
+
     def mock_get_latest_pip_version(current_version: str, **kwargs) -> str:
         return current_version
 

--- a/tests/utils/test_deprecation.py
+++ b/tests/utils/test_deprecation.py
@@ -1,0 +1,41 @@
+import pytest
+
+from lightly.utils.deprecation import warn_deprecated
+
+
+def test_warn_deprecated() -> None:
+    with pytest.warns(FutureWarning) as record:
+        warn_deprecated(
+            name="FeatureFoo",
+            alternative="Use FeatureBar instead.",
+            removed_in="1.6.0",
+        )
+
+    assert len(record) == 1
+    assert (
+        record[0].message.args[0]
+        == "FeatureFoo is deprecated and will be removed in version 1.6.0. Use FeatureBar instead."
+    )
+
+
+def test_warn_deprecated__with_already_deprecated_in_name() -> None:
+    with pytest.warns(FutureWarning) as record:
+        warn_deprecated(
+            name="FeatureFoo is deprecated",
+            alternative="Use FeatureBar instead.",
+            removed_in="1.6.0",
+        )
+
+    assert len(record) == 1
+    assert (
+        record[0].message.args[0]
+        == "FeatureFoo is deprecated and will be removed in version 1.6.0. Use FeatureBar instead."
+    )
+
+
+def test_warn_deprecated__no_optional_args() -> None:
+    with pytest.warns(FutureWarning) as record:
+        warn_deprecated(name="FeatureFoo")
+
+    assert len(record) == 1
+    assert record[0].message.args[0] == "FeatureFoo is deprecated."


### PR DESCRIPTION
### Summary

Fixes #2019.

This PR standardises deprecation warnings across the codebase using a unified `warn_deprecated` helper function:
- Introduced `warn_deprecated(name, alternative, removed_in, stacklevel)` in `lightly/utils/deprecation.py` emitting `FutureWarning`.
- Exported `warn_deprecated` in `lightly/utils/__init__.py`.
- Updated model classes (`BYOL`, `BarlowTwins`, `MoCo`, `NNCLR`, `SimCLR`, `SimSiam`) to call `warn_deprecated`.
- Updated `_deprecation_warning_collate_functions` in `lightly/data/collate.py` and `raise_active_learning_deprecation_warning` in `lightly/active_learning/__init__.py`.
- Added `filterwarnings = ["error::FutureWarning"]` to `pyproject.toml`.
- Added unit tests in `tests/utils/test_deprecation.py`.

### Testing
- `pytest tests/utils/test_deprecation.py`
- `pytest tests/models/test_Models*.py`
- `pytest tests/data/test_data_collate.py`
- `ruff check`
