### PR TITLE
Add ViT gradient checkpointing

### DIFF
--- a/benchmarks/imagenet/vitb16/main.py
+++ b/benchmarks/imagenet/vitb16/main.py
@@ -44,6 +44,7 @@ parser.add_argument("--devices", type=int, default=1)
 parser.add_argument("--precision", type=str, default="16-mixed")
 parser.add_argument("--ckpt-path", type=Path, default=None)
 parser.add_argument("--compile-model", action="store_true")
+parser.add_argument("--grad-checkpointing", action="store_true")
 parser.add_argument("--methods", type=str, nargs="+")
 parser.add_argument("--eval-method", type=str, default="mae", choices=["mae", "simclr"])
 parser.add_argument("--num-classes", type=int, default=1000)
@@ -79,6 +80,7 @@ def main(
     devices: int,
     precision: str,
     compile_model: bool,
+    grad_checkpointing: bool,
     methods: Union[Sequence[str], None],
     eval_method: str,
     num_classes: int,
@@ -106,6 +108,12 @@ def main(
         model = METHODS[method]["model"](
             batch_size_per_device=batch_size_per_device, num_classes=num_classes
         )
+
+        if grad_checkpointing:
+            for module in model.modules():
+                set_grad_checkpointing = getattr(module, "set_grad_checkpointing", None)
+                if callable(set_grad_checkpointing):
+                    set_grad_checkpointing(enable=True)
 
         if compile_model and hasattr(torch, "compile"):
             # Compile model if PyTorch supports it.

--- a/lightly/models/modules/masked_vision_transformer_timm.py
+++ b/lightly/models/modules/masked_vision_transformer_timm.py
@@ -4,8 +4,9 @@ from typing import List, Optional, Tuple, cast
 import torch
 import torch.nn as nn
 from timm.layers.pos_embed import resample_abs_pos_embed
+from timm.models._manipulate import checkpoint_seq
 from timm.models.vision_transformer import VisionTransformer
-from torch import Tensor
+from torch import Tensor, jit
 from torch.nn import LayerNorm, Linear, Module, Parameter
 
 from lightly.models import utils
@@ -63,6 +64,11 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer):
         )
 
         self.antialias = antialias
+        self.grad_checkpointing = False
+
+    def set_grad_checkpointing(self, enable: bool = True) -> None:
+        """Enables or disables gradient checkpointing."""
+        self.grad_checkpointing = enable
 
     @property
     def sequence_length(self) -> int:
@@ -106,7 +112,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer):
 
         intermediates: List[Tensor] = []
         for blk in self.vit.blocks:
-            tokens = blk(tokens)
+            if self.grad_checkpointing and not jit.is_scripting():
+                tokens = checkpoint_seq((blk,), tokens)
+            else:
+                tokens = blk(tokens)
             intermediates.append(self.vit.norm(tokens) if norm else tokens)
 
         # normalize
@@ -128,7 +137,10 @@ class MaskedVisionTransformerTIMM(MaskedVisionTransformer):
         # normalization layer
         tokens = self.vit.norm_pre(tokens)
         # apply Transformer blocks
-        tokens = self.vit.blocks(tokens)
+        if self.grad_checkpointing and not jit.is_scripting():
+            tokens = checkpoint_seq(self.vit.blocks, tokens)
+        else:
+            tokens = self.vit.blocks(tokens)
         # normalize
         tokens = self.vit.norm(tokens)
         return tokens

--- a/tests/models/modules/test_masked_vision_transformer_timm.py
+++ b/tests/models/modules/test_masked_vision_transformer_timm.py
@@ -95,3 +95,41 @@ class TestMaskedVisionTransformerTIMM(MaskedVisionTransformerTest):
         model.add_pos_embed(x)
         _, call_kwargs = mock_resample_abs_pos_embed.call_args
         assert call_kwargs["antialias"] == antialias
+
+    @pytest.mark.parametrize("method_name", ["encode", "forward_intermediates"])
+    def test_gradient_checkpointing(
+        self, method_name: str, mocker: MockerFixture
+    ) -> None:
+        model = self.get_masked_vit(
+            patch_size=32,
+            depth=2,
+            num_heads=1,
+            embed_dim=32,
+        )
+        model.eval()
+        images = torch.rand(2, 3, 64, 64)
+
+        expected = getattr(model, method_name)(images)
+        model.set_grad_checkpointing(enable=True)
+        mock_checkpoint_seq = mocker.spy(
+            masked_vision_transformer_timm, "checkpoint_seq"
+        )
+
+        checkpointed_images = images.clone().requires_grad_()
+        actual = getattr(model, method_name)(checkpointed_images)
+        mock_checkpoint_seq.assert_called()
+
+        if method_name == "forward_intermediates":
+            expected_output, expected_intermediates = expected
+            actual_output, actual_intermediates = actual
+            torch.testing.assert_close(actual_output, expected_output)
+            for actual_intermediate, expected_intermediate in zip(
+                actual_intermediates, expected_intermediates
+            ):
+                torch.testing.assert_close(actual_intermediate, expected_intermediate)
+            actual_output.sum().backward()
+        else:
+            torch.testing.assert_close(actual, expected)
+            actual.sum().backward()
+
+        assert checkpointed_images.grad is not None


### PR DESCRIPTION
Closes #2054

## Description

- [ ] My change is breaking.
- Add opt-in gradient checkpointing to `MaskedVisionTransformerTIMM` for both `encode()` and `forward_intermediates()`.
- Add `--grad-checkpointing` to the ViT-B/16 ImageNet benchmark and enable it across compatible model modules before compilation.
- Keep the default execution path unchanged.

## Tests

- [x] My change needs new tests.
- [x] I have added/adapted the tests accordingly.
- [x] I have manually tested the change.

Verification:

- RED: both new cases failed because `MaskedVisionTransformerTIMM.set_grad_checkpointing()` did not exist.
- GREEN: `uv run --frozen --extra timm pytest -q tests/models/modules/test_masked_vision_transformer_timm.py -k gradient_checkpointing` — 2 passed.
- Module suite: 23 passed, 47 skipped.
- `make format` — passed.
- Ruff and full-project mypy — passed.
- `make all-checks` reached 1,543 passed / 234 skipped with one pre-existing failure in `tests/utils/test_dist__gather__losses.py::TestGatherLayer_Losses::test_loss_dcl`. The same test fails with the same resulting parameters in a clean worktree at `0a6a3a3`, without this patch.
- `python benchmarks/imagenet/vitb16/main.py --help` exposes `--grad-checkpointing`.

## Documentation

- [x] I have added docstrings to changed public methods.
- [ ] My change requires a change to the `.rst` documentation.

## AI assistance

AI tooling assisted with repository exploration, test drafting, and validation. I reviewed the complete diff, reproduced the regression before implementation, and ran the checks listed above locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added opt-in gradient checkpointing to `MaskedVisionTransformerTIMM` for `encode()` and `forward_intermediates()`.
- Added `--grad-checkpointing` to the ViT-B/16 ImageNet benchmark.
- Added tests for output parity and gradient flow.
- Formatting, Ruff, and mypy checks passed. One pre-existing full-suite failure remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->