### PR TITLE
fix(loss): validate VICRegL feature-grid shapes

### DIFF
--- a/lightly/loss/vicregl_loss.py
+++ b/lightly/loss/vicregl_loss.py
@@ -138,8 +138,8 @@ class VICRegLLoss(Module):
             ValueError: If the lengths of global_view_features and global_view_grids are not the same.
             ValueError: If the lengths of local_view_features and local_view_grids are not the same.
             ValueError: If only one of local_view_features or local_view_grids is set.
-            ValueError: If a local feature map and its grid do not have matching batch,
-                height, and width dimensions.
+            ValueError: If a global or local feature map and its grid do not have
+                matching batch, height, and width dimensions.
         """
         if len(global_view_features) != len(global_view_grids):
             raise ValueError(
@@ -193,7 +193,7 @@ class VICRegLLoss(Module):
         view_grids: Sequence[Tensor],
         view_type: str,
     ) -> None:
-        """Validates that every local feature map matches its grid."""
+        """Validates that every global or local feature map matches its grid."""
         for index, ((_, local_features), grid) in enumerate(
             zip(view_features, view_grids)
         ):

--- a/lightly/loss/vicregl_loss.py
+++ b/lightly/loss/vicregl_loss.py
@@ -138,6 +138,8 @@ class VICRegLLoss(Module):
             ValueError: If the lengths of global_view_features and global_view_grids are not the same.
             ValueError: If the lengths of local_view_features and local_view_grids are not the same.
             ValueError: If only one of local_view_features or local_view_grids is set.
+            ValueError: If a local feature map and its grid do not have matching batch,
+                height, and width dimensions.
         """
         if len(global_view_features) != len(global_view_grids):
             raise ValueError(
@@ -156,6 +158,18 @@ class VICRegLLoss(Module):
                 f"None but found {type(local_view_features)} and {type(local_view_grids)}."
             )
 
+        self._validate_view_feature_and_grid_shapes(
+            view_features=global_view_features,
+            view_grids=global_view_grids,
+            view_type="global",
+        )
+        if local_view_features is not None and local_view_grids is not None:
+            self._validate_view_feature_and_grid_shapes(
+                view_features=local_view_features,
+                view_grids=local_view_grids,
+                view_type="local",
+            )
+
         # Calculate loss from global features
         global_loss = self._global_loss(
             global_view_features=global_view_features,
@@ -172,6 +186,24 @@ class VICRegLLoss(Module):
 
         loss = self.alpha * global_loss + (1 - self.alpha) * local_loss
         return loss
+
+    @staticmethod
+    def _validate_view_feature_and_grid_shapes(
+        view_features: Sequence[Tuple[Tensor, Tensor]],
+        view_grids: Sequence[Tensor],
+        view_type: str,
+    ) -> None:
+        """Validates that every local feature map matches its grid."""
+        for index, ((_, local_features), grid) in enumerate(
+            zip(view_features, view_grids)
+        ):
+            if local_features.shape[:3] != grid.shape[:3]:
+                raise ValueError(
+                    f"{view_type}_view_features[{index}][1] and "
+                    f"{view_type}_view_grids[{index}] must have matching batch, "
+                    f"height, and width but found local feature shape "
+                    f"{tuple(local_features.shape)} and grid shape {tuple(grid.shape)}."
+                )
 
     def _global_loss(
         self,

--- a/tests/loss/test_vicregl_loss.py
+++ b/tests/loss/test_vicregl_loss.py
@@ -122,8 +122,12 @@ class TestVICRegLLoss:
             )
 
     @pytest.mark.parametrize("view_type", ["global", "local"])
+    @pytest.mark.parametrize(
+        "grid_shape",
+        [(3, 7, 7, 2), (2, 9, 7, 2), (2, 7, 9, 2)],
+    )
     def test_forward__error_view_features_and_grids_not_same_shape(
-        self, view_type: str
+        self, view_type: str, grid_shape: tuple[int, int, int, int]
     ) -> None:
         criterion = VICRegLLoss()
         global_view_features = [
@@ -136,18 +140,18 @@ class TestVICRegLLoss:
         local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(2)]
 
         if view_type == "global":
-            global_view_grids[0] = torch.randn((2, 9, 9, 2))
+            global_view_grids[0] = torch.randn(grid_shape)
             expected_message = (
                 "global_view_features[0][1] and global_view_grids[0] must have "
                 "matching batch, height, and width but found local feature shape "
-                "(2, 7, 7, 8) and grid shape (2, 9, 9, 2)."
+                f"(2, 7, 7, 8) and grid shape {grid_shape}."
             )
         else:
-            local_view_grids[0] = torch.randn((2, 6, 6, 2))
+            local_view_grids[0] = torch.randn(grid_shape)
             expected_message = (
                 "local_view_features[0][1] and local_view_grids[0] must have "
                 "matching batch, height, and width but found local feature shape "
-                "(2, 4, 4, 8) and grid shape (2, 6, 6, 2)."
+                f"(2, 4, 4, 8) and grid shape {grid_shape}."
             )
 
         with pytest.raises(ValueError, match=re.escape(expected_message)):

--- a/tests/loss/test_vicregl_loss.py
+++ b/tests/loss/test_vicregl_loss.py
@@ -1,3 +1,4 @@
+import re
 import typing
 from typing import List
 
@@ -117,6 +118,43 @@ class TestVICRegLLoss:
                 global_view_features=[],
                 global_view_grids=[],
                 local_view_features=None,
+                local_view_grids=local_view_grids,
+            )
+
+    @pytest.mark.parametrize("view_type", ["global", "local"])
+    def test_forward__error_view_features_and_grids_not_same_shape(
+        self, view_type: str
+    ) -> None:
+        criterion = VICRegLLoss()
+        global_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 7, 7, 8))) for _ in range(2)
+        ]
+        global_view_grids = [torch.randn((2, 7, 7, 2)) for _ in range(2)]
+        local_view_features = [
+            (torch.randn((2, 32)), torch.randn((2, 4, 4, 8))) for _ in range(2)
+        ]
+        local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(2)]
+
+        if view_type == "global":
+            global_view_grids[0] = torch.randn((2, 9, 9, 2))
+            expected_message = (
+                "global_view_features[0][1] and global_view_grids[0] must have "
+                "matching batch, height, and width but found local feature shape "
+                "(2, 7, 7, 8) and grid shape (2, 9, 9, 2)."
+            )
+        else:
+            local_view_grids[0] = torch.randn((2, 6, 6, 2))
+            expected_message = (
+                "local_view_features[0][1] and local_view_grids[0] must have "
+                "matching batch, height, and width but found local feature shape "
+                "(2, 4, 4, 8) and grid shape (2, 6, 6, 2)."
+            )
+
+        with pytest.raises(ValueError, match=re.escape(expected_message)):
+            criterion.forward(
+                global_view_features=global_view_features,
+                global_view_grids=global_view_grids,
+                local_view_features=local_view_features,
                 local_view_grids=local_view_grids,
             )
 

--- a/tests/loss/test_vicregl_loss.py
+++ b/tests/loss/test_vicregl_loss.py
@@ -122,12 +122,9 @@ class TestVICRegLLoss:
             )
 
     @pytest.mark.parametrize("view_type", ["global", "local"])
-    @pytest.mark.parametrize(
-        "grid_shape",
-        [(3, 7, 7, 2), (2, 9, 7, 2), (2, 7, 9, 2)],
-    )
+    @pytest.mark.parametrize("mismatched_dimension", [0, 1, 2])
     def test_forward__error_view_features_and_grids_not_same_shape(
-        self, view_type: str, grid_shape: tuple[int, int, int, int]
+        self, view_type: str, mismatched_dimension: int
     ) -> None:
         criterion = VICRegLLoss()
         global_view_features = [
@@ -140,18 +137,26 @@ class TestVICRegLLoss:
         local_view_grids = [torch.randn((2, 4, 4, 2)) for _ in range(2)]
 
         if view_type == "global":
+            feature_shape = (2, 7, 7, 8)
+            grid_dimensions = [2, 7, 7, 2]
+            grid_dimensions[mismatched_dimension] += 1
+            grid_shape = tuple(grid_dimensions)
             global_view_grids[0] = torch.randn(grid_shape)
             expected_message = (
                 "global_view_features[0][1] and global_view_grids[0] must have "
                 "matching batch, height, and width but found local feature shape "
-                f"(2, 7, 7, 8) and grid shape {grid_shape}."
+                f"{feature_shape} and grid shape {grid_shape}."
             )
         else:
+            feature_shape = (2, 4, 4, 8)
+            grid_dimensions = [2, 4, 4, 2]
+            grid_dimensions[mismatched_dimension] += 1
+            grid_shape = tuple(grid_dimensions)
             local_view_grids[0] = torch.randn(grid_shape)
             expected_message = (
                 "local_view_features[0][1] and local_view_grids[0] must have "
                 "matching batch, height, and width but found local feature shape "
-                f"(2, 4, 4, 8) and grid shape {grid_shape}."
+                f"{feature_shape} and grid shape {grid_shape}."
             )
 
         with pytest.raises(ValueError, match=re.escape(expected_message)):


### PR DESCRIPTION
Closes #1179

## Description

- [ ] My change is breaking

Validate the batch, height, and width dimensions of every VICRegL local feature
map against its matching grid before nearest-neighbour matching. A mismatched
grid previously reached `torch.gather` and raised an opaque out-of-bounds error.
The new `ValueError` identifies the global or local view index and both shapes.

## Tests

- [ ] My change is covered by existing tests.
- [x] My change needs new tests.
- [x] I have added/adapted the tests accordingly.
- [x] I have manually tested the change. CPU mismatches for global and local
  views now raise the documented `ValueError`; the unmodified implementation
  raises the out-of-bounds error reported in #1179.

## Documentation

- [ ] I have added docstrings to all public functions/methods.
- [ ] My change requires a change to the documentation ( `.rst` files).
- [ ] I have updated the documentation accordingly.
- [ ] The autodocs update the documentation accordingly.

## Implications / comments / further issues

- None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Validate global and local feature-map dimensions against their grids before nearest-neighbour matching.
- Raise a descriptive `ValueError` for batch, height, or width mismatches.
- Add parameterized tests for global and local shape mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->