### PR TITLE
ci: enforce Conventional Commit PR titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/PR_template_checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PR_template_checklist.md
@@ -1,3 +1,4 @@
+<!-- PR title must follow Conventional Commits, e.g. `feat(loss): ...` or `fix: ...`. It is squash-merged onto master and checked in CI. See CONTRIBUTING.md. -->
 closes #issue_number
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE/PR_template_checklist_full.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PR_template_checklist_full.md
@@ -1,3 +1,4 @@
+<!-- PR title must follow Conventional Commits, e.g. `feat(loss): ...` or `fix: ...`. It is squash-merged onto master and checked in CI. See CONTRIBUTING.md. -->
 closes #issue_number
 
 ## Description

--- a/.github/PULL_REQUEST_TEMPLATE/PR_template_minimal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PR_template_minimal.md
@@ -1,3 +1,4 @@
+<!-- PR title must follow Conventional Commits, e.g. `feat(loss): ...` or `fix: ...`. It is squash-merged onto master and checked in CI. See CONTRIBUTING.md. -->
 closes #issue_number
 
 ## Description

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,0 +1,47 @@
+name: Lint PR Title
+
+# The PR title becomes the squash-merge commit subject on master, so it is the
+# string that has to follow Conventional Commits. This check validates it.
+#
+# Runs on pull_request_target so it can comment on pull requests from forks, where
+# a plain pull_request token is read-only. It deliberately never checks out the PR
+# branch, so the elevated token is not an injection surface.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+  merge_group:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check title against the Conventional Commits spec
+      if: github.event_name == 'pull_request_target'
+      uses: amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        # Keep this list in sync with CONTRIBUTING.md and the [tool.commitizen]
+        # configuration in pyproject.toml. Removing a type here starts rejecting
+        # PRs that use it.
+        types: |
+          feat
+          fix
+          docs
+          test
+          ci
+          build
+          perf
+          refactor
+          chore
+          revert
+    # merge_group events carry no PR title to lint. This step keeps the required
+    # check green in the merge queue instead of stalling it. It shares the job name
+    # with the step above so branch protection sees one check across both events.
+    - name: No title to lint in the merge queue
+      if: github.event_name == 'merge_group'
+      run: echo "Skipping: merge_group events carry no pull request title."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_install_hook_types: [pre-commit, pre-push] # install both git hooks (mypy runs on pre-push)
+default_install_hook_types: [pre-commit, pre-push, commit-msg] # commit-msg runs commitizen
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.6.0
@@ -17,6 +17,11 @@ repos:
     - id: ruff-check
       args: [--fix]
     - id: ruff-format
+- repo: https://github.com/commitizen-tools/commitizen
+  rev: v3.29.1 # run `pre-commit autoupdate` to move this forward
+  hooks:
+  - id: commitizen
+    stages: [commit-msg] # lint the commit message against Conventional Commits
 - repo: local
   hooks:
   - id: mypy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Touch points, mirroring an existing method (e.g. BYOL) as the template:
 ## PR workflow
 
 - Branch off `upstream/master`; never commit directly to `master`.
+- PR titles and commit subjects follow [Conventional Commits](https://www.conventionalcommits.org): `type(scope): summary`, where `type` is one of `feat fix docs test ci build perf refactor chore revert`. The title is squash-merged onto `master` and validated by the `Lint PR Title` check, so it must match. `feat` → minor bump, `fix` → patch, `!` or a `BREAKING CHANGE:` footer → major.
 - Before committing: `make format`, then `make all-checks` (or at least `static-checks` + targeted tests for faster iterations).
 - If you touched `examples/`, regenerate notebooks (`make generate-example-notebooks`) and commit them.
 - If you touched `docs/source`, verify the docs still build (see `docs/README.md`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,17 @@ Follow these steps to start contributing:
    git commit
    ```
 
-   Please write [good commit messages](https://chris.beams.io/git-commit).
+   Write your commit messages, and above all your **pull request title**,
+   following the [Conventional Commits](https://www.conventionalcommits.org)
+   specification. Pull requests are squash-merged, so the PR title becomes the
+   commit subject on `master`, and a CI check rejects titles that don't match.
+   Allowed types:
+
+   `feat` `fix` `docs` `test` `ci` `build` `perf` `refactor` `chore` `revert`
+
+   The type sets the next release version: `fix` bumps the patch, `feat` the
+   minor, and a `!` after the type (or a `BREAKING CHANGE:` footer) bumps the
+   major. For example `feat(loss): add DINOv2 head` or `fix!: drop Python 3.7`.
 
    It is a good idea to sync your copy of the code with the original
    repository regularly. This way you can quickly account for changes:


### PR DESCRIPTION
Pull requests are squash-merged, so the PR title is the commit subject that lands on `master`. This makes that title follow Conventional Commits and adds a CI check that rejects titles that don't match.

First of two PRs. This one only enforces the convention; the release automation that consumes it is the stacked follow-up (#2057).

Changes:
- `lint_pr_title.yml` validates the title against the allowed types on every PR, with a `merge_group` pass-through so the merge queue doesn't stall.
- `.pre-commit-config.yaml` gains a `commit-msg` hook running commitizen locally. Best-effort: squash discards local commit messages, so the CI check is the real gate.
- `CONTRIBUTING.md`, `CLAUDE.md`, and the PR templates document the types and the type→version-bump mapping.

Before making the check required:
- Set the squash-merge default to "Pull request title", not the first commit.
- Confirm the `merge_group` pass-through keeps the queue green.

No history is rewritten; only new PRs are affected.
