### PR TITLE
added types for online_linear_classifier.py

### DIFF
--- a/lightly/utils/benchmarking/online_linear_classifier.py
+++ b/lightly/utils/benchmarking/online_linear_classifier.py
@@ -23,9 +23,12 @@ class OnlineLinearClassifier(LightningModule):
         self.criterion = CrossEntropyLoss()
 
     def forward(self, x: Tensor) -> Tensor:
-        return self.classification_head(x.detach().flatten(start_dim=1))
+        predictions: Tensor = self.classification_head(x.detach().flatten(start_dim=1))
+        return predictions
 
-    def shared_step(self, batch, batch_idx) -> Tuple[Tensor, Dict[int, Tensor]]:
+    def shared_step(
+        self, batch: Tuple[Tensor, ...], batch_idx: int
+    ) -> Tuple[Tensor, Dict[int, Tensor]]:
         features, targets = batch[0], batch[1]
         predictions = self.forward(features)
         loss = self.criterion(predictions, targets)
@@ -33,13 +36,23 @@ class OnlineLinearClassifier(LightningModule):
         topk = mean_topk_accuracy(predicted_classes, targets, k=self.topk)
         return loss, topk
 
-    def training_step(self, batch, batch_idx) -> Tuple[Tensor, Dict[str, Tensor]]:
+    # type ignore is needed because LightningModule.training_step is typed to return
+    # STEP_OUTPUT. this classifier is not run by a Trainer directly; the parent module
+    # calls it and logs the returned dict itself.
+    def training_step(  # type: ignore[override]
+        self, batch: Tuple[Tensor, ...], batch_idx: int
+    ) -> Tuple[Tensor, Dict[str, Tensor]]:
         loss, topk = self.shared_step(batch=batch, batch_idx=batch_idx)
         log_dict = {"train_online_cls_loss": loss}
         log_dict.update({f"train_online_cls_top{k}": acc for k, acc in topk.items()})
         return loss, log_dict
 
-    def validation_step(self, batch, batch_idx) -> Tuple[Tensor, Dict[str, Tensor]]:
+    # type ignore is needed because LightningModule.validation_step is typed to return
+    # STEP_OUTPUT. this classifier is not run by a Trainer directly; the parent module
+    # calls it and logs the returned dict itself.
+    def validation_step(  # type: ignore[override]
+        self, batch: Tuple[Tensor, ...], batch_idx: int
+    ) -> Tuple[Tensor, Dict[str, Tensor]]:
         loss, topk = self.shared_step(batch=batch, batch_idx=batch_idx)
         log_dict = {"val_online_cls_loss": loss}
         log_dict.update({f"val_online_cls_top{k}": acc for k, acc in topk.items()})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,6 @@ exclude = '''(?x)(
     lightly/utils/debug.py |
     lightly/utils/benchmarking/benchmark_module.py |
     lightly/utils/benchmarking/knn_classifier.py |
-    lightly/utils/benchmarking/online_linear_classifier.py |
     lightly/models/modules/masked_autoencoder.py |
     lightly/models/modules/ijepa.py |
     lightly/models/utils.py |
@@ -278,7 +277,6 @@ exclude = '''(?x)(
     tests/utils/test_debug.py |
     tests/utils/benchmarking/test_benchmark_module.py |
     tests/utils/benchmarking/test_topk.py |
-    tests/utils/benchmarking/test_online_linear_classifier.py |
     tests/utils/benchmarking/test_knn_classifier.py |
     tests/utils/benchmarking/test_knn.py |
     tests/utils/benchmarking/test_linear_classifier.py |

--- a/tests/utils/benchmarking/test_online_linear_classifier.py
+++ b/tests/utils/benchmarking/test_online_linear_classifier.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import pytest
 import torch
 from pytorch_lightning import LightningModule, Trainer
@@ -55,7 +57,7 @@ class _DummyModule(LightningModule):
         self.linear = nn.Sequential(nn.Flatten(), nn.Linear(3 * 8 * 8, 3))
         self.online_classifier = OnlineLinearClassifier(feature_dim=3, num_classes=5)
 
-    def training_step(self, batch, batch_idx) -> Tensor:
+    def training_step(self, batch: Tuple[Tensor, ...], batch_idx: int) -> Tensor:
         images, targets = batch[0], batch[1]
         features = self.linear(images)
         cls_loss, cls_log = self.online_classifier.training_step(
@@ -64,7 +66,7 @@ class _DummyModule(LightningModule):
         self.log_dict(cls_log)
         return cls_loss
 
-    def validation_step(self, batch, batch_idx) -> Tensor:
+    def validation_step(self, batch: Tuple[Tensor, ...], batch_idx: int) -> Tensor:
         images, targets = batch[0], batch[1]
         features = self.linear(images)
         cls_loss, cls_log = self.online_classifier.validation_step(


### PR DESCRIPTION
Part of#1635

Added type annotations to lightly/utils/benchmarking/online_linear_classifier.py and its test file, and removes both from the mypy exclude list in pyproject.toml. Type-checked files go from 551 to 553. I checked with another file in utils/benchmarking for confirmation (not an open issue file).

I left lightly.utils.benchmarking.* in the follow_imports = "skip" list, since benchmark_module.py and knn_classifier.py in that package are still excluded.

make format-check, make type-check, and pytest tests/utils/benchmarking/test_online_linear_classifier.py all pass locally.