### PR TITLE
ci: automate versioning and changelog with commitizen

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,45 @@
+name: Prepare Release
+
+# Manually dispatched. Runs `cz bump`, which reads the Conventional Commit history
+# since the last tag, computes the next version, updates lightly/__init__.py and
+# CHANGELOG.md, commits, and creates the version tag. Publishing to PyPI stays in
+# release_pypi.yml, which builds whatever tag this produces.
+#
+# Defaults to a dry run so dispatching it never mutates the repo by accident.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only print the computed bump; do not commit, tag or push."
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: Bump version and changelog
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout full history
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v9.0.0
+      with:
+        version: 0.12.3
+    - name: Show the computed bump
+      if: ${{ inputs.dry_run }}
+      run: uvx --from commitizen cz bump --dry-run --yes
+    # NOTE: pushing to master from CI needs branch protection to allow the
+    # github-actions bot (or a dedicated PAT). Confirm that before disabling the
+    # dry-run default. See the PR description.
+    - name: Bump, tag and push
+      if: ${{ !inputs.dry_run }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        uvx --from commitizen cz bump --yes
+        git push --follow-tags origin HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to lightly are recorded here.
+
+From the first release cut after this file was added, entries are generated from
+[Conventional Commits](https://www.conventionalcommits.org) by
+[commitizen](https://commitizen-tools.github.io/commitizen/). For releases before
+that, see the [GitHub releases](https://github.com/lightly-ai/lightly/releases).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,25 @@ version = {attr = "lightly.__version__"}
 [tool.setuptools.package-data]
 lightly = ["lightly/cli/config/*.yaml"]
 
+# Conventional-commit tooling. `cz bump` derives the next version and the changelog
+# from the commit history since the last tag. Deliberately not a dependency-groups
+# entry: the commit-msg hook runs commitizen from its own pre-commit environment and
+# prepare_release.yml runs it with `uvx`, so uv.lock is untouched and lock-check stays
+# green.
+#
+# `version` mirrors lightly.__version__, which [tool.setuptools.dynamic] above reads as
+# the package version; `version_files` makes `cz bump` rewrite both so they never drift.
+# The default rule map is the standard SemVer mapping: fix -> patch, feat -> minor, a
+# `!` after the type or a `BREAKING CHANGE:` footer -> major.
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "1.5.26"
+version_files = [
+  "lightly/__init__.py:__version__",
+]
+tag_format = "v$version" # matches the existing v-prefixed release tags (v1.5.26, ...)
+update_changelog_on_bump = true
+
 [tool.ruff]
 line-length = 88
 target-version = "py38"


### PR DESCRIPTION
Derives the release version and `CHANGELOG.md` from Conventional Commit history, replacing the hand-edited version bump. Stacked on the enforcement PR (#2056), so merge that first.

Changes:
- `[tool.commitizen]` in `pyproject.toml`: standard SemVer mapping (fix→patch, feat→minor, `!` or `BREAKING CHANGE:`→major). `version_files` keeps `lightly.__version__` and the config `version` in sync. Not in any dependency group, so `uv.lock` is untouched.
- `prepare_release.yml`: manual `workflow_dispatch` running `cz bump`, dry-run by default. `release_pypi.yml` still publishes the tag it produces.
- `CHANGELOG.md`: seed file; the first real bump backfills it from history.

Before enabling non-dry-run:
- Pushing the bump commit and tag to `master` needs branch protection to allow the `github-actions` bot or a PAT.
- cz warns about two legacy tags (`v.1.2.37`, `1.1.8`); ignored, but worth deleting.

Validation: `cz bump --dry-run` computed `1.5.26 → 1.6.0` (minor) from the `feat:` commits since `v1.5.26`; changelog grouped entries under Feat/Fix.
