### PR TITLE
Fix masked attention with gradient checkpointing

### DIFF
--- a/lightly/models/modules/masked_causal_vision_transformer.py
+++ b/lightly/models/modules/masked_causal_vision_transformer.py
@@ -1,4 +1,5 @@
 import inspect
+from functools import partial
 from typing import Optional
 
 import torch
@@ -202,9 +203,8 @@ class MaskedCausalVisionTransformer(VisionTransformer):  # type: ignore[misc]
         x = self.patch_drop(x)
         x = self.norm_pre(x)
         if self.grad_checkpointing and not jit.is_scripting():
-            # TODO: This probably doesn't work correctly as it doesn't consider the
-            # mask.
-            x = _manipulate.checkpoint_seq(self.blocks, x)
+            blocks = [partial(block, mask=mask) for block in self.blocks]
+            x = _manipulate.checkpoint_seq(blocks, x)
         else:
             for block in self.blocks:
                 x = block(x, mask=mask)

--- a/tests/models/modules/test_masked_causal_vision_transformer.py
+++ b/tests/models/modules/test_masked_causal_vision_transformer.py
@@ -96,3 +96,29 @@ class TestMaskedCausalVisionTransformer:
         assert features.shape == (2, sequence_length, 24)
         # The mask switches the patch tokens to causal attention and changes the output.
         assert not torch.allclose(features, features_no_mask)
+
+    @skip_without_fused_attention
+    def test_forward__with_mask__grad_checkpointing(self) -> None:
+        torch.manual_seed(0)
+        model = MaskedCausalVisionTransformer(
+            img_size=32, patch_size=16, embed_dim=24, depth=2, num_heads=3
+        )
+        model.eval()
+        images = torch.rand(2, 3, 32, 32, requires_grad=True)
+        sequence_length = (32 // 16) ** 2 + model.num_prefix_tokens
+        mask = torch.zeros(2, sequence_length, dtype=torch.bool)
+        mask[:, model.num_prefix_tokens :] = True
+
+        expected = model.forward_features(images, mask=mask)
+        expected.sum().backward()
+        assert images.grad is not None
+        expected_input_grad = images.grad.detach().clone()
+
+        model.zero_grad(set_to_none=True)
+        images.grad.zero_()
+        model.set_grad_checkpointing()
+        features = model.forward_features(images, mask=mask)
+        features.sum().backward()
+
+        torch.testing.assert_close(features, expected)
+        torch.testing.assert_close(images.grad, expected_input_grad)


### PR DESCRIPTION
Fixes #2049

Forward the attention mask through checkpointed transformer blocks. Add regression coverage for forward and input-gradient parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fix masked attention when gradient checkpointing is enabled. Forward the mask through checkpointed transformer blocks and add regression coverage for output and input-gradient parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->