### PR TITLE
chore: standardise deprecations using the warn_deprecated helper

### DIFF
--- a/lightly/active_learning/__init__.py
+++ b/lightly/active_learning/__init__.py
@@ -1,11 +1,9 @@
-import warnings
+from lightly.utils.deprecation import warn_deprecated
 
 
-def raise_active_learning_deprecation_warning():
-    warnings.warn(
-        "Using active learning via the lightly package is deprecated and will be removed soon. "
-        "Please use the Lightly Solution instead. "
-        "See https://docs.lightly.ai for more information and tutorials on doing active learning.",
-        DeprecationWarning,
-        stacklevel=2,
+def raise_active_learning_deprecation_warning() -> None:
+    warn_deprecated(
+        "Active learning via the lightly package",
+        "the Lightly Solution",
+        removed_in="1.7.0",
     )

--- a/lightly/data/collate.py
+++ b/lightly/data/collate.py
@@ -4,7 +4,6 @@
 # All Rights Reserved
 
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
-from warnings import warn
 
 import torch
 import torch.nn as nn
@@ -16,6 +15,7 @@ from lightly.transforms.random_crop_and_flip_with_grid import RandomResizedCropA
 from lightly.transforms.rotation import random_rotation_transform
 from lightly.transforms.torchvision_v2_compatibility import torchvision_transforms as T
 from lightly.transforms.utils import IMAGENET_NORMALIZE
+from lightly.utils.deprecation import warn_deprecated
 
 imagenet_normalize = IMAGENET_NORMALIZE
 # Kept for backwards compatibility
@@ -1341,10 +1341,10 @@ class VICRegLCollateFunction(nn.Module):
 
 
 def _deprecation_warning_collate_functions() -> None:
-    warn(
-        "Collate functions are deprecated and will be removed in favor of transforms in v1.4.0.\n"
-        "See https://docs.lightly.ai/self-supervised-learning/examples/models.html for examples.",
-        category=DeprecationWarning,
+    warn_deprecated(
+        "The collate function API",
+        "transforms",
+        removed_in="1.7.0",
     )
 
 
@@ -1359,7 +1359,6 @@ else:
         # instead of failing, and raises AttributeError once it is removed.
         if name == "IJEPAMaskCollator":
             from lightly.data.ijepa_collate import IJEPAMaskCollator
-            from lightly.utils.deprecation import warn_deprecated
 
             warn_deprecated(
                 "Importing IJEPAMaskCollator from lightly.data.collate",

--- a/lightly/models/__init__.py
+++ b/lightly/models/__init__.py
@@ -1,7 +1,7 @@
 """The lightly.models package provides model implementations.
 
-Note that the high-level building blocks will be deprecated with
-lightly version 1.3.0. Instead, use low-level building blocks to build the
+Note that the high-level building blocks are deprecated and will be removed
+in lightly version 1.7.0. Instead, use low-level building blocks to build the
 models yourself.
 
 Example implementations for all models can be found here:

--- a/lightly/models/barlowtwins.py
+++ b/lightly/models/barlowtwins.py
@@ -5,12 +5,11 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import BarlowTwinsProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class BarlowTwins(nn.Module):
@@ -53,13 +52,10 @@ class BarlowTwins(nn.Module):
             num_ftrs, proj_hidden_dim, out_dim
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block BarlowTwins will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
-            ),
-            DeprecationWarning,
+        warn_deprecated(
+            "The high-level building block BarlowTwins",
+            "low-level building blocks",
+            removed_in="1.7.0",
         )
 
     def forward(

--- a/lightly/models/byol.py
+++ b/lightly/models/byol.py
@@ -3,13 +3,12 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models._momentum import _MomentumEncoderMixin
 from lightly.models.modules import BYOLProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 def _get_byol_mlp(num_ftrs: int, hidden_dim: int, out_dim: int):
@@ -64,13 +63,10 @@ class BYOL(nn.Module, _MomentumEncoderMixin):
         self._init_momentum_encoder()
         self.m = m
 
-        warnings.warn(
-            Warning(
-                "The high-level building block BYOL will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
-            ),
-            DeprecationWarning,
+        warn_deprecated(
+            "The high-level building block BYOL",
+            "low-level building blocks",
+            removed_in="1.7.0",
         )
 
     def _forward(self, x0: torch.Tensor, x1: torch.Tensor = None):

--- a/lightly/models/moco.py
+++ b/lightly/models/moco.py
@@ -3,13 +3,12 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models._momentum import _MomentumEncoderMixin
 from lightly.models.modules import MoCoProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class MoCo(nn.Module, _MomentumEncoderMixin):
@@ -53,13 +52,10 @@ class MoCo(nn.Module, _MomentumEncoderMixin):
         # initialize momentum features and momentum projection head
         self._init_momentum_encoder()
 
-        warnings.warn(
-            Warning(
-                "The high-level building block MoCo will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
-            ),
-            DeprecationWarning,
+        warn_deprecated(
+            "The high-level building block MoCo",
+            "low-level building blocks",
+            removed_in="1.7.0",
         )
 
     def forward(

--- a/lightly/models/nnclr.py
+++ b/lightly/models/nnclr.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2021. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import NNCLRPredictionHead, NNCLRProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 def _prediction_mlp(in_dims: int, h_dims: int, out_dims: int) -> nn.Sequential:
@@ -149,13 +148,10 @@ class NNCLR(nn.Module):
             out_dim,
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block NNCLR will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
-            ),
-            DeprecationWarning,
+        warn_deprecated(
+            "The high-level building block NNCLR",
+            "low-level building blocks",
+            removed_in="1.7.0",
         )
 
     def forward(

--- a/lightly/models/simclr.py
+++ b/lightly/models/simclr.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import SimCLRProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class SimCLR(nn.Module):
@@ -36,13 +35,10 @@ class SimCLR(nn.Module):
             num_ftrs, num_ftrs, out_dim, batch_norm=False
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block SimCLR will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
-            ),
-            DeprecationWarning,
+        warn_deprecated(
+            "The high-level building block SimCLR",
+            "low-level building blocks",
+            removed_in="1.7.0",
         )
 
     def forward(

--- a/lightly/models/simsiam.py
+++ b/lightly/models/simsiam.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2020. Lightly AG and its affiliates.
 # All Rights Reserved
 
-import warnings
-
 import torch
 import torch.nn as nn
 
 from lightly.models.modules import SimSiamPredictionHead, SimSiamProjectionHead
+from lightly.utils.deprecation import warn_deprecated
 
 
 class SimSiam(nn.Module):
@@ -62,13 +61,10 @@ class SimSiam(nn.Module):
             out_dim,
         )
 
-        warnings.warn(
-            Warning(
-                "The high-level building block SimSiam will be deprecated in version 1.3.0. "
-                + "Use low-level building blocks instead. "
-                + "See https://docs.lightly.ai/self-supervised-learning/lightly.models.html for more information"
-            ),
-            DeprecationWarning,
+        warn_deprecated(
+            "The high-level building block SimSiam",
+            "low-level building blocks",
+            removed_in="1.7.0",
         )
 
     def forward(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,15 @@ ignore_errors = true
 # workers re-import the test module, which deadlocks under the default prepend
 # import mode. It is a no-op for the rest of the suite.
 addopts = "--import-mode=importlib"
+filterwarnings = [
+    # Never let a deprecated API be called silently in the test suite.
+    "error::FutureWarning",
+    # Collate functions are deprecated but still used internally; asserted in test_data_collate.py.
+    "ignore:The collate function API is deprecated:FutureWarning",
+    # torch-internal FutureWarnings (weight_norm, _pytree) that lightly cannot fix here.
+    "ignore:.*weight_norm.*:FutureWarning",
+    "ignore:.*treespec.*:FutureWarning",
+]
 
 [tool.jupytext]
 notebook_metadata_filter="-all"

--- a/tests/active_learning/test_active_learning.py
+++ b/tests/active_learning/test_active_learning.py
@@ -1,0 +1,8 @@
+import pytest
+
+from lightly.active_learning import raise_active_learning_deprecation_warning
+
+
+def test_raise_active_learning_deprecation_warning() -> None:
+    with pytest.warns(FutureWarning, match="deprecated"):
+        raise_active_learning_deprecation_warning()

--- a/tests/api_workflow/test_api_workflow_selection.py
+++ b/tests/api_workflow/test_api_workflow_selection.py
@@ -16,6 +16,9 @@ from lightly.openapi_generated.swagger_client.models import (
 )
 from tests.api_workflow import utils
 
+# SelectionConfig is deprecated and emits a FutureWarning on init.
+pytestmark = pytest.mark.filterwarnings("ignore::FutureWarning")
+
 
 def _get_tags(dataset_id: str, tag_name: str = "just-a-tag") -> List[TagData]:
     return [

--- a/tests/data/test_data_collate.py
+++ b/tests/data/test_data_collate.py
@@ -38,6 +38,10 @@ class TestDataCollate:
 
         return batch
 
+    def test_deprecation_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="deprecated"):
+            BaseCollateFunction(T.ToTensor())
+
     def test_base_collate(self) -> None:
         batch = self.create_batch()
         transform = T.ToTensor()

--- a/tests/models/test_ModelsBYOL.py
+++ b/tests/models/test_ModelsBYOL.py
@@ -18,6 +18,7 @@ def get_backbone(resnet, num_ftrs=64):
     return backbone
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestModelsBYOL:
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/tests/models/test_ModelsBYOL.py
+++ b/tests/models/test_ModelsBYOL.py
@@ -25,6 +25,10 @@ class TestModelsBYOL:
         self.batch_size = 2
         self.input_tensor = torch.rand((self.batch_size, 3, 32, 32))
 
+    def test_deprecation_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="deprecated"):
+            BYOL(nn.Identity(), num_ftrs=8, hidden_dim=8, out_dim=8)
+
     def test_create_variations_cpu(self):
         for model_name in self.resnet_variants:
             resnet = ResNetGenerator(model_name)

--- a/tests/models/test_ModelsBarlowTwins.py
+++ b/tests/models/test_ModelsBarlowTwins.py
@@ -1,0 +1,10 @@
+import pytest
+import torch.nn as nn
+
+from lightly.models import BarlowTwins
+
+
+class TestModelsBarlowTwins:
+    def test_deprecation_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="deprecated"):
+            BarlowTwins(nn.Identity(), num_ftrs=8, proj_hidden_dim=8, out_dim=8)

--- a/tests/models/test_ModelsMoCo.py
+++ b/tests/models/test_ModelsMoCo.py
@@ -18,6 +18,7 @@ def get_backbone(resnet, num_ftrs=64):
     return backbone
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestModelsMoCo:
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/tests/models/test_ModelsMoCo.py
+++ b/tests/models/test_ModelsMoCo.py
@@ -25,6 +25,10 @@ class TestModelsMoCo:
         self.batch_size = 2
         self.input_tensor = torch.rand((self.batch_size, 3, 32, 32))
 
+    def test_deprecation_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="deprecated"):
+            MoCo(nn.Identity())
+
     def test_create_variations_cpu(self):
         for model_name in self.resnet_variants:
             resnet = ResNetGenerator(model_name)

--- a/tests/models/test_ModelsNNCLR.py
+++ b/tests/models/test_ModelsNNCLR.py
@@ -20,6 +20,7 @@ def get_backbone(model: nn.Module):
     return backbone
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestNNCLR:
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/tests/models/test_ModelsNNCLR.py
+++ b/tests/models/test_ModelsNNCLR.py
@@ -40,6 +40,16 @@ class TestNNCLR:
         self.batch_size = 2
         self.input_tensor = torch.rand((self.batch_size, 3, 32, 32))
 
+    def test_deprecation_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="deprecated"):
+            NNCLR(
+                nn.Identity(),
+                num_ftrs=8,
+                proj_hidden_dim=8,
+                pred_hidden_dim=8,
+                out_dim=8,
+            )
+
     def test_create_variations_cpu(self):
         for model_name, config in self.resnet_variants.items():
             resnet = resnet_generator(model_name)

--- a/tests/models/test_ModelsSimCLR.py
+++ b/tests/models/test_ModelsSimCLR.py
@@ -18,6 +18,7 @@ def get_backbone(resnet, num_ftrs=64):
     return backbone
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestModelsSimCLR:
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/tests/models/test_ModelsSimCLR.py
+++ b/tests/models/test_ModelsSimCLR.py
@@ -25,6 +25,10 @@ class TestModelsSimCLR:
         self.batch_size = 2
         self.input_tensor = torch.rand((self.batch_size, 3, 32, 32))
 
+    def test_deprecation_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="deprecated"):
+            SimCLR(nn.Identity())
+
     def test_create_variations_cpu(self):
         for model_name in self.resnet_variants:
             resnet = ResNetGenerator(model_name)

--- a/tests/models/test_ModelsSimSiam.py
+++ b/tests/models/test_ModelsSimSiam.py
@@ -39,6 +39,16 @@ class TestSimSiam:
         self.batch_size = 2
         self.input_tensor = torch.rand((self.batch_size, 3, 32, 32))
 
+    def test_deprecation_warning(self) -> None:
+        with pytest.warns(FutureWarning, match="deprecated"):
+            SimSiam(
+                nn.Identity(),
+                num_ftrs=8,
+                proj_hidden_dim=8,
+                pred_hidden_dim=8,
+                out_dim=8,
+            )
+
     def test_create_variations_cpu(self):
         for model_name, config in self.resnet_variants.items():
             resnet = resnet_generator(model_name)

--- a/tests/models/test_ModelsSimSiam.py
+++ b/tests/models/test_ModelsSimSiam.py
@@ -19,6 +19,7 @@ def get_backbone(model: nn.Module):
     return backbone
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestSimSiam:
     @pytest.fixture(autouse=True)
     def setup(self):


### PR DESCRIPTION
Closes #2019. Follows up on #2006, which added `warn_deprecated`.

The high-level model classes (BarlowTwins, BYOL, MoCo, NNCLR, SimCLR, SimSiam), the collate functions, and the active-learning entry point now warn through `warn_deprecated`. Each raises a `FutureWarning` and names 1.7.0 as the removal version, replacing the stale 1.3.0 and 1.4.0 strings. Each migrated symbol has a deprecation test.

The pytest configuration sets `filterwarnings = ["error::FutureWarning", ...]`, so a deprecated API used in the tests fails the suite. Tests that use one on purpose opt out with a filter mark. Torch's own `weight_norm` and `_pytree` warnings are allowlisted because they are not ours to fix.

Questions:
- The collate deprecation is allowlisted because the train CLI still builds a collate function internally (`lightly/cli/train_cli.py`), which trips the guard. With the guard on, `lightly-train` now shows this `FutureWarning` to users at runtime. Do you want to keep the allowlist and migrate the CLI to transforms in a follow-up, or handle it differently in this PR?
- The removal version is 1.7.0 to match the decoders deprecated in #2006.