### PR TITLE
feat(benchmarks): add --resume flag and last.ckpt saving to imagenet benchmarks

### DIFF
--- a/benchmarks/imagenet/README.md
+++ b/benchmarks/imagenet/README.md
@@ -140,7 +140,11 @@ Common flags supported by both benchmark families:
 * `--devices`: Number of devices used by PyTorch Lightning.
 * `--accelerator`: Accelerator used by PyTorch Lightning. Defaults to `gpu`.
 * `--precision`: PyTorch Lightning precision. Defaults to `16-mixed`.
-* `--ckpt-path`: Load or resume from a checkpoint.
+* `--ckpt-path`: Load or resume from a specific checkpoint file.
+* `--resume`: Resume the newest run of each method. Reuses its run directory
+  and continues pretraining from its `last.ckpt`. Starts a new run if no
+  checkpoint exists yet, so the flag is safe to always pass on preemptible
+  clusters. Cannot be combined with `--ckpt-path`.
 * `--num-classes`: Number of dataset classes. Defaults to `1000`.
 * `--skip-knn-eval`: Skip kNN evaluation.
 * `--skip-linear-eval`: Skip linear evaluation.

--- a/benchmarks/imagenet/resnet50/main.py
+++ b/benchmarks/imagenet/resnet50/main.py
@@ -15,7 +15,7 @@ import inspect
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Sequence, Union
+from typing import Dict, Sequence, Tuple, Union
 
 import barlowtwins
 import byol
@@ -36,6 +36,7 @@ from pytorch_lightning.callbacks import (
     DeviceStatsMonitor,
     EarlyStopping,
     LearningRateMonitor,
+    ModelCheckpoint,
 )
 from pytorch_lightning.loggers import TensorBoardLogger
 from torch.utils.data import DataLoader
@@ -57,6 +58,7 @@ parser.add_argument("--accelerator", type=str, default="gpu")
 parser.add_argument("--devices", type=int, default=1)
 parser.add_argument("--precision", type=str, default="16-mixed")
 parser.add_argument("--ckpt-path", type=Path, default=None)
+parser.add_argument("--resume", action="store_true")
 parser.add_argument("--compile-model", action="store_true")
 parser.add_argument("--methods", type=str, nargs="+")
 parser.add_argument("--num-classes", type=int, default=1000)
@@ -105,11 +107,14 @@ def main(
     skip_linear_eval: bool,
     skip_finetune_eval: bool,
     ckpt_path: Union[Path, None],
+    resume: bool,
     float32_matmul_precision: str,
     strategy: str,
     seed: int | None = None,
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
+    if resume and ckpt_path is not None:
+        raise ValueError("--resume and --ckpt-path cannot be used together.")
     if seed is not None:
         seed_everything(seed, workers=True, verbose=True)
 
@@ -118,9 +123,21 @@ def main(
     method_names = methods or METHODS.keys()
 
     for method in method_names:
-        method_dir = (
-            log_dir / method / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        ).resolve()
+        method_ckpt_path = ckpt_path
+        method_dir = None
+        if resume:
+            resume_run = find_resume_run(log_dir / method)
+            if resume_run is None:
+                print_rank_zero(
+                    f"No checkpoint found in {log_dir / method}, starting a new run."
+                )
+            else:
+                method_dir, method_ckpt_path = resume_run
+                print_rank_zero(f"Resuming from checkpoint {method_ckpt_path}")
+        if method_dir is None:
+            method_dir = (
+                log_dir / method / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            ).resolve()
         print_rank_zero(f"Logging to {method_dir}")
         # Initialise the base arguments for all models
         model_kwargs = {
@@ -147,8 +164,8 @@ def main(
 
         if epochs <= 0:
             print_rank_zero("Epochs <= 0, skipping pretraining.")
-            if ckpt_path is not None:
-                model.load_state_dict(torch.load(ckpt_path)["state_dict"])
+            if method_ckpt_path is not None:
+                model.load_state_dict(torch.load(method_ckpt_path)["state_dict"])
         else:
             pretrain(
                 model=model,
@@ -162,7 +179,7 @@ def main(
                 accelerator=accelerator,
                 devices=devices,
                 precision=precision,
-                ckpt_path=ckpt_path,
+                ckpt_path=method_ckpt_path,
                 strategy=strategy,
                 run_online_knn_eval=run_online_knn_eval,
             )
@@ -222,6 +239,30 @@ def main(
         if eval_metrics:
             print_rank_zero(f"Results for {method}:")
             print_rank_zero(eval_metrics_to_markdown(eval_metrics))
+
+
+def find_resume_run(method_log_dir: Path) -> Union[Tuple[Path, Path], None]:
+    """Finds the newest run of a method that can be resumed.
+
+    Returns:
+        Tuple with the run directory and its most recent last.ckpt checkpoint,
+        or None if no run with a checkpoint exists.
+    """
+    if not method_log_dir.is_dir():
+        return None
+    # Run directories are named after their start time, so the lexicographic
+    # order matches the chronological order.
+    for run_dir in sorted(
+        (path for path in method_log_dir.iterdir() if path.is_dir()), reverse=True
+    ):
+        # Every resume logs to a new version subdirectory, so a run can contain
+        # multiple checkpoints. Pick the most recently modified one.
+        checkpoints = sorted(
+            run_dir.rglob("last.ckpt"), key=lambda path: path.stat().st_mtime
+        )
+        if checkpoints:
+            return run_dir.resolve(), checkpoints[-1].resolve()
+    return None
 
 
 def pretrain(
@@ -305,6 +346,8 @@ def pretrain(
         devices=devices,
         callbacks=[
             LearningRateMonitor(),
+            # Save last.ckpt so interrupted runs can be resumed with --resume.
+            ModelCheckpoint(save_last=True),
             # Stop if training loss diverges.
             EarlyStopping(monitor="train_loss", patience=int(1e12), check_finite=True),
             DeviceStatsMonitor(),

--- a/benchmarks/imagenet/vitb16/main.py
+++ b/benchmarks/imagenet/vitb16/main.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Sequence, Union
+from typing import Dict, Sequence, Tuple, Union
 
 import aim
 import capi
@@ -21,6 +21,7 @@ from pytorch_lightning.callbacks import (
     DeviceStatsMonitor,
     EarlyStopping,
     LearningRateMonitor,
+    ModelCheckpoint,
 )
 from pytorch_lightning.loggers import TensorBoardLogger
 from torch.utils.data import DataLoader
@@ -43,6 +44,7 @@ parser.add_argument("--accelerator", type=str, default="gpu")
 parser.add_argument("--devices", type=int, default=1)
 parser.add_argument("--precision", type=str, default="16-mixed")
 parser.add_argument("--ckpt-path", type=Path, default=None)
+parser.add_argument("--resume", action="store_true")
 parser.add_argument("--compile-model", action="store_true")
 parser.add_argument("--methods", type=str, nargs="+")
 parser.add_argument("--eval-method", type=str, default="mae", choices=["mae", "simclr"])
@@ -88,20 +90,35 @@ def main(
     skip_linear_eval: bool,
     skip_finetune_eval: bool,
     ckpt_path: Union[Path, None],
+    resume: bool,
     float32_matmul_precision: str,
     strategy: str,
     seed: int | None = None,
 ) -> None:
     print_rank_zero(f"Args: {locals()}")
+    if resume and ckpt_path is not None:
+        raise ValueError("--resume and --ckpt-path cannot be used together.")
     seed_everything(seed, workers=True, verbose=True)
     torch.set_float32_matmul_precision(float32_matmul_precision)
 
     method_names = methods or METHODS.keys()
 
     for method in method_names:
-        method_dir = (
-            log_dir / method / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        ).resolve()
+        method_ckpt_path = ckpt_path
+        method_dir = None
+        if resume:
+            resume_run = find_resume_run(log_dir / method)
+            if resume_run is None:
+                print_rank_zero(
+                    f"No checkpoint found in {log_dir / method}, starting a new run."
+                )
+            else:
+                method_dir, method_ckpt_path = resume_run
+                print_rank_zero(f"Resuming from checkpoint {method_ckpt_path}")
+        if method_dir is None:
+            method_dir = (
+                log_dir / method / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            ).resolve()
         print_rank_zero(f"Logging to {method_dir}")
         model = METHODS[method]["model"](
             batch_size_per_device=batch_size_per_device, num_classes=num_classes
@@ -114,9 +131,9 @@ def main(
 
         if epochs <= 0:
             print_rank_zero("Epochs <= 0, skipping pretraining.")
-            if ckpt_path is not None:
+            if method_ckpt_path is not None:
                 model.load_state_dict(
-                    torch.load(ckpt_path, weights_only=False)["state_dict"]
+                    torch.load(method_ckpt_path, weights_only=False)["state_dict"]
                 )
         else:
             pretrain(
@@ -131,7 +148,7 @@ def main(
                 accelerator=accelerator,
                 devices=devices,
                 precision=precision,
-                ckpt_path=ckpt_path,
+                ckpt_path=method_ckpt_path,
                 strategy=strategy,
             )
 
@@ -195,6 +212,30 @@ def main(
             print_rank_zero(eval_metrics_to_markdown(eval_metrics))
 
 
+def find_resume_run(method_log_dir: Path) -> Union[Tuple[Path, Path], None]:
+    """Finds the newest run of a method that can be resumed.
+
+    Returns:
+        Tuple with the run directory and its most recent last.ckpt checkpoint,
+        or None if no run with a checkpoint exists.
+    """
+    if not method_log_dir.is_dir():
+        return None
+    # Run directories are named after their start time, so the lexicographic
+    # order matches the chronological order.
+    for run_dir in sorted(
+        (path for path in method_log_dir.iterdir() if path.is_dir()), reverse=True
+    ):
+        # Every resume logs to a new version subdirectory, so a run can contain
+        # multiple checkpoints. Pick the most recently modified one.
+        checkpoints = sorted(
+            run_dir.rglob("last.ckpt"), key=lambda path: path.stat().st_mtime
+        )
+        if checkpoints:
+            return run_dir.resolve(), checkpoints[-1].resolve()
+    return None
+
+
 def pretrain(
     model: LightningModule,
     method: str,
@@ -251,6 +292,8 @@ def pretrain(
         devices=devices,
         callbacks=[
             LearningRateMonitor(),
+            # Save last.ckpt so interrupted runs can be resumed with --resume.
+            ModelCheckpoint(save_last=True),
             # Stop if training loss diverges.
             EarlyStopping(monitor="train_loss", patience=int(1e12), check_finite=True),
             DeviceStatsMonitor(),


### PR DESCRIPTION
closes #2053

## Description
- [ ] My change is breaking

Implements the scope checklist from the issue, for both `resnet50/main.py` and `vitb16/main.py`:

- `pretrain()` now includes an explicit `ModelCheckpoint(save_last=True)`, so every run writes a `last.ckpt` (plus one rolling epoch checkpoint) instead of relying on Lightning's implicit checkpointing.
- New `--resume` flag: `find_resume_run()` picks the newest timestamped run directory under `log_dir/<method>/` that contains a `last.ckpt`, reuses that directory for logging, and passes the checkpoint to `trainer.fit(ckpt_path=...)` (and to the `--epochs 0` weight-loading path). Since each resume logs to a new `version_N` subdirectory, the most recently modified `last.ckpt` within the run is chosen.
- If no checkpoint exists yet, `--resume` just starts a fresh timestamped run, so the flag can always be passed on preemptible clusters (e.g. in a SLURM requeue script).
- `--resume` and `--ckpt-path` are mutually exclusive and raise a `ValueError` when combined.

The helper is duplicated in both scripts on purpose, matching the self-contained benchmark script layout.

## Tests
- [ ] My change is covered by existing tests.
- [ ] My change needs new tests.
- [x] I have manually tested the change. Verified `find_resume_run()` with an assertion script over a fabricated log tree: missing dir -> None, runs without checkpoints -> None, newest run with a checkpoint wins over both older runs and newer checkpoint-less runs, and the most recently modified `last.ckpt` is picked when a run contains multiple `version_N` subdirectories. Also checked that both scripts pass `ruff check` and `ruff format` at the locked version. There is no test infrastructure for `benchmarks/`, so no test files were added.

## Documentation
- [x] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation ( `.rst` files).
- [x] I have updated the documentation accordingly. (`benchmarks/imagenet/README.md` documents the new flag.)

## Implications / comments / further issues
- Mid-epoch time-based checkpointing (`train_time_interval`) was left out to keep the change minimal; easy follow-up if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds resumable ImageNet benchmark runs for ResNet-50 and ViT-B/16.

- Saves `last.ckpt` with explicit `ModelCheckpoint` callbacks.
- Adds `--resume` to find and reuse the newest run with a checkpoint.
- Rejects simultaneous `--resume` and `--ckpt-path`.
- Documents the new option in the ImageNet README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->