### PR TITLE
fix: examples +  benchmarks: weight init in mae+pixio

### DIFF
--- a/benchmarks/imagenet/vitb16/mae.py
+++ b/benchmarks/imagenet/vitb16/mae.py
@@ -11,6 +11,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 from lightly.utils.benchmarking import OnlineLinearClassifier
 from lightly.utils.scheduler import CosineWarmupScheduler
@@ -41,6 +42,9 @@ class MAE(LightningModule):
             attn_drop_rate=0.0,
         )
         self.prediction_head = Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
         self.criterion = MSELoss()
 
         self.online_classifier = OnlineLinearClassifier(

--- a/benchmarks/imagenet/vitb16/pixio.py
+++ b/benchmarks/imagenet/vitb16/pixio.py
@@ -11,6 +11,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 from lightly.utils.benchmarking import OnlineLinearClassifier
 from lightly.utils.scheduler import CosineWarmupScheduler
@@ -45,6 +46,9 @@ class Pixio(LightningModule):
             attn_drop_rate=0.0,
         )
         self.prediction_head = Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
         self.criterion = MSELoss()
 
         self.online_classifier = OnlineLinearClassifier(

--- a/examples/notebooks/pytorch/mae.ipynb
+++ b/examples/notebooks/pytorch/mae.ipynb
@@ -47,6 +47,7 @@
     "    MaskedVisionTransformerDecoderTIMM,\n",
     "    MaskedVisionTransformerTIMM,\n",
     ")\n",
+    "from lightly.models.modules.masked_vision_transformer_timm import init_weights\n",
     "from lightly.transforms import MAETransform"
    ]
   },
@@ -79,6 +80,9 @@
     "            attn_drop_rate=0.0,\n",
     "        )\n",
     "        self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)\n",
+    "        # decoder_embed and prediction_head sit outside the decoder, so init them here.\n",
+    "        self.decoder_embed.apply(init_weights)\n",
+    "        self.prediction_head.apply(init_weights)\n",
     "\n",
     "    def forward_encoder(self, images, idx_keep=None):\n",
     "        return self.backbone.encode(images=images, idx_keep=idx_keep)\n",

--- a/examples/notebooks/pytorch/pixio.ipynb
+++ b/examples/notebooks/pytorch/pixio.ipynb
@@ -47,6 +47,7 @@
     "    MaskedVisionTransformerDecoderTIMM,\n",
     "    MaskedVisionTransformerTIMM,\n",
     ")\n",
+    "from lightly.models.modules.masked_vision_transformer_timm import init_weights\n",
     "from lightly.transforms import MAETransform"
    ]
   },
@@ -83,6 +84,9 @@
     "            attn_drop_rate=0.0,\n",
     "        )\n",
     "        self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)\n",
+    "        # decoder_embed and prediction_head sit outside the decoder, so init them here.\n",
+    "        self.decoder_embed.apply(init_weights)\n",
+    "        self.prediction_head.apply(init_weights)\n",
     "\n",
     "    def forward_encoder(self, images, idx_keep=None):\n",
     "        return self.backbone.encode(images=images, idx_keep=idx_keep)\n",

--- a/examples/notebooks/pytorch_lightning/mae.ipynb
+++ b/examples/notebooks/pytorch_lightning/mae.ipynb
@@ -48,6 +48,7 @@
     "    MaskedVisionTransformerDecoderTIMM,\n",
     "    MaskedVisionTransformerTIMM,\n",
     ")\n",
+    "from lightly.models.modules.masked_vision_transformer_timm import init_weights\n",
     "from lightly.transforms import MAETransform"
    ]
   },
@@ -80,6 +81,9 @@
     "            attn_drop_rate=0.0,\n",
     "        )\n",
     "        self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)\n",
+    "        # decoder_embed and prediction_head sit outside the decoder, so init them here.\n",
+    "        self.decoder_embed.apply(init_weights)\n",
+    "        self.prediction_head.apply(init_weights)\n",
     "        self.criterion = nn.MSELoss()\n",
     "\n",
     "    def forward_encoder(self, images, idx_keep=None):\n",

--- a/examples/notebooks/pytorch_lightning/pixio.ipynb
+++ b/examples/notebooks/pytorch_lightning/pixio.ipynb
@@ -48,6 +48,7 @@
     "    MaskedVisionTransformerDecoderTIMM,\n",
     "    MaskedVisionTransformerTIMM,\n",
     ")\n",
+    "from lightly.models.modules.masked_vision_transformer_timm import init_weights\n",
     "from lightly.transforms import MAETransform"
    ]
   },
@@ -83,6 +84,9 @@
     "            attn_drop_rate=0.0,\n",
     "        )\n",
     "        self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)\n",
+    "        # decoder_embed and prediction_head sit outside the decoder, so init them here.\n",
+    "        self.decoder_embed.apply(init_weights)\n",
+    "        self.prediction_head.apply(init_weights)\n",
     "        self.criterion = nn.MSELoss()\n",
     "\n",
     "    def forward_encoder(self, images, idx_keep=None):\n",

--- a/examples/notebooks/pytorch_lightning_distributed/mae.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/mae.ipynb
@@ -48,6 +48,7 @@
     "    MaskedVisionTransformerDecoderTIMM,\n",
     "    MaskedVisionTransformerTIMM,\n",
     ")\n",
+    "from lightly.models.modules.masked_vision_transformer_timm import init_weights\n",
     "from lightly.transforms import MAETransform"
    ]
   },
@@ -80,6 +81,9 @@
     "            attn_drop_rate=0.0,\n",
     "        )\n",
     "        self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)\n",
+    "        # decoder_embed and prediction_head sit outside the decoder, so init them here.\n",
+    "        self.decoder_embed.apply(init_weights)\n",
+    "        self.prediction_head.apply(init_weights)\n",
     "        self.criterion = nn.MSELoss()\n",
     "\n",
     "    def forward_encoder(self, images, idx_keep=None):\n",

--- a/examples/notebooks/pytorch_lightning_distributed/pixio.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/pixio.ipynb
@@ -48,6 +48,7 @@
     "    MaskedVisionTransformerDecoderTIMM,\n",
     "    MaskedVisionTransformerTIMM,\n",
     ")\n",
+    "from lightly.models.modules.masked_vision_transformer_timm import init_weights\n",
     "from lightly.transforms import MAETransform"
    ]
   },
@@ -83,6 +84,9 @@
     "            attn_drop_rate=0.0,\n",
     "        )\n",
     "        self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)\n",
+    "        # decoder_embed and prediction_head sit outside the decoder, so init them here.\n",
+    "        self.decoder_embed.apply(init_weights)\n",
+    "        self.prediction_head.apply(init_weights)\n",
     "        self.criterion = nn.MSELoss()\n",
     "\n",
     "    def forward_encoder(self, images, idx_keep=None):\n",

--- a/examples/pytorch/mae.py
+++ b/examples/pytorch/mae.py
@@ -14,6 +14,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 
 
@@ -39,6 +40,9 @@ class MAE(nn.Module):
             attn_drop_rate=0.0,
         )
         self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
 
     def forward_encoder(self, images, idx_keep=None):
         return self.backbone.encode(images=images, idx_keep=idx_keep)

--- a/examples/pytorch/pixio.py
+++ b/examples/pytorch/pixio.py
@@ -14,6 +14,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 
 
@@ -43,6 +44,9 @@ class Pixio(nn.Module):
             attn_drop_rate=0.0,
         )
         self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
 
     def forward_encoder(self, images, idx_keep=None):
         return self.backbone.encode(images=images, idx_keep=idx_keep)

--- a/examples/pytorch_lightning/mae.py
+++ b/examples/pytorch_lightning/mae.py
@@ -15,6 +15,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 
 
@@ -40,6 +41,9 @@ class MAE(pl.LightningModule):
             attn_drop_rate=0.0,
         )
         self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
         self.criterion = nn.MSELoss()
 
     def forward_encoder(self, images, idx_keep=None):

--- a/examples/pytorch_lightning/pixio.py
+++ b/examples/pytorch_lightning/pixio.py
@@ -15,6 +15,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 
 
@@ -43,6 +44,9 @@ class Pixio(pl.LightningModule):
             attn_drop_rate=0.0,
         )
         self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
         self.criterion = nn.MSELoss()
 
     def forward_encoder(self, images, idx_keep=None):

--- a/examples/pytorch_lightning_distributed/mae.py
+++ b/examples/pytorch_lightning_distributed/mae.py
@@ -15,6 +15,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 
 
@@ -40,6 +41,9 @@ class MAE(pl.LightningModule):
             attn_drop_rate=0.0,
         )
         self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
         self.criterion = nn.MSELoss()
 
     def forward_encoder(self, images, idx_keep=None):

--- a/examples/pytorch_lightning_distributed/pixio.py
+++ b/examples/pytorch_lightning_distributed/pixio.py
@@ -15,6 +15,7 @@ from lightly.models.modules import (
     MaskedVisionTransformerDecoderTIMM,
     MaskedVisionTransformerTIMM,
 )
+from lightly.models.modules.masked_vision_transformer_timm import init_weights
 from lightly.transforms import MAETransform
 
 
@@ -43,6 +44,9 @@ class Pixio(pl.LightningModule):
             attn_drop_rate=0.0,
         )
         self.prediction_head = nn.Linear(decoder_dim, self.patch_size**2 * 3)
+        # decoder_embed and prediction_head sit outside the decoder, so init them here.
+        self.decoder_embed.apply(init_weights)
+        self.prediction_head.apply(init_weights)
         self.criterion = nn.MSELoss()
 
     def forward_encoder(self, images, idx_keep=None):


### PR DESCRIPTION
Follow-up to the review on (https://github.com/lightly-ai/lightly/pull/2006#discussion_r3747867713).

After the MAE/Pixio decoders moved to `MaskedVisionTransformerDecoderTIMM`, `decoder_embed` and `prediction_head` are plain `nn.Linear` layers outside the decoder. The decoder only initializes its own submodules, so those two layers were left at PyTorch's default init instead of the xavier-uniform weight / zero bias that `MAEDecoderTIMM` applied through `init_weights`. #2006 fixed this in the imagenette benchmark; this applies the same fix to the examples and the vitb16 benchmark scripts.

- Examples: `mae.py` and `pixio.py` under `pytorch`, `pytorch_lightning`, and `pytorch_lightning_distributed` now apply `init_weights` to `decoder_embed` and `prediction_head`. Regenerated the notebooks.
- Benchmarks: same fix in `benchmarks/imagenet/vitb16/{mae,pixio}.py`. This changes their initialization, so the MAE/Pixio benchmark numbers would need a re-run.

Left `IJEPAPredictorTIMM` unchanged: it builds the decoder with `initialize_weights=False` and relies on the timm default init for its predictor layers on purpose, so it isn't the same case.

Verified `make format-check` passes, the notebooks are up to date, and `decoder_embed`/`prediction_head` now initialize with zero bias.