### PR TITLE
build: drop deprecated numpy mypy plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,9 +258,6 @@ warn_unreachable = true
 show_error_codes = true
 show_error_context = true
 
-# Plugins
-plugins = ["numpy.typing.mypy_plugin"]
-
 # Excludes
 # TODO(Philipp, 09/23): Remove these one by one (start with 300 files).
 exclude = '''(?x)(


### PR DESCRIPTION
NumPy 2.3 deprecated `numpy.typing.mypy_plugin`, so the Python 3.12 type-check CI job (which resolves numpy 2.3.2) prints a DeprecationWarning on every run. Nothing in the codebase needs the plugin: the only numpy typing usage is `NDArray[np.float32/float64]` aliases under `TYPE_CHECKING`, which current numpy stubs cover natively. Removing the `plugins` line from `[tool.mypy]` silences the warning.

Testing: `make type-check` passes with no new errors and no warning; `make format-check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Remove the deprecated `numpy.typing.mypy_plugin` entry from the mypy configuration. This removes NumPy 2.3 deprecation warnings while preserving native `NDArray` type support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->