### PR TITLE
Add types for read_yolo_label_file.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,6 @@ exclude = '''(?x)(
     lightly/data/_video.py |
     lightly/core.py |
     lightly/utils/cropping/crop_image_by_bounding_boxes.py |
-    lightly/utils/cropping/read_yolo_label_file.py |
     lightly/utils/debug.py |
     lightly/utils/benchmarking/benchmark_module.py |
     lightly/utils/benchmarking/knn_classifier.py |


### PR DESCRIPTION
## Summary

Remove `read_yolo_label_file.py` from the mypy exclusion list. The file is already fully annotated, so this brings it under continuous type checking and prevents future type regressions.

Part of #1635.

## Checks

- `mypy 1.4.1 lightly/utils/cropping/read_yolo_label_file.py`
- `ruff 0.12.7 check lightly tests`
- `ruff 0.12.7 format --check lightly tests`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes `read_yolo_label_file.py` from the mypy exclusion list. This adds continuous type-checking coverage for the file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->