### PR TITLE
fix: correct torch.linalg.solve_triangular availability check in WMSELoss

### DIFF
--- a/lightly/loss/wmse_loss.py
+++ b/lightly/loss/wmse_loss.py
@@ -6,13 +6,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-try:
-    import torch.linalg.solve_triangular
-except ImportError:
-    # Only available in PyTorch >=1.11.
-    _SOLVE_TRIANGULAR_AVAILABLE = False
-else:
-    _SOLVE_TRIANGULAR_AVAILABLE = True
+# torch.linalg.solve_triangular is only available in PyTorch >=1.11.
+_SOLVE_TRIANGULAR_AVAILABLE = hasattr(torch.linalg, "solve_triangular")
 
 
 def norm_mse_loss(x0: torch.Tensor, x1: torch.Tensor) -> torch.Tensor:

--- a/tests/loss/test_wmse_loss.py
+++ b/tests/loss/test_wmse_loss.py
@@ -3,9 +3,8 @@ import torch
 
 from lightly.loss.wmse_loss import WMSELoss
 
-try:
-    import torch.linalg.solve_triangular
-except ImportError:
+if not hasattr(torch.linalg, "solve_triangular"):
+    # torch.linalg.solve_triangular is only available in PyTorch >=1.11.
     pytest.skip("torch.linalg.solve_triangular not available", allow_module_level=True)
 
 


### PR DESCRIPTION
Closes #2044.

`WMSELoss` and `Whitening2d` gated construction on `_SOLVE_TRIANGULAR_AVAILABLE`, set by `import torch.linalg.solve_triangular`. That statement imports a function as a module, so it always raised `ImportError` and the flag was always `False`, both classes raised `RuntimeError` on construction on every supported torch, including PyTorch >=1.11 where the function exists. `tests/loss/test_wmse_loss.py` used the same import to skip itself, so the failure never ran in CI.

Detect the function with `hasattr(torch.linalg, "solve_triangular")`, in both the module and the test. The WMSE tests now run instead of skipping.

Verified `WMSELoss()` builds and `pytest tests/loss/test_wmse_loss.py` passes (6 tests, previously 1 skipped) on torch 2.13. `make format-check` and mypy pass.