### PR TITLE
fix(models): handle zero masked patch count in random_inverse_block_mask (#2025)

### DIFF
--- a/lightly/models/utils.py
+++ b/lightly/models/utils.py
@@ -797,7 +797,9 @@ def random_inverse_block_mask(
     idx_mask_rows = []
     for _ in range(batch_size):
         visible = torch.zeros(num_patches, dtype=torch.bool)
-        if num_visible > 0:
+        if num_visible == num_patches:
+            visible.fill_(True)
+        elif num_visible > 0:
             # Sample the aspect ratio of the visible block, clamped so it fits.
             min_lar = max(log_aspect_ratio[0], math.log(num_visible / width**2))
             max_lar = min(

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -1125,6 +1125,47 @@ def test_random_inverse_block_mask__not_square_raises() -> None:
         )
 
 
+def test_random_inverse_block_mask__mask_ratio_extremes() -> None:
+    num_prefix_tokens = 1
+    sequence_length = num_prefix_tokens + 16  # 4x4 patch grid
+
+    # mask_ratio=0.0 keeps all patches and masks none.
+    idx_keep, idx_mask = utils.random_inverse_block_mask(
+        size=(2, sequence_length),
+        mask_ratio=0.0,
+        num_prefix_tokens=num_prefix_tokens,
+    )
+    assert idx_mask.shape == (2, 0)
+    assert idx_keep.shape == (2, sequence_length)
+    assert torch.equal(
+        idx_keep, torch.arange(sequence_length).expand(2, sequence_length)
+    )
+
+    # mask_ratio=0.05 rounds to 0 masked patches (int(16 * 0.05) == 0).
+    idx_keep, idx_mask = utils.random_inverse_block_mask(
+        size=(2, sequence_length),
+        mask_ratio=0.05,
+        num_prefix_tokens=num_prefix_tokens,
+    )
+    assert idx_mask.shape == (2, 0)
+    assert idx_keep.shape == (2, sequence_length)
+    assert torch.equal(
+        idx_keep, torch.arange(sequence_length).expand(2, sequence_length)
+    )
+
+    # mask_ratio=1.0 keeps only the prefix tokens and masks all patches.
+    idx_keep, idx_mask = utils.random_inverse_block_mask(
+        size=(2, sequence_length),
+        mask_ratio=1.0,
+        num_prefix_tokens=num_prefix_tokens,
+    )
+    assert idx_mask.shape == (2, 16)
+    assert idx_keep.shape == (2, num_prefix_tokens)
+    assert torch.equal(
+        idx_keep, torch.arange(num_prefix_tokens).expand(2, num_prefix_tokens)
+    )
+
+
 def test_random_grid_token_mask__mask_ratio_extremes() -> None:
     num_prefix_tokens = 1
     sequence_length = num_prefix_tokens + 16  # 4 cells of 4 patches (grid=2)

--- a/tests/models/test_ModelUtils.py
+++ b/tests/models/test_ModelUtils.py
@@ -1125,68 +1125,60 @@ def test_random_inverse_block_mask__not_square_raises() -> None:
         )
 
 
-def test_random_inverse_block_mask__mask_ratio_extremes() -> None:
+@pytest.mark.parametrize(
+    "mask_ratio, expected_keep_shape, expected_mask_shape",
+    [
+        (0.0, (2, 17), (2, 0)),
+        (0.05, (2, 17), (2, 0)),  # rounds to 0 masked patches (int(16 * 0.05) == 0)
+        (1.0, (2, 1), (2, 16)),
+    ],
+)
+def test_random_inverse_block_mask__mask_ratio_extremes(
+    mask_ratio: float,
+    expected_keep_shape: tuple[int, int],
+    expected_mask_shape: tuple[int, int],
+) -> None:
     num_prefix_tokens = 1
     sequence_length = num_prefix_tokens + 16  # 4x4 patch grid
-
-    # mask_ratio=0.0 keeps all patches and masks none.
     idx_keep, idx_mask = utils.random_inverse_block_mask(
         size=(2, sequence_length),
-        mask_ratio=0.0,
+        mask_ratio=mask_ratio,
         num_prefix_tokens=num_prefix_tokens,
     )
-    assert idx_mask.shape == (2, 0)
-    assert idx_keep.shape == (2, sequence_length)
-    assert torch.equal(
-        idx_keep, torch.arange(sequence_length).expand(2, sequence_length)
-    )
-
-    # mask_ratio=0.05 rounds to 0 masked patches (int(16 * 0.05) == 0).
-    idx_keep, idx_mask = utils.random_inverse_block_mask(
-        size=(2, sequence_length),
-        mask_ratio=0.05,
-        num_prefix_tokens=num_prefix_tokens,
-    )
-    assert idx_mask.shape == (2, 0)
-    assert idx_keep.shape == (2, sequence_length)
-    assert torch.equal(
-        idx_keep, torch.arange(sequence_length).expand(2, sequence_length)
-    )
-
-    # mask_ratio=1.0 keeps only the prefix tokens and masks all patches.
-    idx_keep, idx_mask = utils.random_inverse_block_mask(
-        size=(2, sequence_length),
-        mask_ratio=1.0,
-        num_prefix_tokens=num_prefix_tokens,
-    )
-    assert idx_mask.shape == (2, 16)
-    assert idx_keep.shape == (2, num_prefix_tokens)
-    assert torch.equal(
-        idx_keep, torch.arange(num_prefix_tokens).expand(2, num_prefix_tokens)
-    )
+    assert idx_keep.shape == expected_keep_shape
+    assert idx_mask.shape == expected_mask_shape
+    if mask_ratio == 0.0 or mask_ratio == 0.05:
+        assert torch.equal(
+            idx_keep, torch.arange(sequence_length).expand(2, sequence_length)
+        )
+    elif mask_ratio == 1.0:
+        assert torch.equal(
+            idx_keep, torch.arange(num_prefix_tokens).expand(2, num_prefix_tokens)
+        )
 
 
-def test_random_grid_token_mask__mask_ratio_extremes() -> None:
+@pytest.mark.parametrize(
+    "mask_ratio, expected_keep_shape, expected_mask_shape",
+    [
+        (0.0, (2, 17), (2, 0)),
+        (1.0, (2, 1), (2, 16)),
+    ],
+)
+def test_random_grid_token_mask__mask_ratio_extremes(
+    mask_ratio: float,
+    expected_keep_shape: tuple[int, int],
+    expected_mask_shape: tuple[int, int],
+) -> None:
     num_prefix_tokens = 1
     sequence_length = num_prefix_tokens + 16  # 4 cells of 4 patches (grid=2)
-    # mask_ratio=0.0 keeps all patches and masks none.
     idx_keep, idx_mask = utils.random_grid_token_mask(
         size=(2, sequence_length),
-        mask_ratio=0.0,
+        mask_ratio=mask_ratio,
         grid_size=2,
         num_prefix_tokens=num_prefix_tokens,
     )
-    assert idx_keep.shape == (2, sequence_length)
-    assert idx_mask.shape == (2, 0)
-    # mask_ratio=1.0 keeps only the prefix tokens and masks all patches.
-    idx_keep, idx_mask = utils.random_grid_token_mask(
-        size=(2, sequence_length),
-        mask_ratio=1.0,
-        grid_size=2,
-        num_prefix_tokens=num_prefix_tokens,
-    )
-    assert idx_keep.shape == (2, num_prefix_tokens)
-    assert idx_mask.shape == (2, 16)
+    assert idx_keep.shape == expected_keep_shape
+    assert idx_mask.shape == expected_mask_shape
 
 
 def test_random_grid_token_mask__grid_size_4() -> None:


### PR DESCRIPTION
### Summary of Changes

Fixes #2025.

In `lightly/models/utils.py`, `random_inverse_block_mask` previously raised a `RuntimeError: uniform_ expects to return a [from, to) range, but found from=0 > to=-6.25e-07` when `mask_ratio` was `0.0` or small enough that `num_masked = int(num_patches * mask_ratio) == 0`.

### Root Cause
When `num_masked == 0`, `num_visible == num_patches`:
- `min_lar = max(log_aspect_ratio[0], math.log(num_visible / width**2))` evaluated to `0.0`.
- `max_lar = min(log_aspect_ratio[1], math.log(height**2 / (num_visible + 1e-5)))` evaluated to `-6.25e-7` due to the epsilon term.
- `torch.empty(1).uniform_(min_lar, max_lar)` failed because `min_lar > max_lar`.

### Solution
1. Explicitly handle the boundary case `if num_visible == num_patches:` by marking all patches visible (`visible.fill_(True)`), skipping the aspect-ratio sampling loop (consistent with sibling masking functions like `random_grid_token_mask`).
2. Added unit tests in `tests/models/test_ModelUtils.py` (`test_random_inverse_block_mask__mask_ratio_extremes`) verifying `mask_ratio=0.0`, `mask_ratio=0.05` (which rounds to 0 masked patches on a 16-patch grid), and `mask_ratio=1.0`.

### Testing
- `pytest tests/models/test_ModelUtils.py`: 88 passed, 8 skipped.
- `ruff check lightly/models/utils.py tests/models/test_ModelUtils.py`: Passed.
- `ruff format --check lightly/models/utils.py tests/models/test_ModelUtils.py`: Passed.
