### PR TITLE
fix: MaskedCausalVisionTransformer build on all supported timm versions

### DIFF
--- a/benchmarks/imagenet/vitb16/aim.py
+++ b/benchmarks/imagenet/vitb16/aim.py
@@ -31,6 +31,7 @@ class AIM(LightningModule):
             qk_norm=False,
             class_token=False,
             no_embed_class=True,
+            global_pool="avg",
         )
         utils.initialize_2d_sine_cosine_positional_embedding(
             pos_embedding=vit.pos_embed, has_class_token=vit.has_class_token

--- a/examples/notebooks/pytorch/aim.ipynb
+++ b/examples/notebooks/pytorch/aim.ipynb
@@ -110,6 +110,7 @@
     "    qk_norm=False,\n",
     "    class_token=False,\n",
     "    no_embed_class=True,\n",
+    "    global_pool=\"avg\",\n",
     ")\n",
     "model = AIM(vit)"
    ]

--- a/examples/notebooks/pytorch_lightning/aim.ipynb
+++ b/examples/notebooks/pytorch_lightning/aim.ipynb
@@ -73,6 +73,7 @@
     "            qk_norm=False,\n",
     "            class_token=False,\n",
     "            no_embed_class=True,\n",
+    "            global_pool=\"avg\",\n",
     "        )\n",
     "        utils.initialize_2d_sine_cosine_positional_embedding(\n",
     "            pos_embedding=vit.pos_embed, has_class_token=vit.has_class_token\n",

--- a/examples/notebooks/pytorch_lightning_distributed/aim.ipynb
+++ b/examples/notebooks/pytorch_lightning_distributed/aim.ipynb
@@ -73,6 +73,7 @@
     "            qk_norm=False,\n",
     "            class_token=False,\n",
     "            no_embed_class=True,\n",
+    "            global_pool=\"avg\",\n",
     "        )\n",
     "        utils.initialize_2d_sine_cosine_positional_embedding(\n",
     "            pos_embedding=vit.pos_embed, has_class_token=vit.has_class_token\n",

--- a/examples/pytorch/aim.py
+++ b/examples/pytorch/aim.py
@@ -57,6 +57,7 @@ vit = MaskedCausalVisionTransformer(
     qk_norm=False,
     class_token=False,
     no_embed_class=True,
+    global_pool="avg",
 )
 model = AIM(vit)
 

--- a/examples/pytorch_lightning/aim.py
+++ b/examples/pytorch_lightning/aim.py
@@ -27,6 +27,7 @@ class AIM(pl.LightningModule):
             qk_norm=False,
             class_token=False,
             no_embed_class=True,
+            global_pool="avg",
         )
         utils.initialize_2d_sine_cosine_positional_embedding(
             pos_embedding=vit.pos_embed, has_class_token=vit.has_class_token

--- a/examples/pytorch_lightning_distributed/aim.py
+++ b/examples/pytorch_lightning_distributed/aim.py
@@ -27,6 +27,7 @@ class AIM(pl.LightningModule):
             qk_norm=False,
             class_token=False,
             no_embed_class=True,
+            global_pool="avg",
         )
         utils.initialize_2d_sine_cosine_positional_embedding(
             pos_embedding=vit.pos_embed, has_class_token=vit.has_class_token

--- a/lightly/models/modules/masked_causal_vision_transformer.py
+++ b/lightly/models/modules/masked_causal_vision_transformer.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Optional
 
 import torch
@@ -120,9 +121,16 @@ class MaskedCausalBlock(Block):  # type: ignore[misc]
             *args,
             **kwargs,
         )
+        # Keep only the kwargs that timm's Attention accepts. Block-level kwargs
+        # such as mlp_ratio do not apply to the attention layer.
+        attention_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key in inspect.signature(Attention.__init__).parameters
+        }
         self.attn = MaskedCausalAttention(
             *args,
-            **kwargs,
+            **attention_kwargs,
         )
 
     def forward(

--- a/tests/models/modules/test_masked_causal_vision_transformer.py
+++ b/tests/models/modules/test_masked_causal_vision_transformer.py
@@ -1,0 +1,98 @@
+import pytest
+import torch
+
+from lightly.utils import dependency
+
+if not dependency.timm_vit_available():
+    # We do not use pytest.importorskip on module level because it makes mypy unhappy.
+    pytest.skip("TIMM vision transformer is not available", allow_module_level=True)
+
+from lightly.models.modules.masked_causal_vision_transformer import (
+    MaskedCausalAttention,
+    MaskedCausalBlock,
+    MaskedCausalVisionTransformer,
+)
+
+# MaskedCausalAttention supports only fused attention, which needs
+# torch.nn.functional.scaled_dot_product_attention (PyTorch >=2.0).
+skip_without_fused_attention = pytest.mark.skipif(
+    not hasattr(torch.nn.functional, "scaled_dot_product_attention"),
+    reason="MaskedCausalAttention supports only fused attention (PyTorch >=2.0).",
+)
+
+
+class TestMaskedCausalBlock:
+    def test_init__forwards_only_attention_kwargs(self) -> None:
+        # Block-level kwargs such as mlp_ratio must not reach the attention layer.
+        block = MaskedCausalBlock(dim=24, num_heads=3, mlp_ratio=4.0, qkv_bias=True)
+        assert isinstance(block.attn, MaskedCausalAttention)
+        # The mlp_ratio is still applied to the block's mlp, not dropped.
+        fc1 = block.mlp.fc1
+        assert isinstance(fc1, torch.nn.Linear)
+        assert fc1.out_features == 24 * 4
+
+
+class TestMaskedCausalVisionTransformer:
+    def test_init(self) -> None:
+        model = MaskedCausalVisionTransformer(
+            img_size=32,
+            patch_size=16,
+            embed_dim=24,
+            depth=2,
+            num_heads=3,
+            mlp_ratio=4.0,
+        )
+        assert all(
+            isinstance(block.attn, MaskedCausalAttention) for block in model.blocks
+        )
+
+    @skip_without_fused_attention
+    def test_init__aim_config(self) -> None:
+        # The AIM examples build the backbone without a class token and with
+        # average pooling. timm asserts global_pool != "token" when class_token is
+        # False, so both settings are required for the backbone to build.
+        model = MaskedCausalVisionTransformer(
+            img_size=32,
+            patch_size=16,
+            embed_dim=24,
+            depth=2,
+            num_heads=3,
+            class_token=False,
+            no_embed_class=True,
+            global_pool="avg",
+        )
+        assert all(
+            isinstance(block.attn, MaskedCausalAttention) for block in model.blocks
+        )
+        images = torch.rand(2, 3, 32, 32)
+        sequence_length = (32 // 16) ** 2 + model.num_prefix_tokens
+        mask = torch.zeros(2, sequence_length, dtype=torch.bool)
+        mask[:, model.num_prefix_tokens :] = True
+        features = model.forward_features(images, mask=mask)
+        assert features.shape == (2, sequence_length, 24)
+
+    @skip_without_fused_attention
+    def test_forward(self) -> None:
+        model = MaskedCausalVisionTransformer(
+            img_size=32, patch_size=16, embed_dim=24, depth=2, num_heads=3
+        )
+        images = torch.rand(2, 3, 32, 32)
+        features = model.forward_features(images)
+        sequence_length = (32 // 16) ** 2 + model.num_prefix_tokens
+        assert features.shape == (2, sequence_length, 24)
+
+    @skip_without_fused_attention
+    def test_forward__with_mask(self) -> None:
+        model = MaskedCausalVisionTransformer(
+            img_size=32, patch_size=16, embed_dim=24, depth=2, num_heads=3
+        )
+        images = torch.rand(2, 3, 32, 32)
+        sequence_length = (32 // 16) ** 2 + model.num_prefix_tokens
+        mask = torch.zeros(2, sequence_length, dtype=torch.bool)
+        mask[:, model.num_prefix_tokens :] = True
+
+        features = model.forward_features(images, mask=mask)
+        features_no_mask = model.forward_features(images)
+        assert features.shape == (2, sequence_length, 24)
+        # The mask switches the patch tokens to causal attention and changes the output.
+        assert not torch.allclose(features, features_no_mask)


### PR DESCRIPTION
Closes #2042.

Two commits:

1. **Forward only attention kwargs in `MaskedCausalBlock`.** The block forwarded all of its block-level kwargs to the `timm` `Attention` layer. `Attention` rejects arguments like `mlp_ratio`, so `MaskedCausalVisionTransformer` failed to build on every supported `timm` version. This is a regression from #1841 (the `**kwargs` forwarding that fixed #1829). The fix selects the kwargs from `Attention.__init__`'s signature, so it keeps #1841's version-robustness without a hardcoded argument list. Adds a regression test for the block and the model, this backbone had none before.

2. **Set `global_pool="avg"` in the AIM examples and benchmark.** The examples build the backbone with `class_token=False` but no `global_pool`, which trips `timm`'s `class_token or global_pool != "token"` assertion at init, before the block bug is even reached. AIM's self-supervised path uses `forward_features`, so `"avg"` satisfies the assertion without changing behavior. Regenerated the notebooks.

Verified on `timm` `0.9.9`, `1.0.14`, and `1.0.28`. `make format-check` passes and the notebooks are up to date.