### PR TITLE
(prototype) Add the backbone protocols and a torchvision ResNet adapter

### DIFF
--- a/lightly/backbones/__init__.py
+++ b/lightly/backbones/__init__.py
@@ -1,0 +1,22 @@
+"""Adapters that make a foreign model satisfy a backbone protocol.
+
+One adapter per model family, named by the user rather than picked by a factory:
+a factory taking a model name has to branch on family, and the families do not
+agree on what their feature methods return.
+
+    >>> backbone = TorchvisionResNetBackbone(resnet50())
+    >>> backbone = TorchvisionResNetBackbone(small_image_stem(resnet18()))
+"""
+
+from lightly.backbones.protocols import Backbone, DenseBackbone
+from lightly.backbones.torchvision_resnet import (
+    TorchvisionResNetBackbone,
+    small_image_stem,
+)
+
+__all__ = [
+    "Backbone",
+    "DenseBackbone",
+    "TorchvisionResNetBackbone",
+    "small_image_stem",
+]

--- a/lightly/backbones/protocols.py
+++ b/lightly/backbones/protocols.py
@@ -1,0 +1,61 @@
+"""The contracts a backbone satisfies, split by output granularity."""
+
+from __future__ import annotations
+
+from torch import Tensor
+from typing_extensions import Protocol, runtime_checkable
+
+__all__ = ["Backbone", "DenseBackbone"]
+
+
+@runtime_checkable
+class Backbone(Protocol):
+    """A model that turns images into one pooled vector each.
+
+    Enough for SimCLR, BYOL, MoCo and a kNN or linear probe.
+
+    ``embed`` is deliberately not spelled ``forward_features``: that name is
+    timm's, where it returns tokens or a feature map rather than a vector, so a
+    raw timm model would satisfy the contract and return the wrong rank.
+
+    Note that ``isinstance`` against this protocol checks member names, never
+    signatures. The conformance suite in ``tests/backbones`` is what checks
+    behaviour.
+
+    Attributes:
+        feature_dim: The width of what ``embed`` returns.
+    """
+
+    feature_dim: int
+
+    def embed(self, images: Tensor) -> Tensor:
+        """Embeds images into one vector each.
+
+        Args:
+            images: Images of shape ``(B, C, H, W)``.
+
+        Returns:
+            Pooled features of shape ``(B, feature_dim)``.
+        """
+        ...
+
+
+@runtime_checkable
+class DenseBackbone(Backbone, Protocol):
+    """A backbone that also exposes its spatial features.
+
+    What a dense loss and the segmentation probe read. A ResNet satisfies this;
+    the adapter is what normalises NHWC and NCHW to ``(B, N, D)`` plus a grid.
+    """
+
+    def feature_map(self, images: Tensor) -> tuple[Tensor, tuple[int, int]]:
+        """Embeds images into one vector per spatial position.
+
+        Args:
+            images: Images of shape ``(B, C, H, W)``.
+
+        Returns:
+            Features of shape ``(B, N, D)`` and the ``(height, width)`` grid they
+            were flattened from, so that ``N == height * width``.
+        """
+        ...

--- a/lightly/backbones/torchvision_resnet.py
+++ b/lightly/backbones/torchvision_resnet.py
@@ -1,0 +1,116 @@
+"""Adapter for the torchvision ResNet family."""
+
+from __future__ import annotations
+
+from torch import Tensor
+from torch.nn import Conv2d, Identity, Module
+from torchvision.models.resnet import ResNet
+
+__all__ = ["TorchvisionResNetBackbone", "small_image_stem"]
+
+
+class TorchvisionResNetBackbone(Module):
+    """Adapts a torchvision ResNet to ``Backbone`` and ``DenseBackbone``.
+
+    The classification head is replaced by an identity, so the wrapped model
+    returns pooled features. The width is read off the head before it goes.
+
+    Example:
+        >>> backbone = TorchvisionResNetBackbone(resnet50())
+        >>> backbone.feature_dim
+        2048
+        >>> backbone.embed(images).shape
+        torch.Size([8, 2048])
+
+    Args:
+        model:
+            A torchvision ResNet, mutated in place. Wrap the stem first if the
+            images are small, see :func:`small_image_stem`.
+
+    Raises:
+        ValueError: If the model has no classification head to read the width
+            from, because it is not a ResNet or its head was already replaced.
+    """
+
+    def __init__(self, model: ResNet) -> None:
+        super().__init__()
+        head = getattr(model, "fc", None)
+        in_features = getattr(head, "in_features", None)
+        if in_features is None:
+            raise ValueError(
+                f"cannot read feature_dim: {type(model).__name__}.fc is "
+                f"{type(head).__name__}, not a Linear. Pass a torchvision ResNet "
+                "with its classification head still attached."
+            )
+        self.feature_dim: int = in_features
+        model.fc = Identity()
+        self.model = model
+
+    def embed(self, images: Tensor) -> Tensor:
+        """Embeds images into one vector each.
+
+        Goes through ``__call__`` rather than around it, so a forward hook
+        registered on this module sees the call.
+
+        Args:
+            images: Images of shape ``(B, C, H, W)``.
+
+        Returns:
+            Pooled features of shape ``(B, feature_dim)``.
+        """
+        features: Tensor = self(images)
+        return features
+
+    def feature_map(self, images: Tensor) -> tuple[Tensor, tuple[int, int]]:
+        """Embeds images into one vector per spatial position.
+
+        Args:
+            images: Images of shape ``(B, C, H, W)``.
+
+        Returns:
+            Features of shape ``(B, N, feature_dim)`` and the ``(height, width)``
+            grid they were flattened from.
+        """
+        model = self.model
+        x = model.maxpool(model.relu(model.bn1(model.conv1(images))))
+        x = model.layer4(model.layer3(model.layer2(model.layer1(x))))
+        height, width = x.shape[-2:]
+        return x.flatten(2).transpose(1, 2), (height, width)
+
+    def forward(self, images: Tensor) -> Tensor:
+        """Same as :meth:`embed`, so the adapter drops into ``nn.Sequential``.
+
+        Args:
+            images: Images of shape ``(B, C, H, W)``.
+
+        Returns:
+            Pooled features of shape ``(B, feature_dim)``.
+        """
+        features: Tensor = self.model(images)
+        return features
+
+
+def small_image_stem(model: ResNet) -> ResNet:
+    """Swaps a ResNet's stem for the one used on small images.
+
+    A 3x3 stride-1 convolution and no max pooling, which keeps a 32-pixel image
+    from being reduced to a 1x1 grid before the first block. This is what
+    ``ResNetGenerator("resnet-18")`` did for the CIFAR-10 benchmark.
+
+    Args:
+        model: A torchvision ResNet, mutated in place.
+
+    Returns:
+        The same model, so it composes with the adapter on one line.
+    """
+    conv1 = model.conv1
+    model.conv1 = Conv2d(
+        in_channels=conv1.in_channels,
+        out_channels=conv1.out_channels,
+        kernel_size=3,
+        stride=1,
+        padding=1,
+        bias=False,
+    )
+    model.maxpool = Identity()
+    return model

--- a/tests/backbones/test_conformance.py
+++ b/tests/backbones/test_conformance.py
@@ -1,0 +1,107 @@
+"""The conformance suite every backbone adapter is registered in.
+
+mypy checks that a member exists with the right signature. It cannot check that
+the member does what the contract says: a ``raise NotImplementedError`` is a
+body, and two adapters can return different ranks from the same name. That is
+what this suite is for.
+
+Adding a family is an adapter and one line in ``ADAPTERS``.
+"""
+
+from typing import Callable, List, NamedTuple, Tuple
+
+import pytest
+import torch
+from torch import Tensor
+from torchvision.models import resnet18
+
+from lightly.backbones import (
+    Backbone,
+    DenseBackbone,
+    TorchvisionResNetBackbone,
+    small_image_stem,
+)
+
+
+class Adapter(NamedTuple):
+    name: str
+    # Widen this to a union as more families are adapted.
+    build: Callable[[], TorchvisionResNetBackbone]
+    input_size: int
+    dense: bool
+
+
+ADAPTERS: List[Adapter] = [
+    Adapter(
+        name="torchvision_resnet",
+        build=lambda: TorchvisionResNetBackbone(resnet18()),
+        input_size=64,
+        dense=True,
+    ),
+    Adapter(
+        name="torchvision_resnet_small_stem",
+        build=lambda: TorchvisionResNetBackbone(small_image_stem(resnet18())),
+        input_size=32,
+        dense=True,
+    ),
+]
+
+IDS = [adapter.name for adapter in ADAPTERS]
+DENSE_ADAPTERS = [adapter for adapter in ADAPTERS if adapter.dense]
+DENSE_IDS = [adapter.name for adapter in DENSE_ADAPTERS]
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=IDS)
+def test_satisfies_backbone(adapter: Adapter) -> None:
+    assert isinstance(adapter.build(), Backbone)
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=IDS)
+def test_embed_returns_feature_dim_columns(adapter: Adapter) -> None:
+    backbone = adapter.build()
+    images = torch.randn(2, 3, adapter.input_size, adapter.input_size)
+    features = backbone.embed(images)
+    assert features.shape == (2, backbone.feature_dim)
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=IDS)
+def test_embed_is_deterministic_in_eval(adapter: Adapter) -> None:
+    backbone = adapter.build().eval()
+    images = torch.randn(2, 3, adapter.input_size, adapter.input_size)
+    with torch.no_grad():
+        assert torch.equal(backbone.embed(images), backbone.embed(images))
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=IDS)
+def test_calling_the_module_equals_embed(adapter: Adapter) -> None:
+    backbone = adapter.build().eval()
+    images = torch.randn(2, 3, adapter.input_size, adapter.input_size)
+    with torch.no_grad():
+        assert torch.equal(backbone(images), backbone.embed(images))
+
+
+@pytest.mark.parametrize("adapter", DENSE_ADAPTERS, ids=DENSE_IDS)
+def test_satisfies_dense_backbone(adapter: Adapter) -> None:
+    assert isinstance(adapter.build(), DenseBackbone)
+
+
+@pytest.mark.parametrize("adapter", DENSE_ADAPTERS, ids=DENSE_IDS)
+def test_feature_map_flattens_the_grid_it_returns(adapter: Adapter) -> None:
+    backbone = adapter.build()
+    images = torch.randn(2, 3, adapter.input_size, adapter.input_size)
+    features, (height, width) = backbone.feature_map(images)
+    assert features.shape == (2, height * width, backbone.feature_dim)
+
+
+@pytest.mark.parametrize("adapter", ADAPTERS, ids=IDS)
+def test_no_member_raises_not_implemented(adapter: Adapter) -> None:
+    backbone = adapter.build()
+    images = torch.randn(2, 3, adapter.input_size, adapter.input_size)
+    members: List[Tuple[str, Callable[[Tensor], object]]] = [("embed", backbone.embed)]
+    if adapter.dense:
+        members.append(("feature_map", backbone.feature_map))
+    for name, member in members:
+        try:
+            member(images)
+        except NotImplementedError:
+            pytest.fail(f"{adapter.name}.{name} raises NotImplementedError")


### PR DESCRIPTION
> **Prototype. Do not merge.** This is a design exploration for the LightlySSL 2.0
> refactor, opened to be read and argued with, not to land on `master`. The whole
> stack goes together or not at all, and the shape is still open.

2 of 7 in a stack. Base: #2033.

A masked vision transformer exists once per backbone source today: 1,951 LOC across 8 files, where both wrappers implement the same seven members and the only real difference is what the wrapped model calls its parts. A third source costs a third copy of masking that has nothing to do with masking.

`Backbone` declares `feature_dim` and `embed(images) -> (B, feature_dim)`. `DenseBackbone` adds `feature_map`, which returns `(B, N, D)` plus the grid, and is the granularity a dense loss and a segmentation probe read. `embed` is deliberately not spelled `forward_features`: that name is timm's, where it returns tokens or a feature map, so a raw timm model would satisfy the old spelling and return the wrong rank.

`TorchvisionResNetBackbone` is the first adapter, and the user names it rather than a factory picking it. `small_image_stem` is the 3x3 stride-1 stem the CIFAR benchmark used through `ResNetGenerator`.

mypy checks that a member exists with the right signature. It cannot check that a member does what the contract says, since `raise NotImplementedError` is a body. `tests/backbones/test_conformance.py` is the second check, parameterised over a registry every adapter joins.

Testing: `pytest tests/backbones`, 14 cases.
